### PR TITLE
Use DDEV's Symfony project type

### DIFF
--- a/docs/getting_started/install_with_ddev.md
+++ b/docs/getting_started/install_with_ddev.md
@@ -31,7 +31,7 @@ mkdir my-ddev-project && cd my-ddev-project
 Next, configure your DDEV environment with the following command:
 
 ```bash
-ddev config --project-type=php --php-version 8.3 --nodejs-version 22 --docroot=public
+ddev config --project-type=symfony --php-version 8.3 --nodejs-version 22 --docroot=public
 ```
 
 This command sets the project type to PHP, the PHP version to 8.3, the document root to `public` directory, and creates the document root if it doesn't exist.
@@ -158,7 +158,7 @@ ddev composer create ibexa/<edition>-skeleton:<version>
 Once you've made this change, you can proceed to install [[= product_name =]].
 
 ```bash
-ddev php bin/console ibexa:install
+ddev console ibexa:install
 ```
 
 ### 7. Open browser
@@ -177,7 +177,7 @@ You can edit the configuration and code in the DDEV project directory.
 You can use commands listed in the documentation by prefixing them with `ddev exec` or by opening a terminal inside the container by using `ddev ssh`.
 For example, if a guideline invites you to run `php bin/console cache:clear`, you can do it in the DDEV container in one of the following ways:
 
-- run `ddev php bin/console cache:clear`
+- run `ddev console cache:clear`
 - enter `ddev ssh` and run `php bin/console cache:clear` after the new prompt
 
 ## Other options for configuration
@@ -366,7 +366,7 @@ To run an existing project, you need to:
 1. Add Composer authentication.
 1. Install dependencies packages with Composer.
 1. Populate the contents, which could mean:
-    - getting a clean database with `ddev php bin/console ibexa:install` and adding some data with [Ibexa data migration](importing_data.md), or
+    - getting a clean database with `ddev console ibexa:install` and adding some data with [Ibexa data migration](importing_data.md), or
     - injecting a dump with [`ddev import-db`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#import-db) and copying related binary files into `public/var`.
 
 The following examples run an already [version-controlled project](install_ibexa_dxp.md#add-project-to-version-control) and have the right content structure (but no content):
@@ -377,7 +377,7 @@ git clone <repository> my-ddev-project && cd my-ddev-project
 # Exclude the whole `.ddev/` directory from version control (some DDEV config could have been committed and shared, see notice below)
 .ddev/ >> .gitignore
 # Configure the DDEV project then start it
-ddev config --project-type=php --php-version 8.3 \
+ddev config --project-type=symfony --php-version 8.3 \
   --docroot=public \
   --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db \
   --http-port=8080 --https-port=8443
@@ -387,9 +387,9 @@ ddev composer config --global http-basic.updates.ibexa.co <installation-key> <to
 # Install the dependencies packages
 ddev composer install
 # Populate the database with a clean install
-ddev php bin/console ibexa:install
+ddev console ibexa:install
 # Add some content types using a migration file (previously created on another installation) and update the GraphQL schema
-ddev php bin/console ibexa:migrations:migrate --file=project_content_types.yaml
+ddev console ibexa:migrations:migrate --file=project_content_types.yaml
 # Open the project in the default browser which should display the default SiteAccess frontpage
 ddev launch
 ```

--- a/docs/getting_started/install_with_ddev.md
+++ b/docs/getting_started/install_with_ddev.md
@@ -34,7 +34,8 @@ Next, configure your DDEV environment with the following command:
 ddev config --project-type=symfony --php-version 8.3 --nodejs-version 22 --docroot=public
 ```
 
-This command sets the project type to PHP, the PHP version to 8.3, the document root to `public` directory, and creates the document root if it doesn't exist.
+This command sets the project type to Symfony, the PHP version to 8.3, the document root to `public` directory, and creates the document root if it doesn't exist.
+The Symfony project type add the `ddev console` command (equivalent to `ddev php bin/console` from PHP project type).
 
 #### Use another database type (optional)
 

--- a/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
+++ b/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
@@ -53,7 +53,7 @@ See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.htm
 
 ```bash
 ibexa_cloud project:get <project-ID> my-ddev-project && cd my-ddev-project
-ddev config --project-type=php --php-version 8.3 --web-environment-add COMPOSER_AUTH='',DATABASE_URL=mysql://db:db@db:3306/db
+ddev config --project-type=symfony --php-version 8.3 --web-environment-add COMPOSER_AUTH='',DATABASE_URL=mysql://db:db@db:3306/db
 ddev config --web-environment-add IBEXA_PROJECT=<project-ID>,IBEXA_ENVIRONMENT=production,IBEXA_APP=app
 ddev config --web-environment-add IBEXA_CLI_TOKEN=<api-token>
 echo '.ddev/' >> .gitignore
@@ -93,7 +93,7 @@ The following sequence of commands:
 
 ```bash
 ibexa_cloud project:get <project-ID> my-ddev-project && cd my-ddev-project
-ddev config --project-type=php --php-version 8.3 --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
+ddev config --project-type=symfony --php-version 8.3 --docroot=public --web-environment-add DATABASE_URL=mysql://db:db@db:3306/db
 echo '.ddev/' >> .gitignore
 ddev start
 ddev composer config --global http-basic.updates.ibexa.co <installation-key> <token-password>

--- a/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
@@ -45,9 +45,9 @@ ddev add-on get ddev/ddev-elasticsearch
 ddev config --web-environment-add SEARCH_ENGINE=elasticsearch
 ddev config --web-environment-add ELASTICSEARCH_DSN=http://elasticsearch:9200
 ddev restart
-ddev php bin/console cache:clear
-ddev php bin/console ibexa:elasticsearch:put-index-template
-ddev php bin/console ibexa:reindex
+ddev console cache:clear
+ddev console ibexa:elasticsearch:put-index-template
+ddev console ibexa:reindex
 ```
 
 You can now check whether Elasticsearch works.
@@ -86,8 +86,8 @@ mkdir .ddev/solr/configsets/collection1
 ddev exec -s solr cp -R /opt/solr/server/solr/configsets/_default/conf/* /mnt/ddev_config/solr/configsets/collection1/
 cp -R vendor/ibexa/solr/src/lib/Resources/config/solr/* .ddev/solr/configsets/collection1/
 ddev restart
-ddev php bin/console cache:clear
-ddev php bin/console ibexa:reindex
+ddev console cache:clear
+ddev console ibexa:reindex
 ```
 
 You can now check whether Solr works.
@@ -134,7 +134,7 @@ ddev config --web-environment-add SESSION_HANDLER_ID='Ibexa\\Bundle\\Core\\Sessi
 ddev config --web-environment-add SESSION_SAVE_PATH=tcp://redis:6379
 sed -i 's/maxmemory-policy allkeys-lfu/maxmemory-policy volatile-lfu/' .ddev/redis/redis.conf;
 ddev restart
-ddev php bin/console cache:clear
+ddev console cache:clear
 ```
 
 You can now check whether Redis works.


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

I prefer `ddev php bin/console` to `ddev console` as there is just to remove `ddev` to convert it back to "regular" command like in production. (For same reason, I didn't use `ddev exec command` with PHP type in contrary to https://docs.ddev.com/en/stable/users/quickstart/#ibexa-dxp where I choose to show full integration with DDEV.)

…But, that might not be the case for the reader. 

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
