### PR TITLE
4.6.27: Update doc for dropped unused guzzle dependencies

### DIFF
--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -470,7 +470,7 @@ composer why guzzlehttp/guzzle
 composer why php-http/guzzle6-adapter
 ```
 
-If only the `ibexa/core` entry appears in the output, check your codebase to determine if you use Guzzle directly. 
+If only the `ibexa/core` entry appears in the output, check your codebase to determine if you use Guzzle directly.
 If you do, add the required dependencies to your project:
 
 ```bash

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -452,6 +452,31 @@ Run the provided SQL upgrade script to add the missing indexes to your database:
 
 No additional steps needed.
 
+## v4.6.27
+
+### Removed Composer dependencies
+
+The following unused Composer dependencies have been removed from `ibexa/core`:
+
+- `guzzlehttp/guzzle`
+- `php-http/guzzle6-adapter`
+
+If your project uses Guzzle directly, you should add these dependencies to your project's `composer.json` file.
+
+To check if you need to add these dependencies, run:
+
+```bash
+composer why guzzlehttp/guzzle
+composer why php-http/guzzle6-adapter
+```
+
+If only the `ibexa/core` entry appears in the output, check your codebase to determine if you use Guzzle directly. 
+If you do, add the required dependencies to your project:
+
+```bash
+composer require guzzlehttp/guzzle:^6.5 php-http/guzzle6-adapter:^2.0
+```
+
 <!-- End of update instructions -->
 
 [[% include 'snippets/update/notify_support.md' %]]


### PR DESCRIPTION
Update doc fragment for 4.6.27

See https://github.com/ibexa/core/pull/691

Status: waiting for 4.6.27 release