### PR TITLE
Wrong yaml config in "Create custom taxonomy" example

### DIFF
--- a/code_samples/taxonomy/config/packages/ibexa_taxonomy.yaml
+++ b/code_samples/taxonomy/config/packages/ibexa_taxonomy.yaml
@@ -13,6 +13,6 @@ ibexa_taxonomy:
             field_mappings:
                 identifier: category_identifier
                 parent: parent_category
-                name: name_field
+                name: name
             assigned_content_tab: false
             register_main_menu: false

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "ibexa/form-builder": "4.6.x-dev",
         "ibexa/solr": "4.6.x-dev",
         "ibexa/version-comparison": "4.6.x-dev",
-        "league/oauth2-google": "^4.0"
+        "league/oauth2-google": "^4.0",
         "ibexa/connector-dam": "~4.6.x-dev"
     },
     "scripts": {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A)
| Versions      | 4.6
| Edition       |  Experience

This is fix for the page : https://doc.ibexa.co/en/latest/content_management/taxonomy/taxonomy/#customize-taxonomy-structure

The docs instructs you to name that field "name", but this doesn't match the config presented : https://github.com/ibexa/documentation-developer/blob/bb643999f925210719dc995b6839d616d8c87354/docs/content_management/taxonomy/taxonomy.md?plain=1#L50

Note that the instructions still doesn't work as listed due to [IBX-8420](https://issues.ibexa.co/browse/IBX-8420)

Work-around is to do this after the content type with `content_category` identifier as been created:

1. Comment out new taxonomy config in yaml
2. Attempt to create that "root" content in admin-ui. Draft will be created, but TaxonomyNotFoundException will be thrown due to missing yaml config. So you won't be able to edit and publish the draft
3. Re-enable yaml config
4. Go to dashboard
5. Edit draft of the "Content category" which was just created

Then continue from "Finish taxonomy setup by creating a new Content category (...)" as described in the docs

Not sure if we should add the bullet list above to the documentation until IBX-8420 has been fixed?

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR


[IBX-8420]: https://ibexa.atlassian.net/browse/IBX-8420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ