### PR TITLE
Release 4.6.27 - release notes

### DIFF
--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -11,7 +11,7 @@ month_change: false
 <div class="release-notes" markdown="1">
 
 [[% set version = 'v4.6.27' %]]
-[= release_note_entry_begin("Ibexa DXP " + version, '2026-02-03', ['Headless', 'Experience', 'Commerce']) =]]
+[[= release_note_entry_begin("Ibexa DXP " + version, '2026-02-03', ['Headless', 'Experience', 'Commerce']) =]]
 
 ### Added support for Elasticsearch 8
 
@@ -42,8 +42,8 @@ You can now indicate which [query parameters](https://en.wikipedia.org/wiki/Quer
 This allows you to improve performance for blocks using the query parameters, for example, paginated blocks in the [dashboard](customize_dashboard.md).
 
 To set it up, use the new `cacheable_query_params` [block setting](page_blocks.md#block-configuration).
-Then, adjust your [layouts](render_page.md#configure-layout) and pass the parameters to Symfony's `controller function`([[= symfony_doc =]]/reference/twig_reference.html#controller) by using the new `ibexa_append_cacheable_query_params` Twig function.
-See the example below:
+
+Then, adjust your [layouts](render_page.md#configure-layout) and pass the parameters to [Symfony's `controller function`]([[= symfony_doc =]]/reference/twig_reference.html#controller) by using the new `ibexa_append_cacheable_query_params` Twig function, as in the example below:
 
 ``` html+twig
 {{ render_esi(controller('Ibexa\\Bundle\\FieldTypePage\\Controller\\BlockController::renderAction',

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -22,7 +22,7 @@ See the [update instructions](update_from_4.6.md#elasticsearch-8-support) for mo
 ### Added asynchronous processing of data in Ibexa DXP
 
 You can now process requests from [[[= product_name_cdp =]]](/cdp/cdp.md) asynchronously, in the background.
-Use it to make the system faster and prevent data loss.
+Use it to improve performance and prevent data loss.
 
 To enable this behavior, install and configure the [Ibexa Messenger package](background_tasks.md).
 Then, set the batch size that triggers asynchronous processing:
@@ -35,7 +35,7 @@ ibexa_cdp:
 When the number of [audience](https://content.raptorservices.com/help-center/how-to-build-audiences-in-the-customer-data-platform) changes coming from [Raptor](https://www.raptorservices.com/) exceeds this number, the changes are sent to the queue and processed in the background.
 Otherwise, they are processed synchronously.
 
-### Improved HTTP caching for Page Builder and Dashboard blocks
+### Improved HTTP caching for Page Builder and dashboard blocks
 
 You can now indicate which [query parameters](https://en.wikipedia.org/wiki/Query_string) must be used as keys when generating [HTTP cache](http_cache.md) for block requests.
 

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -10,6 +10,84 @@ month_change: false
 
 <div class="release-notes" markdown="1">
 
+[[% set version = 'v4.6.27' %]]
+[= release_note_entry_begin("Ibexa DXP " + version, '2026-02-03', ['Headless', 'Experience', 'Commerce']) =]]
+
+### Added support for Elasticsearch 8
+
+Elasticsearch 8 is now officially supported.
+If you're currently using Elasticsearch 7, which is [no longer maintained](https://www.elastic.co/support/eol), it's recommended to upgrade.
+See the [update instructions](update_from_4.6.md#elasticsearch-8-support) for more information.
+
+### Added asynchronous processing of data in Ibexa DXP
+
+You can now process requests from [[[= product_name_cdp =]]](/cdp/cdp.md) asynchronously, in the background.
+Use it to make the system faster and prevent data loss.
+
+To enable this behavior, install and configure the [Ibexa Messenger package](background_tasks.md).
+Then, set the batch size that triggers asynchronous processing:
+
+``` yaml
+ibexa_cdp:
+    bulk_async_threshold: 100
+```
+
+When the number of [audience](https://content.raptorservices.com/help-center/how-to-build-audiences-in-the-customer-data-platform) changes coming from [Raptor](https://www.raptorservices.com/) exceeds this number, the changes are sent to the queue and processed in the background.
+Otherwise, they are processed synchronously.
+
+### Improved HTTP caching for Page Builder and Dashboard blocks
+
+You can now indicate which [query parameters](https://en.wikipedia.org/wiki/Query_string) must be used as keys when generating [HTTP cache](http_cache.md) for block requests.
+
+This allows you to improve performance for blocks using the query parameters, for example, paginated blocks in the [dashboard](customize_dashboard.md).
+
+To set it up, use the new `cacheable_query_params` [block setting](page_blocks.md#block-configuration).
+Then, adjust your [layouts](render_page.md#configure-layout) and pass the parameters to Symfony's `controller function`([[= symfony_doc =]]/reference/twig_reference.html#controller) by using the new `ibexa_append_cacheable_query_params` Twig function.
+See the example below:
+
+``` html+twig
+{{ render_esi(controller('Ibexa\\Bundle\\FieldTypePage\\Controller\\BlockController::renderAction',
+    {
+        'locationId': locationId,
+        'contentId': contentInfo.id,
+        'blockId': block.id,
+        'versionNo': versionInfo.versionNo,
+        'languageCode': field.languageCode
+    },
+    ibexa_append_cacheable_query_params(block)
+)) }}
+```
+
+### Developer experience
+
+#### Easier debugging of Page Builder blocks
+
+In Symfony's `dev` environment, use the "Open profiler" action to quickly debug Page Builder's block rendering failures.
+
+![Quickly debug failing Page Builder blocks with "Open profiler" action](img/5.0_open_in_profiler.png "Quickly debug failing Page Builder blocks with 'Open profiler' action")
+
+#### Improved logging for Ibexa CDP
+
+You can configure the new `ibexa.cdp.webhook` Monolog channels to direct all CDP webhook logs to specific output for easier separation of logs.
+
+Example configuration:
+
+```yaml
+when@prod:
+    monolog:
+        handlers:
+            cdp_webhook:
+                type: stream
+                path: "%kernel.logs_dir%/cdp_webhook_%kernel.environment%.log"
+                level: debug
+                channels: [ 'ibexa.cdp.webhook' ]
+```
+
+### Full changelog
+
+[[% include 'snippets/release_46.md' %]]
+[[= release_note_entry_end() =]]
+
 [[% set version = 'v4.6.26' %]]
 
 [[= release_note_entry_begin("Integrated help " + version, '2025-12-10', ['Headless', 'Experience', 'Commerce', 'LTS Update', 'New feature']) =]]

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -4,7 +4,7 @@ title: Ibexa DXP v4.6 LTS
 month_change: false
 ---
 
-<!-- vale VariablesVersion = NO -->
+<!-- vale Ibexa.VariablesVersion = NO -->
 
 [[= release_notes_filters('Ibexa DXP v4.6 LTS', ['Headless', 'Experience', 'Commerce', 'LTS Update', 'New feature']) =]]
 
@@ -39,7 +39,7 @@ Otherwise, they are processed synchronously.
 
 You can now indicate which [query parameters](https://en.wikipedia.org/wiki/Query_string) must be used as keys when generating [HTTP cache](http_cache.md) for block requests.
 
-This allows you to improve performance for blocks using the query parameters, for example, paginated blocks in the [dashboard](customize_dashboard.md).
+This allows you to improve performance for blocks by utilizing HTTP cache more effectively, for example, for paginated blocks in the [dashboard](customize_dashboard.md).
 
 To set it up, use the new `cacheable_query_params` [block setting](page_blocks.md#block-configuration).
 
@@ -82,6 +82,8 @@ when@prod:
                 level: debug
                 channels: [ 'ibexa.cdp.webhook' ]
 ```
+
+#### 
 
 ### Full changelog
 

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -85,9 +85,18 @@ when@prod:
 
 #### Simplified creation of product types
 
-Use the new `ProductTypeCreateStruct::setNames()` method to set names, in multiple languages, of a product type during its creation.
+Use the new (`ProductTypeCreateStruct::setNames()`)[https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-Values-ProductType-ProductTypeCreateStruct.html#method_setNames] method to set names, in multiple languages, of a product type during its creation.
 
 See [creating product types](product_api.md#creating-product-types) for an example.
+
+#### PHP API
+
+The PHP API has been enhanced with the following classes and interfaces:
+
+- [`Ibexa\Contracts\Core\Search\Embedding\EmbeddingProviderExceptionInterface`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Search-Embedding-EmbeddingProviderExceptionInterface.html)
+- [`Ibexa\Contracts\Taxonomy\Embedding\Exception`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/namespaces/ibexa-contracts-taxonomy-embedding-exception.html)
+- [`Ibexa\Contracts\Taxonomy\Embedding\Exception\TaxonomyEmbeddingConfigurationException`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Taxonomy-Embedding-Exception-TaxonomyEmbeddingConfigurationException.html)
+
 
 ### Full changelog
 

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -85,7 +85,7 @@ when@prod:
 
 #### Simplified creation of product types
 
-Use the new (`ProductTypeCreateStruct::setNames()`)[https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-Values-ProductType-ProductTypeCreateStruct.html#method_setNames] method to set names, in multiple languages, of a product type during its creation.
+Use the new [`ProductTypeCreateStruct::setNames()`](https://doc.ibexa.co/en/4.6/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-Values-ProductType-ProductTypeCreateStruct.html#method_setNames) method to set names, in multiple languages, of a product type during its creation.
 
 See [creating product types](product_api.md#creating-product-types) for an example.
 
@@ -93,9 +93,8 @@ See [creating product types](product_api.md#creating-product-types) for an examp
 
 The PHP API has been enhanced with the following classes and interfaces:
 
-- [`Ibexa\Contracts\Core\Search\Embedding\EmbeddingProviderExceptionInterface`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Search-Embedding-EmbeddingProviderExceptionInterface.html)
-- [`Ibexa\Contracts\Taxonomy\Embedding\Exception`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/namespaces/ibexa-contracts-taxonomy-embedding-exception.html)
-- [`Ibexa\Contracts\Taxonomy\Embedding\Exception\TaxonomyEmbeddingConfigurationException`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Taxonomy-Embedding-Exception-TaxonomyEmbeddingConfigurationException.html)
+- [`Ibexa\Contracts\Core\Search\Embedding\EmbeddingProviderExceptionInterface`](https://doc.ibexa.co/en/4.6/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Search-Embedding-EmbeddingProviderExceptionInterface.html)
+- [`Ibexa\Contracts\Taxonomy\Embedding\Exception\TaxonomyEmbeddingConfigurationException`](https://doc.ibexa.co/en/4.6/api/php_api/php_api_reference/classes/Ibexa-Contracts-Taxonomy-Embedding-Exception-TaxonomyEmbeddingConfigurationException.html)
 
 
 ### Full changelog

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -83,7 +83,11 @@ when@prod:
                 channels: [ 'ibexa.cdp.webhook' ]
 ```
 
-#### 
+#### Simplified creation of product types
+
+Use the new `ProductTypeCreateStruct::setNames()` method to set names, in multiple languages, of a product type during its creation.
+
+See [creating product types](product_api.md#creating-product-types) for an example.
 
 ### Full changelog
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -989,7 +989,7 @@ extra:
   latest_tag_4_3: '4.3.5'
   latest_tag_4_4: '4.4.4'
   latest_tag_4_5: '4.5.7'
-  latest_tag_4_6: '4.6.26'
+  latest_tag_4_6: '4.6.27'
   latest_tag_5_0: '5.0.5'
 
   symfony_doc: 'https://symfony.com/doc/5.x'


### PR DESCRIPTION
To mention in the release notes:
- Adam Wójs: Added "Open profiler" action to block rendering error notification - https://github.com/ibexa/page-builder/pull/316 
- Konrad Oboza: IBX-10630: Added possibility to set product type names at the struct level - https://github.com/ibexa/product-catalog/pull/1433

New features:
- Elasticsearch 8
- IBX-9813: Cacheable request query parameters in blocks - https://github.com/ibexa/fieldtype-page/pull/184
- IBX-8713: Added ibexa/messenger support for large batches of data - https://github.com/ibexa/cdp/pull/40
- Made CDP webhook error responses more verbose - https://github.com/ibexa/cdp/pull/39