### PR TITLE
site_factory: Fix `ibexadesign` config

### DIFF
--- a/docs/multisite/site_factory/site_factory.md
+++ b/docs/multisite/site_factory/site_factory.md
@@ -60,14 +60,13 @@ ibexa:
             '@Ibexa\SiteFactory\SiteAccessMatcher': ~
 ```
 
-`ibexadesign` defines templates for your sites, so add them before continuing.
-Next, add the configuration for `ibexadesign` on the same level as `ibexa`:
+Next, add the [design engine](design_engine.md) configuration for new specific designs and their theme lists:
 
 ``` yaml
 ibexa_design_engine:
     design_list:
-        example_1: [example_1_template]
-        example_2: [example_2_template]
+        example_1: [example_1_theme]
+        example_2: [example_2_theme]
 ```
 
 Finally, configure designs for empty SiteAccess groups:
@@ -90,11 +89,11 @@ ibexa_site_factory:
     templates:
         site1:
             siteaccess_group: example_site_factory_group_1
-            name: example_site_1
+            name: Example site 1
             thumbnail: /path/to/image/example-thumbnail_1.png
         site2:
             siteaccess_group: example_site_factory_group_2
-            name: example_site_2
+            name: Example site 2
             thumbnail: /path/to/image/example-thumbnail_2.png
 ```
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 5.0, 4.6
| Edition       | Experience, Commerce

> `ezdesign` defines templates for your sites, so add them before continuing.
> Next, add the configuration for `ezdesign` on the same level as `ezplatform`:

The original sentence was about this old example:

``` yaml
ezplatform:
    siteaccess: …
ezdesign:
    design_list: …
```

Fix previous rebranding update to avoid confusion between the design path `@ezdesign`→`@ibexadesign` and the design conf `ezdesign.design_list`→`ibexa_design_engine.design_list`

``` yaml
ibexa:
    siteaccess: …
ibexa_design_engine:
    design_list: …
```

I guess the reader can indent this correctly without the instruction about levels. A link to design engine doc page could help readers not aware enough about this part.

Preview: https://ez-systems-developer-documentation--2998.com.readthedocs.build/en/2998/multisite/site_factory/site_factory/#enable-site-factory

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
