### PR TITLE
Added ibexa/phpstan rules

### DIFF
--- a/code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
+++ b/code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
@@ -41,7 +41,7 @@ class MySuggestionEventSubscriber implements EventSubscriberInterface, LoggerAwa
 
         try {
             $productQuery = new ProductQuery(null, new Criterion\LogicalOr([
-                new Criterion\ProductName(implode(' ', array_map(static function (string $word) {
+                new Criterion\ProductName(implode(' ', array_map(static function (string $word) : string {
                     return "$word*";
                 }, $words))),
                 new Criterion\ProductCode($words),

--- a/code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
+++ b/code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
@@ -41,7 +41,7 @@ class MySuggestionEventSubscriber implements EventSubscriberInterface, LoggerAwa
 
         try {
             $productQuery = new ProductQuery(null, new Criterion\LogicalOr([
-                new Criterion\ProductName(implode(' ', array_map(static function (string $word) : string {
+                new Criterion\ProductName(implode(' ', array_map(static function (string $word): string {
                     return "$word*";
                 }, $words))),
                 new Criterion\ProductCode($words),

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
         "ibexa/product-catalog-symbol-attribute": "~4.6.x-dev",
         "ibexa/messenger": "~4.6.x-dev",
         "ibexa/collaboration": "~4.6.x-dev",
-        "ibexa/share": "~4.6.x-dev"
+        "ibexa/share": "~4.6.x-dev",
+        "ibexa/phpstan": "~4.6.-dev"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 includes:
     - phpstan-baseline.neon
     - vendor/phpstan/phpstan-symfony/extension.neon
+    - vendor/ibexa/phpstan/extension.neon
 
 parameters:
     level: 8


### PR DESCRIPTION
Added ibexa/phpstan ruleset. It detected one issue:

```
~/Desktop/repos/mnocon/doc/4.6 improve-phpstan *1 !2 ❯ composer phpstan                                                                                                                       15:42:36
> phpstan analyse
Note: Using configuration file /Users/marek/Desktop/repos/mnocon/doc/4.6/phpstan.neon.
 258/258 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------------ 
  Line   back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php  
 ------ ------------------------------------------------------------------------ 
  :44    Closure is missing a return type declaration       
```