### PR TITLE
locationId parameter is missing in call to BlockController::renderAct…

### DIFF
--- a/code_samples/front/render_page/templates/themes/my_theme/layouts/sidebar.html.twig
+++ b/code_samples/front/render_page/templates/themes/my_theme/layouts/sidebar.html.twig
@@ -4,6 +4,7 @@
             {% for block in zones[0].blocks %}
                 <div class="landing-page__block block_{{ block.type }}" data-ez-block-id="{{ block.id }}">
                     {{ render_esi(controller('EzSystems\\EzPlatformPageFieldTypeBundle\\Controller\\BlockController::renderAction', {
+                        'locationId': locationId,
                         'contentId': contentInfo.id,
                         'blockId': block.id,
                         'versionNo': versionInfo.versionNo,
@@ -19,6 +20,7 @@
             {% for block in zones[1].blocks %}
                 <div class="landing-page__block block_{{ block.type }}" data-ez-block-id="{{ block.id }}">
                     {{ render_esi(controller('EzSystems\\EzPlatformPageFieldTypeBundle\\Controller\\BlockController::renderAction', {
+                        'locationId': locationId,
                         'contentId': contentInfo.id,
                         'blockId': block.id,
                         'versionNo': versionInfo.versionNo,


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | 
| Versions      | 3.3, 4.5
| Edition       | Content/Headless, Experience, Commerce

The template is missing `locationId` parameter which is needed. See https://github.com/ezsystems/ezplatform-page-fieldtype/blob/2.3/src/bundle/Resources/views/default_layout.html.twig#L9

Doc pages:
https://doc.ibexa.co/en/3.3/guide/content_rendering/render_content/render_page/#configure-layout
https://doc.ibexa.co/en/4.5/templating/render_content/render_page/#configure-layout

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
