### PR TITLE
Updated performAccessCheck doc

### DIFF
--- a/code_samples/back_office/limitation/src/Controller/CustomController.php
+++ b/code_samples/back_office/limitation/src/Controller/CustomController.php
@@ -2,54 +2,14 @@
 
 namespace App\Controller;
 
-use App\Security\Limitation\CustomLimitationValue;
 use Ibexa\Contracts\AdminUi\Controller\Controller;
-use Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface;
-use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\User\Controller\AuthenticatedRememberedCheckTrait;
-use Ibexa\Contracts\User\Controller\RestrictedControllerInterface;
 use Ibexa\Core\MVC\Symfony\Security\Authorization\Attribute;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 
-class CustomController extends Controller implements RestrictedControllerInterface
+class CustomController extends Controller
 {
     use AuthenticatedRememberedCheckTrait {
         AuthenticatedRememberedCheckTrait::performAccessCheck as public traitPerformAccessCheck;
-    }
-
-    public function __construct(
-        // ...,
-        private readonly PermissionResolver $permissionResolver,
-        private readonly PermissionCheckerInterface $permissionChecker
-    ) {
-    }
-
-    // Controller actions...
-    public function customAction(Request $request): Response
-    {
-        // ...
-        if ($this->getCustomLimitationValue()) {
-            // Action only for user having the custom limitation checked
-        }
-
-        return new Response('<html><body>...</body></html>');
-    }
-
-    private function getCustomLimitationValue(): bool
-    {
-        $hasAccess = $this->permissionResolver->hasAccess('custom_module', 'custom_function_2');
-
-        if (is_bool($hasAccess)) {
-            return $hasAccess;
-        }
-
-        $customLimitationValues = $this->permissionChecker->getRestrictions(
-            $hasAccess,
-            CustomLimitationValue::class
-        );
-
-        return $customLimitationValues['value'] ?? false;
     }
 
     public function performAccessCheck(): void

--- a/code_samples/back_office/limitation/src/Controller/CustomLimitationController.php
+++ b/code_samples/back_office/limitation/src/Controller/CustomLimitationController.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Security\Limitation\CustomLimitationValue;
+use Ibexa\Contracts\AdminUi\Controller\Controller;
+use Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\User\Controller\AuthenticatedRememberedCheckTrait;
+use Ibexa\Core\MVC\Symfony\Security\Authorization\Attribute;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomLimitationController extends Controller
+{
+    use AuthenticatedRememberedCheckTrait {
+        AuthenticatedRememberedCheckTrait::performAccessCheck as public traitPerformAccessCheck;
+    }
+
+    public function __construct(
+        // ...,
+        private readonly PermissionResolver $permissionResolver,
+        private readonly PermissionCheckerInterface $permissionChecker
+    ) {
+    }
+
+    // Controller actions...
+    public function customAction(Request $request): Response
+    {
+        // ...
+        if ($this->getCustomLimitationValue()) {
+            // Action only for user having the custom limitation checked
+        }
+
+        return new Response('<html><body>...</body></html>');
+    }
+
+    private function getCustomLimitationValue(): bool
+    {
+        $hasAccess = $this->permissionResolver->hasAccess('custom_module', 'custom_function_2');
+
+        if (is_bool($hasAccess)) {
+            return $hasAccess;
+        }
+
+        $customLimitationValues = $this->permissionChecker->getRestrictions(
+            $hasAccess,
+            CustomLimitationValue::class
+        );
+
+        return $customLimitationValues['value'] ?? false;
+    }
+
+    public function performAccessCheck(): void
+    {
+        $this->traitPerformAccessCheck();
+        $this->denyAccessUnlessGranted(new Attribute('custom_module', 'custom_function_2'));
+    }
+}

--- a/docs/permissions/custom_policies.md
+++ b/docs/permissions/custom_policies.md
@@ -251,5 +251,5 @@ For example, `translations/ibexa_content_forms_policies.en.yaml`:
 Check if current user has this custom limitation set to true from a custom controller:
 
 ```php
-[[= include_file('code_samples/back_office/limitation/src/Controller/CustomController.php') =]]
+[[= include_file('code_samples/back_office/limitation/src/Controller/CustomLimitationController.php') =]]
 ```

--- a/docs/permissions/permission_overview.md
+++ b/docs/permissions/permission_overview.md
@@ -34,12 +34,12 @@ The more role assignments and complex policies you add for a given user, the mor
 
 ## Permissions for custom controllers
 
-You can control access to a custom controller by implementing the [`RestrictedControllerInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-RestrictedControllerInterface.html) interface directly or, for back office controllers, by inheriting from [`\Ibexa\Contracts\AdminUi\Controller\Controller`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-AdminUi-Controller-Controller.html).
+You can control access to a custom controller by implementing the [`RestrictedControllerInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-RestrictedControllerInterface.html) interface directly or, for back office controllers, by extending the [`\Ibexa\Contracts\AdminUi\Controller\Controller`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-AdminUi-Controller-Controller.html) class.
 
 In the following example the user doesn't have access to the controller unless they have the `section/view` policy and are [logged in using the "rememeber me cookie"]([[= symfony_doc =]]/security.html#checking-to-see-if-a-user-is-logged-in).
-It uses the [`AuthenticatedRememberedCheckTrait`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-AuthenticatedRememberedCheckTrait.html) to reuse the existing code.
+It uses the [`AuthenticatedRememberedCheckTrait`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-AuthenticatedRememberedCheckTrait.html) to for the latter check.
 
-``` php hl_lines="17-18"
+``` php hl_lines="15-19"
 [[= include_file('code_samples/back_office/limitation/src/Controller/CustomController.php', 0, 20) =]]
 ```
 

--- a/docs/permissions/permission_overview.md
+++ b/docs/permissions/permission_overview.md
@@ -37,7 +37,7 @@ The more role assignments and complex policies you add for a given user, the mor
 You can control access to a custom controller by implementing the [`RestrictedControllerInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-RestrictedControllerInterface.html) interface directly or, for back office controllers, by extending the [`\Ibexa\Contracts\AdminUi\Controller\Controller`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-AdminUi-Controller-Controller.html) class.
 
 In the following example the user doesn't have access to the controller unless they have the `section/view` policy and are [logged in using the "rememeber me cookie"]([[= symfony_doc =]]/security.html#checking-to-see-if-a-user-is-logged-in).
-It uses the [`AuthenticatedRememberedCheckTrait`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-AuthenticatedRememberedCheckTrait.html) to for the latter check.
+It uses the [`AuthenticatedRememberedCheckTrait`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-AuthenticatedRememberedCheckTrait.html) for the latter check.
 
 ``` php hl_lines="15-19"
 [[= include_file('code_samples/back_office/limitation/src/Controller/CustomController.php', 0, 20) =]]

--- a/docs/permissions/permission_overview.md
+++ b/docs/permissions/permission_overview.md
@@ -34,23 +34,18 @@ The more role assignments and complex policies you add for a given user, the mor
 
 ## Permissions for custom controllers
 
-You can control access to a custom controller by implementing the `performAccessCheck()` method.
+You can control access to a custom controller by implementing the [`RestrictedControllerInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-RestrictedControllerInterface.html) interface directly or, for back office controllers, by inheriting from [`\Ibexa\Contracts\AdminUi\Controller\Controller`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-AdminUi-Controller-Controller.html).
 
-In the following example the user doesn't have access to the controller unless they have the `section/view` policy:
+In the following example the user doesn't have access to the controller unless they have the `section/view` policy and are [logged in using the "rememeber me cookie"]([[= symfony_doc =]]/security.html#checking-to-see-if-a-user-is-logged-in).
+It uses the [`AuthenticatedRememberedCheckTrait`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-User-Controller-AuthenticatedRememberedCheckTrait.html) to reuse the existing code.
 
-``` php
-use Ibexa\Core\MVC\Symfony\Security\Authorization\Attribute;
-
-public function performAccessCheck(): void
-{
-    parent::performAccessCheck();
-    $this->denyAccessUnlessGranted(new Attribute('section', 'view'));
-}
+``` php hl_lines="17-18"
+[[= include_file('code_samples/back_office/limitation/src/Controller/CustomController.php', 0, 20) =]]
 ```
 
 `Attribute` accepts three arguments:
 
-- `module` is the policy module (for example,`content`)
+- `module` is the policy module (for example, `content`)
 - `function` is the function inside the module (for example, `read`)
 - `limitations` are optional limitations to check against. Here you can provide two keys:
     - `valueObject` is the object you want to check for, for example `ContentInfo`.


### PR DESCRIPTION
Things done:

1) CustomController is renamed to CustomLimitationController
2) I've decided that instead of splicing a new code sample for the doc with many include_file calls, it's cheaper to create a new short code sample based on the existing one. Reasoning: PHPStan and Rector make the maintenence of PHP files easier than fixing fragmented `include_file` calls manually.