### PR TITLE
Updated Commons DAM example to work - User-agent is missing

### DIFF
--- a/code_samples/back_office/images/src/Connector/Dam/Handler/WikimediaCommonsHandler.php
+++ b/code_samples/back_office/images/src/Connector/Dam/Handler/WikimediaCommonsHandler.php
@@ -14,6 +14,7 @@ use Ibexa\Contracts\Connector\Dam\Search\Query;
 
 class WikimediaCommonsHandler implements HandlerInterface
 {
+    private const USER_AGENT = 'Ibexa DXP Commons Dam Connector';
     public function search(Query $query, int $offset = 0, int $limit = 20): AssetSearchResult
     {
         $searchUrl = 'https://commons.wikimedia.org/w/api.php?action=query&list=search&format=json&srnamespace=6'
@@ -22,7 +23,16 @@ class WikimediaCommonsHandler implements HandlerInterface
             . '&srlimit=' . $limit
         ;
 
-        $jsonResponse = file_get_contents($searchUrl);
+        $opts = [
+            "http" => [
+                "method" => "GET",
+                'header' => [
+                    'User-Agent: ' . self::USER_AGENT,
+                ],
+            ]
+        ];
+
+        $jsonResponse = file_get_contents($searchUrl, false, stream_context_create($opts));
         if ($jsonResponse === false) {
             return new AssetSearchResult(0, new AssetCollection([]));
         }
@@ -50,7 +60,16 @@ class WikimediaCommonsHandler implements HandlerInterface
             . '&titles=File%3a' . urlencode($id)
         ;
 
-        $jsonResponse = file_get_contents($metadataUrl);
+        $opts = [
+            "http" => [
+                "method" => "GET",
+                'header' => [
+                    'User-Agent: ' . self::USER_AGENT,
+                ],
+            ]
+        ];
+
+        $jsonResponse = file_get_contents($metadataUrl, false, stream_context_create($opts));
         if ($jsonResponse === false) {
             throw new \RuntimeException('Couldn\'t retrieve asset metadata');
         }

--- a/code_samples/back_office/images/src/Connector/Dam/Handler/WikimediaCommonsHandler.php
+++ b/code_samples/back_office/images/src/Connector/Dam/Handler/WikimediaCommonsHandler.php
@@ -15,6 +15,7 @@ use Ibexa\Contracts\Connector\Dam\Search\Query;
 class WikimediaCommonsHandler implements HandlerInterface
 {
     private const USER_AGENT = 'Ibexa DXP Commons Dam Connector';
+
     public function search(Query $query, int $offset = 0, int $limit = 20): AssetSearchResult
     {
         $searchUrl = 'https://commons.wikimedia.org/w/api.php?action=query&list=search&format=json&srnamespace=6'
@@ -24,12 +25,12 @@ class WikimediaCommonsHandler implements HandlerInterface
         ;
 
         $opts = [
-            "http" => [
-                "method" => "GET",
+            'http' => [
+                'method' => 'GET',
                 'header' => [
                     'User-Agent: ' . self::USER_AGENT,
                 ],
-            ]
+            ],
         ];
 
         $jsonResponse = file_get_contents($searchUrl, false, stream_context_create($opts));
@@ -61,12 +62,12 @@ class WikimediaCommonsHandler implements HandlerInterface
         ;
 
         $opts = [
-            "http" => [
-                "method" => "GET",
+            'http' => [
+                'method' => 'GET',
                 'header' => [
                     'User-Agent: ' . self::USER_AGENT,
                 ],
-            ]
+            ],
         ];
 
         $jsonResponse = file_get_contents($metadataUrl, false, stream_context_create($opts));

--- a/code_samples/back_office/images/templates/themes/standard/commons_asset_view.html.twig
+++ b/code_samples/back_office/images/templates/themes/standard/commons_asset_view.html.twig
@@ -4,7 +4,7 @@
     {{ parent() }}
     <div>
         <a href="{{ asset.assetMetadata.page_url }}">Image</a>
-        {% if asset.assetMetadata.author %} by {{ asset.assetMetadata.author }}{% endif %}
+        {% if asset.assetMetadata.author %} by {{ asset.assetMetadata.author|striptags }}{% endif %}
         {% if asset.assetMetadata.license and asset.assetMetadata.license_url %}
             under <a href="{{ asset.assetMetadata.license_url }}">{{ asset.assetMetadata.license }}</a>
         {% endif %}.


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 4.6, 5.0
| Edition       | Headless, Experience, Commerce


An [`User-Agent` header](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy) is required, or Commons will only reply with 403 access denied now.

Also, small improvement to view template:
<img width="2296" height="987" alt="image" src="https://github.com/user-attachments/assets/f8d7e5cd-4d0a-4b6f-914f-b3c490e0cc51" />

vs

<img width="1161" height="941" alt="image" src="https://github.com/user-attachments/assets/1ae13c76-af39-4195-b269-056c8219cc9f" />



#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
