### PR TITLE
Config activity log as a post-installation step

### DIFF
--- a/docs/getting_started/install_ibexa_dxp.md
+++ b/docs/getting_started/install_ibexa_dxp.md
@@ -417,6 +417,11 @@ Finally, remove the temporary file:
 
 `rm ezp_cron.txt`
 
+### Configure recent activity log
+
+Actions in a repository are logged in its database,
+you may want to [limit this log length by setting its automatic truncation](recent_activity.md#configuration-and-cronjob).
+
 ### Enable the Link manager
 
 To make use of the [Link Manager](url_management.md#enabling-automatic-url-validation).

--- a/docs/getting_started/install_ibexa_dxp.md
+++ b/docs/getting_started/install_ibexa_dxp.md
@@ -396,6 +396,11 @@ You should see the welcome page.
 
     See the [Security checklist](security_checklist.md) for a list of security-related issues you should take care of before going live with a project.
 
+### Configure recent activity log
+
+Actions in a repository are logged in its database,
+you may want to [limit this log length by enabling its automatic truncation](recent_activity.md#configuration-and-cronjob).
+
 ### Enable Date-based Publisher
 
 To enable delayed publishing of Content using the Date-based Publisher, you must set up cron to run the `bin/console ibexa:scheduled:run` command periodically.
@@ -416,11 +421,6 @@ Assuming the web server user data is `www-data`:
 Finally, remove the temporary file:
 
 `rm ezp_cron.txt`
-
-### Configure recent activity log
-
-Actions in a repository are logged in its database,
-you may want to [limit this log length by setting its automatic truncation](recent_activity.md#configuration-and-cronjob).
 
 ### Enable the Link manager
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 4.6, master
| Edition       | All

At the end of installation process, suggest to configure activity log to limit its length.
I add "Configure recent activity log" section before the two other cron related sections because it can be critical to fill up DB with activity log while the other two are just feature enablements.

[Preview](https://ez-systems-developer-documentation--2663.com.readthedocs.build/en/2663/getting_started/install_ibexa_dxp/#post-installation-steps)

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
