### PR TITLE
Fixed spelling issues

### DIFF
--- a/docs/discounts/discounts_api.md
+++ b/docs/discounts/discounts_api.md
@@ -45,7 +45,7 @@ Only a single discount can be applied to a given product, and a discount can onl
 
 When creating a rule, not with the user interface but an API, you must pass the required expression values for the rule to be valid:
 
-- using PHP, the values are passed through the constuctor which converts them into an expression variable
+- using PHP, the values are passed through the constructor which converts them into an expression variable
 - using data migrations and the REST API, the values are specified using the `expressionValues` key
 
 See the following examples for data migrations and the REST API usage:
@@ -83,7 +83,7 @@ When multiple conditions are specified, all of them must be met.
 
 As with rules, when creating a condition through other means than the user interface, you must pass the required expression values for the condition to be valid:
 
-- using PHP, the values are passed through the constuctor which converts them into an expression variable
+- using PHP, the values are passed through the constructor which converts them into an expression variable
 - using data migrations and the REST API, the values are specified using the `expressionValues` key
 
 See the following examples for data migrations and the REST API usage:

--- a/docs/discounts/extend_discounts.md
+++ b/docs/discounts/extend_discounts.md
@@ -173,7 +173,7 @@ It uses three expressions:
 
 - the built-in `amount` variable, holding the purchase amount
 - the built-in `get_current_region()` function, returning the current region
-- a custom `power_parity_map` variable, holding the purchasing power parity map. It's defined in the constructor.
+- a custom `power_parity_map` variable, holding the purchasing power parity map. It's defined in the constructor
 
 As with conditions, create a dedicated rule factory:
 

--- a/docs/discounts/extend_discounts.md
+++ b/docs/discounts/extend_discounts.md
@@ -69,7 +69,7 @@ And mark it as a service using the `ibexa.discounts.expression_language.variable
 - New function: `is_anniversary()`
 
 It's a function returning a boolean value indicating if today is the anniversary of the date passed as an argument.
-The function accepts an optional argument, `tolerance`, allowing you to extend the range of dates that are acccepted as anniversaries.
+The function accepts an optional argument, `tolerance`, allowing you to extend the range of dates that are accepted as anniversaries.
 This implementation is simplified and does not cover the approach for accounts created on February 29 during leap years.
 
 ``` php
@@ -125,7 +125,7 @@ The example uses three expressions:
 - the custom `current_user_registration_date` variable, holding the value of current user's registration date
 - the custom `tolerance` variable, holding the acceptable tolerance (in days) for the calculation
 
-For each custom condition class, you must create a dedicated condition factory, a class implementing the `\Ibexa\Discounts\Repository\DiscountCondition\DiscountConditionFactoryInterface` inteface.
+For each custom condition class, you must create a dedicated condition factory, a class implementing the `\Ibexa\Discounts\Repository\DiscountCondition\DiscountConditionFactoryInterface` interface.
 
 This allows you to create conditions when working in the context of the Symfony service container.
 
@@ -173,7 +173,7 @@ It uses three expressions:
 
 - the built-in `amount` variable, holding the purchase amount
 - the built-in `get_current_region()` function, returning the current region
-- a custom `power_parity_map` variable, holding the purchasing power partity map. It's defined in the constuctor.
+- a custom `power_parity_map` variable, holding the purchasing power parity map. It's defined in the constructor.
 
 As with conditions, create a dedicated rule factory:
 

--- a/docs/pim/price_api.md
+++ b/docs/pim/price_api.md
@@ -70,9 +70,9 @@ To display a product price on a product page or in the cart, you must calculate 
 Context contains information about any price modifiers that may apply to a specific customer group.
 To determine the final price, or resolve the price, use the [`PriceResolverInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-PriceResolverInterface.html) service, which takes the following conditions into account:
 
-1. Existance of base price for the product in the specified currency
-2. Existance of customer group-related modifiers
-3. Existance of applicable [discounts](discounts.md)
+1. Existence of base price for the product in the specified currency
+2. Existence of customer group-related modifiers
+3. Existence of applicable [discounts](discounts.md)
 
 If the base price in the specified currency is missing, the return value is `null`.
 


### PR DESCRIPTION
Result of:

```
~/Desktop/repos/mnocon/documentation-developer/5.0 5.0 !6517 ?4 ❯ vale --minAlertLevel=suggestion --filter=".Name==\"Ibexa.Spellcheck\"" docs                         24.4.0 08:23:47

 docs/discounts/discounts_api.md
 48:48  error  Did you really mean             Ibexa.Spellcheck 
               'constuctor'?                                    
 86:48  error  Did you really mean             Ibexa.Spellcheck 
               'constuctor'?                                    


 docs/discounts/extend_discounts.md
 72:108   error  Did you really mean             Ibexa.Spellcheck 
                 'acccepted'?                                     
 128:188  error  Did you really mean             Ibexa.Spellcheck 
                 'inteface'?                                      
 176:70   error  Did you really mean 'partity'?  Ibexa.Spellcheck 
 176:103  error  Did you really mean             Ibexa.Spellcheck 
                 'constuctor'?                                    


 docs/pim/price_api.md
 73:4  error  Did you really mean             Ibexa.Spellcheck 
              'Existance'?                                     
 74:4  error  Did you really mean             Ibexa.Spellcheck 
              'Existance'?                                     
 75:4  error  Did you really mean             Ibexa.Spellcheck 
              'Existance'?                                     

✖ 9 errors, 0 warnings and 0 suggestions in 805 files.
```

Spellcheck in vale PR coming soon

About the removed fullstop at the end of the list - I'm not sure, I think it's better without one?