### PR TITLE
Speed up comment workflow

### DIFF
--- a/.github/workflows/preview_comment.yaml
+++ b/.github/workflows/preview_comment.yaml
@@ -22,8 +22,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
+
+            -   name: Fetch base branch for comparison
+                run: git fetch origin ${{ github.base_ref }} --depth=1
 
             -   name: Create comment for changed files
                 run: |


### PR DESCRIPTION
Target: 4.6, 5.0

As you can see, the full documentation repo checkout lasts 6 minutes (!), making the CI job very slow.

This PR contains a suggestion from copilot that says that a full repo checkout is not needed.

Example long run (before these changes):
https://github.com/ibexa/documentation-developer/actions/runs/21744310343/job/62726364711?pr=3046

After the changes: **8 seconds**
https://github.com/ibexa/documentation-developer/actions/runs/21745189974/job/62729230618?pr=3047