### PR TITLE
[DEMO] Page type customization

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -606,5 +606,9 @@ div.path {
     color: var(--ibexa-dusk-black);
 }
 
-
+article>.type-landing_page>p:first-of-type {
+    font-size: 18px;
+    font-weight: bold;
+}
+    
 

--- a/theme/main.html
+++ b/theme/main.html
@@ -49,7 +49,11 @@
           {% include "partials/integrations/bootstrap.html" %}
         {% endfor %}
 
+        {% if page and page.meta.page_type %}
+        <div class="{{ ns.bootstrap_extra_css }} type-{{page.meta.page_type}}">
+        {% else %}
         <div class="{{ ns.bootstrap_extra_css }}">
+        {% endif %}
           <ul class="breadcrumbs">
                   <li class="breadcrumb-item">Documentation &#62;</li>
               {% for ancestor in page.ancestors|reverse %}

--- a/theme/partials/toc.html
+++ b/theme/partials/toc.html
@@ -17,6 +17,7 @@
           <a href="{{ toc_item.url }}" title="{{ toc_item.title }}" class="md-nav__link">
             {{ toc_item.title }}
           </a>
+          {% if page and page.meta.page_type != 'reference' %}
           {% if toc_item.children %}
               <nav class="md-nav">
                 <ul class="md-nav__list">
@@ -29,6 +30,7 @@
                   {% endfor %}
                 </ul>
               </nav>
+          {% endif %}
           {% endif %}
         </li>
       {% endfor %}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | n/a
| Versions      | n/a
| Edition       | n/a

This PR is for demonstration purposes only.

It shows how to use page types to customize page styles and templates.

Page metadata is available in templates under the `page.meta` variable.

EXAMPLE: limit toc in reference pages to lvl2 - part of templates can be made conditional on the page type. In this example, the part of template that renders lvl3 in the table of contents is used only when the page is not of type `reference`:
![image](https://github.com/ezsystems/developer-documentation/assets/13621049/5d206091-e4e0-44d6-aadc-c92a13ca0881)
vs 
![image](https://github.com/ezsystems/developer-documentation/assets/13621049/3352f0df-2331-4ca1-b5a9-991cc7c4d296)
in current doc.

EXAMPLE: style first paragraph in landing pages - the variable can we also used as a CSS variable in the templates. In this example, the template adds a `type-<page-type>` CSS class to the page content element. This allows for styling part of the page depending on the page type. For example: changing the styling of the first paragraph in pages of type `landing_page`.

![image](https://github.com/ezsystems/developer-documentation/assets/13621049/a4941e80-1a7e-4090-81aa-aca624e53230)


Note: in templates any use of the variable must be wrapped in an if statement: `{% if page and page.meta.page_type %}`. Otherwise, the rendering will stop with an error when there is no page type defined.

Note 2: the same can be applied to any custom metadata added to a page.
