### PR TITLE
Changed event type for integrated help

### DIFF
--- a/code_samples/back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php
+++ b/code_samples/back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use Ibexa\AdminUi\Menu\Event\ConfigureMenuEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
 final class HelpMenuSubscriber implements EventSubscriberInterface
 {
@@ -21,7 +21,7 @@ final class HelpMenuSubscriber implements EventSubscriberInterface
         ];
     }
 
-    public function onHelpMenuConfigure(Event $event): void
+    public function onHelpMenuConfigure(ConfigureMenuEvent $event): void
     {
         $menu = $event->getMenu();
 


### PR DESCRIPTION
PHPStan error:
```
  ------ ----------------------------------------------------------------------- 
  Line   back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php  
 ------ ----------------------------------------------------------------------- 
  26     Call to an undefined method                                            
         Symfony\Contracts\EventDispatcher\Event::getMenu().                    
         🪪  method.notFound                                                    
 ------ ------------------------
```