### PR TITLE
Changed examples deleting Elasticsearch indices

### DIFF
--- a/docs/search/search_engines/elasticsearch/elasticsearch_overview.md
+++ b/docs/search/search_engines/elasticsearch/elasticsearch_overview.md
@@ -24,11 +24,12 @@ To proceed you need to be familiar with how indexing, filtering and queries work
 
 Whenever you make any changes in case of variables (for example, environmental ones) or configuration files, you need to erase Elasticsearch index, update the schema, and rebuild the index.
 
-To delete the index, you can use an HTTP request.
-Use the command as in the following example:
+To delete the index, use the [delete index REST API](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-delete-index.html).
+Use the commands as in the following example:
 
 ```bash
-curl --request DELETE 'https://elasticsearch:9200/_all'
+curl --request DELETE 'https://elasticsearch:9200/default_location*'
+curl --request DELETE 'https://elasticsearch:9200/default_content*'
 ```
 
 To update the schema and then reindex the search, use the following commands:

--- a/docs/search/search_engines/elasticsearch/elasticsearch_overview.md
+++ b/docs/search/search_engines/elasticsearch/elasticsearch_overview.md
@@ -24,17 +24,4 @@ To proceed you need to be familiar with how indexing, filtering and queries work
 
 Whenever you make any changes in case of variables (for example, environmental ones) or configuration files, you need to erase Elasticsearch index, update the schema, and rebuild the index.
 
-To delete the index, use the [delete index REST API](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-delete-index.html).
-Use the commands as in the following example:
-
-```bash
-curl --request DELETE 'https://elasticsearch:9200/default_location*'
-curl --request DELETE 'https://elasticsearch:9200/default_content*'
-```
-
-To update the schema and then reindex the search, use the following commands:
-
-```bash
-php bin/console ibexa:elasticsearch:put-index-template --overwrite
-php bin/console ibexa:reindex
-```
+[[% include 'snippets/elasticsearch_clear_index.md' %]]

--- a/docs/snippets/elasticsearch_clear_index.md
+++ b/docs/snippets/elasticsearch_clear_index.md
@@ -1,6 +1,6 @@
 To delete an index, you can use the ElasticSearch's REST API.
 
-First, use the [`_cat/indices` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cat-indices.html) to list existing indices:
+First, use the [`_cat/indices` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/cat-indices.html) to list existing indices:
 
 ``` bash
 yellow open default_location_eng_gb_54 DoSFV-CtQFylKKVvd48YfA 1 1  1 0 16.7kb 16.7kb
@@ -14,7 +14,7 @@ yellow open default_location_eng_gb_46 fSGtpljwTpGfascFechmww 1 1  1 0   21kb   
 
 Create a list containing all indices used by the DXP, including the [custom indices](search/search_engines/elasticsearch/configure_elasticsearch.md#define-field-type-mappingtemplates) as well.
 
-Then, delete them by using the [delete index endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-delete-index.html) 
+Then, delete them by using the [delete index endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/indices-delete-index.html) 
 
 ``` bash
 curl --request DELETE 'https://elasticsearch:9200/default_location*'

--- a/docs/snippets/elasticsearch_clear_index.md
+++ b/docs/snippets/elasticsearch_clear_index.md
@@ -12,7 +12,7 @@ yellow open default_location_eng_gb_46 fSGtpljwTpGfascFechmww 1 1  1 0   21kb   
 (...)
 ```
 
-Create a list containing all indices used by the DXP, including the [custom indices](search/search_engines/elasticsearch/configure_elasticsearch.md#define-field-type-mappingtemplates) as well.
+Create a list containing all indices used by the DXP, including the [custom indices](/search/search_engines/elasticsearch/configure_elasticsearch.md#define-field-type-mapping-templates) as well.
 
 Then, delete them by using the [delete index endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/indices-delete-index.html) 
 

--- a/docs/snippets/elasticsearch_clear_index.md
+++ b/docs/snippets/elasticsearch_clear_index.md
@@ -1,6 +1,7 @@
 To delete an index, you can use the Elasticsearch's REST API.
 
-First, use the [`_cat/indices` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/cat-indices.html) to list existing indices:
+First, use the [`_cat/indices` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/cat-indices.html) to list existing indices.
+For example, the command `curl  -H "Accept: application/text" elasticsearch:9200/_cat/indices` returns output like the following:
 
 ``` bash
 yellow open default_location_eng_gb_54 DoSFV-CtQFylKKVvd48YfA 1 1  1 0 16.7kb 16.7kb
@@ -21,6 +22,11 @@ curl --request DELETE 'https://elasticsearch:9200/default_location*'
 curl --request DELETE 'https://elasticsearch:9200/default_content*'
 (...)
 ```
+
+!!! tip
+
+    To quickly delete all existing Elasticsearch indices, you can use the `_all` keyword as the name of the index, as in the following request: `curl --request DELETE 'https://elasticsearch:9200/_all`.
+    Always review the list of existing indices and confirm they are safe to delete before executing this command, as it permanently removes data.
 
 To update the schema and then reindex the search, use the following commands:
 

--- a/docs/snippets/elasticsearch_clear_index.md
+++ b/docs/snippets/elasticsearch_clear_index.md
@@ -1,0 +1,30 @@
+To delete an index, you can use the ElasticSearch's REST API.
+
+First, use the [`_cat/indices` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cat-indices.html) to list existing indices:
+
+``` bash
+yellow open default_location_eng_gb_54 DoSFV-CtQFylKKVvd48YfA 1 1  1 0 16.7kb 16.7kb
+yellow open default_location_eng_gb_42 3Z_IrWVHQh2m37jPqQBOcQ 1 1  1 0 20.1kb 20.1kb
+yellow open default_content_eng_gb_45  y-t4uNQwR4KRJ-N9i3zUog 1 1  1 0 21.3kb 21.3kb
+yellow open default_content_eng_gb_46  e_LS5qG3RIih6iQRPsNp-w 1 1  1 0 22.5kb 22.5kb
+yellow open default_content_eng_gb_1   101-1-tQS_2KSvNs2X2JAQ 1 1 17 0 39.8kb 39.8kb
+yellow open default_location_eng_gb_46 fSGtpljwTpGfascFechmww 1 1  1 0   21kb   21kb
+(...)
+```
+
+Create a list containing all indices used by the DXP, including the [custom indices](search/search_engines/elasticsearch/configure_elasticsearch.md#define-field-type-mappingtemplates) as well.
+
+Then, delete them by using the [delete index endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-delete-index.html) 
+
+``` bash
+curl --request DELETE 'https://elasticsearch:9200/default_location*'
+curl --request DELETE 'https://elasticsearch:9200/default_content*'
+(...)
+```
+
+To update the schema and then reindex the search, use the following commands:
+
+``` bash
+php bin/console ibexa:elasticsearch:put-index-template --overwrite
+php bin/console ibexa:reindex
+```

--- a/docs/snippets/elasticsearch_clear_index.md
+++ b/docs/snippets/elasticsearch_clear_index.md
@@ -25,7 +25,7 @@ curl --request DELETE 'https://elasticsearch:9200/default_content*'
 
 !!! tip
 
-    To quickly delete all existing Elasticsearch indices, you can use the `_all` keyword as the name of the index, as in the following request: `curl --request DELETE 'https://elasticsearch:9200/_all`.
+    To quickly delete all existing Elasticsearch indices, you can use the `_all` keyword as the name of the index, as in the following request: `curl --request DELETE https://elasticsearch:9200/_all`.
     Always review the list of existing indices and confirm they are safe to delete before executing this command, as it permanently removes data.
 
 To update the schema and then reindex the search, use the following commands:

--- a/docs/snippets/elasticsearch_clear_index.md
+++ b/docs/snippets/elasticsearch_clear_index.md
@@ -1,4 +1,4 @@
-To delete an index, you can use the ElasticSearch's REST API.
+To delete an index, you can use the Elasticsearch's REST API.
 
 First, use the [`_cat/indices` endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/cat-indices.html) to list existing indices:
 

--- a/docs/update_and_migration/from_4.5/update_from_4.5.md
+++ b/docs/update_and_migration/from_4.5/update_from_4.5.md
@@ -489,11 +489,12 @@ Restart Solr for `solrconfig.xml` changes to take effect.
 Elasticsearch schema's templates change, for example, with the addition of new features such as spellchecking.
 When this happens, you need to erase the index, update the schema, and rebuild the index.
 
-To delete the index, you can use an HTTP request.
+To delete the index, use the [delete index REST API](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-delete-index.html).
 Use the command as in the following example:
 
 ```bash
-curl --request DELETE 'https://elasticsearch:9200/_all'
+curl --request DELETE 'https://elasticsearch:9200/default_location*'
+curl --request DELETE 'https://elasticsearch:9200/default_content*'
 ```
 
 To update the schema, and then reindex the content, use the following commands:

--- a/docs/update_and_migration/from_4.5/update_from_4.5.md
+++ b/docs/update_and_migration/from_4.5/update_from_4.5.md
@@ -489,20 +489,7 @@ Restart Solr for `solrconfig.xml` changes to take effect.
 Elasticsearch schema's templates change, for example, with the addition of new features such as spellchecking.
 When this happens, you need to erase the index, update the schema, and rebuild the index.
 
-To delete the index, use the [delete index REST API](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/indices-delete-index.html).
-Use the command as in the following example:
-
-```bash
-curl --request DELETE 'https://elasticsearch:9200/default_location*'
-curl --request DELETE 'https://elasticsearch:9200/default_content*'
-```
-
-To update the schema, and then reindex the content, use the following commands:
-
-```bash
-php bin/console ibexa:elasticsearch:put-index-template --overwrite
-php bin/console ibexa:reindex
-```
+[[% include 'snippets/elasticsearch_clear_index.md' %]]
 
 ## Update to v4.6.latest
 


### PR DESCRIPTION
Target: master, 4.6, 3.3

Community feedback:

> Hi, can you please update https://doc.ibexa.co/en/latest/update_and_migration/from_4.5/update_from_4.5/#updateelasticsearch-schema 
> to indicate that the DELETE curl with 'all' is highly destructive and should not be run on elastic.co hosted servers.
> instead the curl should target the specific CMS indexes like 'default*'

I've verified locally that it works by running the Elasticsearch container and then executing:
```
php bin/console ibexa:reindex
curl --request DELETE 'http://0.0.0.0:9200/default_content*'
curl --request DELETE 'http://0.0.0.0:9200/default_location*'
php bin/console ibexa:elasticsearch:put-index-template
php bin/console ibexa:reindex
```

which is enough to solve the issue described in https://issues.ibexa.co/browse/IBX-3758, but potentially less desctuctive.
