### PR TITLE
Added redirects for LTS updates

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -556,3 +556,7 @@ plugins:
             'getting_started/ibexa_cloud_guide.md': 'ibexa_cloud/ibexa_cloud_guide.md'
             'getting_started/install_on_ibexa_cloud.md': 'ibexa_cloud/install_on_ibexa_cloud.md'
             'infrastructure_and_maintenance/clustering/ddev_and_ibexa_cloud.md': 'ibexa_cloud/ddev_and_ibexa_cloud.md'
+
+            'ai_actions/configure_ai_actions.md': 'ai_actions/install_ai_actions.md'
+            'discounts/configure_discounts.md': 'discounts/install_discounts.md'
+            'content_management/collaborative_editing/configure_collaborative_editing.md': 'content_management/collaborative_editing/install_collaborative_editing.md'

--- a/plugins.yml
+++ b/plugins.yml
@@ -556,7 +556,6 @@ plugins:
             'getting_started/ibexa_cloud_guide.md': 'ibexa_cloud/ibexa_cloud_guide.md'
             'getting_started/install_on_ibexa_cloud.md': 'ibexa_cloud/install_on_ibexa_cloud.md'
             'infrastructure_and_maintenance/clustering/ddev_and_ibexa_cloud.md': 'ibexa_cloud/ddev_and_ibexa_cloud.md'
-
             'ai_actions/configure_ai_actions.md': 'ai_actions/install_ai_actions.md'
             'discounts/configure_discounts.md': 'discounts/install_discounts.md'
             'content_management/collaborative_editing/configure_collaborative_editing.md': 'content_management/collaborative_editing/install_collaborative_editing.md'


### PR DESCRIPTION
The idea is simple - very often I encounter an error page when switching between doc versions for LTS updates.

I'd like to have this redirects for 4.6 (and the reverse in v5), so that switching to 4.6 version while being on https://doc.ibexa.co/en/5.0/ai_actions/configure_ai_actions/ doesn't result in 404, but results in a redirect to https://doc.ibexa.co/en/4.6/ai_actions/install_ai_actions/

Once approved I'll create a PR for v5