### PR TITLE
IBX-10937: Document the ContentTypeGroupName criterion for Find CTs API

### DIFF
--- a/code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php
+++ b/code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php
@@ -27,7 +27,7 @@ class FindContentTypeCommand extends Command
         // Find content types from the "Content" group that contains a specific field definition (in this case, a "Body" field).
         $query = new ContentTypeQuery(
             new Criterion\LogicalAnd([
-                new Criterion\ContentTypeGroupId([1]),
+                new Criterion\ContentTypeGroupName(['Content']),
                 new Criterion\ContainsFieldDefinitionId([121]),
             ]),
             [

--- a/docs/search/content_type_search_reference/content_type_criteria.md
+++ b/docs/search/content_type_search_reference/content_type_criteria.md
@@ -12,6 +12,7 @@ Content Type Search Criteria are only supported by [Content Type Search (`Conten
 |-------|-------------|
 | [ContainsFieldDefinitionId](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-Criterion-ContainsFieldDefinitionId.html) | Matches content types that contain a field definition with the specified ID. |
 | [ContentTypeGroupId](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-Criterion-ContentTypeGroupId.html) | Matches content types by their assigned group ID. |
+| [ContentTypeGroupName](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-Criterion-ContentTypeGroupName.html) | Matches content types by the name of their assigned group. |
 | [ContentTypeId](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-Criterion-ContentTypeId.html) | Matches content types by their ID. |
 | [ContentTypeIdentifier](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-Criterion-ContentTypeIdentifier.html) | Matches content types by their identifier. |
 | [IsSystem](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-Criterion-IsSystem.html) | Matches content types based on whether the group they belong to is system or not. |


### PR DESCRIPTION
| Question      | Answer |
| ------------- | --- |
| JIRA Ticket   | IBX-10937 |
| Versions      | 4.6, 5.0 |
| Edition       | all |

Document the ContentTypeGroupName criterion added in https://github.com/ibexa/core/pull/675

Link to API reference will work once the reference is rebuilt after the release.

Note: Merge after the release.

#### Checklist

- [x] Text renders correctly
- [x] Text has been checked with vale
- [x] Code samples are working
- [x] Added link to this PR in relevant JIRA ticket or code PR
