### PR TITLE
IBX-7865: Added Recent Activity Dashboard block migration to upgrade procedure

### DIFF
--- a/docs/update_and_migration/from_4.5/update_from_4.5.md
+++ b/docs/update_and_migration/from_4.5/update_from_4.5.md
@@ -191,7 +191,8 @@ you must run data migration required by the dashboard and other features to fini
 ```bash
 php bin/console ibexa:migrations:import vendor/ibexa/dashboard/src/bundle/Resources/migrations/structure.yaml --name=2023_09_23_14_15_dashboard_structure.yaml
 php bin/console ibexa:migrations:import vendor/ibexa/dashboard/src/bundle/Resources/migrations/permissions.yaml --name=2023_10_10_16_14_dashboard_permissions.yaml
-php bin/console ibexa:migrations:migrate --file=2023_09_23_14_15_dashboard_structure.yaml --file=2023_10_10_16_14_dashboard_permissions.yaml
+php bin/console ibexa:migrations:import vendor/ibexa/activity-log/src/bundle/Resources/migrations/dashboard_structure.yaml --name=2023_12_04_13_34_activity_log_dashboard_structure.yaml
+php bin/console ibexa:migrations:migrate --file=2023_09_23_14_15_dashboard_structure.yaml --file=2023_10_10_16_14_dashboard_permissions.yaml --file=2023_12_04_13_34_activity_log_dashboard_structure.yaml
 ```
 
 ## Revisit configuration


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | [IBX-7865](https://issues.ibexa.co/browse/IBX-7865)
| Versions      | 4.6
| Edition       | Experience, Commerce

This is a follow-up to #2276. We're missing Recent Activity Dashboard block migration for activity-log package. The migration is executed during clean install via the provisioner, so it should be added during upgrade as well. Without this, Recent Activity block is not present on the default Dashboard after an upgrade from 4.5.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
