### PR TITLE
Replaced "type" attribute type with a real example

### DIFF
--- a/code_samples/page/custom_page_block/config/packages/nested_attribute.yaml
+++ b/code_samples/page/custom_page_block/config/packages/nested_attribute.yaml
@@ -13,13 +13,13 @@ ibexa_fieldtype_page:
                         attributes:
                             attribute_1:
                                 name: Name 1
-                                type: type
+                                type: string
                                 validators:
                                     not_blank:
                                         message: 'Provide a value'
                             attribute_2:
                                 name: Name 2
-                                type: type
+                                type: string
                         multiple: true
                     validators:
                         not_blank:


### PR DESCRIPTION
As suggested on Slack

Preview: https://ez-systems-developer-documentation--3031.com.readthedocs.build/en/3031/content_management/pages/page_block_attributes/#nested-attribute-configuration