### PR TITLE
5.0.3 to 5.0.4: DB Update

### DIFF
--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -152,7 +152,32 @@ Run the provided SQL upgrade script to add the missing indexes to your database:
 
 ## v5.0.4
 
-No additional steps needed.
+### Database update [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
+
+On a platform first installed on v5.0.3, you need to execute the requests below.
+If the platform comes from an earlier version, you don't need this (but if you run the requests anyway, you just obtain error messages).
+
+=== "MySQL"
+
+    ``` sql
+    ALTER TABLE `ibexa_site_public_access` ADD COLUMN `tree_root_location_id` INT DEFAULT NULL;
+    ALTER TABLE `ibexa_site_public_access` ADD INDEX `ibexa_spa_trl_id` (`tree_root_location_id`);
+
+    UPDATE ibexa_site_public_access
+      SET tree_root_location_id = CAST(JSON_UNQUOTE(JSON_EXTRACT(config, '$."ibexa.site_access.config.content.tree_root.location_id"')) AS SIGNED)
+      WHERE tree_root_location_id IS NULL AND JSON_EXTRACT(config, '$."ibexa.site_access.config.content.tree_root.location_id"') IS NOT NULL;
+    ```
+
+=== "PostgreSQL"
+
+    ``` sql
+    ALTER TABLE ibexa_site_public_access ADD COLUMN tree_root_location_id INT DEFAULT NULL;
+    CREATE INDEX "ibexa_spa_trl_id" ON "ibexa_site_public_access" ("tree_root_location_id");
+
+    UPDATE ibexa_site_public_access
+      SET tree_root_location_id = (config::jsonb ->> 'ibexa.site_access.config.content.tree_root.location_id')::integer
+      WHERE tree_root_location_id IS NULL AND config::jsonb ? 'ibexa.site_access.config.content.tree_root.location_id';
+    ```
 
 ## LTS Updates and additional packages
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -154,8 +154,8 @@ Run the provided SQL upgrade script to add the missing indexes to your database:
 
 ### Database update [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 
-On a platform first installed on v5.0.3, you need to execute the requests below.
-If the platform comes from an earlier version, you don't need this (but if you run the requests anyway, you just obtain error messages).
+From a platform first installed on v5.0.3 or updated precisely to v5.0.3, you need to execute the requests below.
+If the platform comes from lower than v5.0.3 and is updated to higher than v5.0.3, you don't need this part (but if you run the requests anyway, you just obtain error messages, nothing being broken or lost).
 
 === "MySQL"
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -155,7 +155,8 @@ Run the provided SQL upgrade script to add the missing indexes to your database:
 ### Database update [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 
 From a platform first installed on v5.0.3 or updated precisely to v5.0.3, you need to execute the requests below.
-If the platform comes from lower than v5.0.3 and is updated to higher than v5.0.3, you don't need this part (but if you run the requests anyway, you just obtain error messages, nothing being broken or lost).
+If the platform comes from lower than v5.0.3 and is updated to higher than v5.0.3, you don't need this part
+(but if you run the requests anyway, you only obtain error messages, nothing being broken or lost).
 
 === "MySQL"
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | [IBX-10320](https://ibexa.atlassian.net/browse/IBX-10320)
| Versions      | 5.0.3 and 5.0.4
| Edition       | Experience, Commerce

* [mysql/ibexa-5.0.2-to-5.0.3.sql v5.0.3](https://github.com/ibexa/installer/blob/v5.0.3/upgrade/db/mysql/ibexa-5.0.2-to-5.0.3.sql)
* [mysql/ibexa-5.0.2-to-5.0.3.sql v5.0.4](https://github.com/ibexa/installer/blob/v5.0.4/upgrade/db/mysql/ibexa-5.0.2-to-5.0.3.sql)
* [postgresql/ibexa-5.0.2-to-5.0.3.sql v5.0.3](https://github.com/ibexa/installer/blob/v5.0.3/upgrade/db/postgresql/ibexa-5.0.2-to-5.0.3.sql)
* [postgresql/ibexa-5.0.2-to-5.0.3.sql v5.0.4](https://github.com/ibexa/installer/blob/v5.0.4/upgrade/db/postgresql/ibexa-5.0.2-to-5.0.3.sql)

ibexa-5.0.2-to-5.0.3.sql files have been edited between 5.0.3 and 5.0.4
https://github.com/ibexa/installer/commit/c84c6ad3c5b9b9367fdae85ec1c7c888a298ecd3

If someone ended on v5.0.3, this DB upgrade SQL file won't be played again so the v5.0.4 part must be executed manually.

* v5.0.3→v5.0.4: needed
* v5.0.2→v5.0.3→v5.0.4: needed
* v5.0.2→v5.0.4: not needed

`ibexa_site_public_access` is a site factory table only existing on Experience and Commerce.
The `ibexa_site_public_access.tree_root_location_id` isn't used until v5.0.4 https://github.com/ibexa/site-factory/commit/f248888b0ccee6f9bee84556455c3e19fe00d8ef

I added condition to not override `tree_root_location_id` if the last request have already been ran.

Preview: https://ez-systems-developer-documentation--2997.com.readthedocs.build/en/2997/update_and_migration/from_5.0/update_from_5.0/#database-update_1

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR


[IBX-10320]: https://ibexa.atlassian.net/browse/IBX-10320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ