### PR TITLE
Removed Jira mentions from the doc

### DIFF
--- a/docs/content_management/field_types/field_type_reference/imagefield.md
+++ b/docs/content_management/field_types/field_type_reference/imagefield.md
@@ -25,15 +25,8 @@ The `value` property of an Image field returns an `Ibexa\Core\FieldType\Image\V
 |`uri`|string|`var/ezdemo_site/storage/images/0/8/4/1/1480-1-eng-GB/image.png`|The original image's URI.|
 |`imageId`|string|`240-1480`|A special image ID, used by REST.|
 |`inputUri`|string|`var/storage/images/test/199-2-eng-GB/image.png`|Input image file URI.|
-|`width`*|int|`null`|Original image width in pixels. For more details see Caution note below.|
-|`height`*|int|`null`|Original image height in pixels. For more details see Caution note below.|
-
-!!! caution
-
-    Properties marked with an asterisk are currently unsupported.
-    They're available but their value is always `null`.
-
-    Follow [EZP-27987](https://issues.ibexa.co/browse/EZP-27987) for future progress on this issue.
+|`width`|int|`null`|Original image width in pixels.|
+|`height`|int|`null`|Original image height in pixels.|
 
 ### Settings
 
@@ -46,8 +39,8 @@ They're `Ibexa\Contracts\Core\Variation\Values\ImageVariation` objects with th
 
 | Property       | Type     | Example  | Description|
 |----------------|----------|----------|------------|
-| `width`*       | int      | `null`    | The variation's width in pixels. For more details see Caution note below.|
-| `height`*      | int      | `null`    | The variation's height in pixels. For more details see Caution note below.|
+| `width`       | int      | `null`    | The variation's width in pixels.|
+| `height`      | int      | `null`    | The variation's height in pixels.|
 | `name`         | string   | `medium` | The variation's identifier, name of the image variation.|
 | `info`         | mixed    |n/a| Extra information about the image, depending on the image type, such as EXIF data. If there is no information, the `info` value is `null`.|
 | `fileSize`     | int      |`31010` |Size (in byte) of current variation.|
@@ -56,13 +49,6 @@ They're `Ibexa\Contracts\Core\Variation\Values\ImageVariation` objects with th
 | `dirPath`      | string   |`var/storage/images/test/199-2-eng-GB`|The path to the file.|
 | `uri`          | string   |`var/storage/images/test/199-2-eng-GB/apple.png`| The variation's URI. Complete path with a name of image file.|
 | `lastModified` | DateTime |``"2017-08-282 12:20 Europe/Berlin"``| When the variation was last modified.|
-
-!!! caution
-
-    Properties marked with an asterisk are currently unsupported.
-    They're available but their value is always `null`.
-
-    Follow [EZP-27987](https://issues.ibexa.co/browse/EZP-27987) for future progress on this issue.
 
 ### Field Definition options
 

--- a/docs/content_management/url_management/url_management.md
+++ b/docs/content_management/url_management/url_management.md
@@ -147,7 +147,6 @@ For each URL alias definition the history of changes is preserved, so that users
 !!! caution "Legacy storage engine limitation"
 
     The [Legacy storage engine](field_type_storage.md#legacy-storage-engine) doesn't archive URL aliases, which initially had the same name in multiple languages.
-    For more information, see [the Jira ticket](https://issues.ibexa.co/browse/EZP-31818).
 
 URL aliases aren't SiteAccess-aware. When creating an alias, you can select a SiteAccess to base it on.
 If the SiteAccess root path (configured in `content.tree_root.location_id`) is different than the default,

--- a/docs/infrastructure_and_maintenance/clustering/clustering_with_aws_s3.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering_with_aws_s3.md
@@ -93,4 +93,4 @@ Clear all caches and reload, and that's it.
 
 ## Migrate your existing binary data to S3
 
-You can [migrate existing binary data](clustering.md#migrating-to-a-cluster-setup) to S3 with the `php bin/console ibexa:io:migrate-files` command that was added in [EZP-25946](https://issues.ibexa.co/browse/EZP-25946).
+You can [migrate existing binary data](clustering.md#migrating-to-a-cluster-setup) to S3 with the `php bin/console ibexa:io:migrate-files` command.

--- a/docs/release_notes/ez_platform_v1.10.0.md
+++ b/docs/release_notes/ez_platform_v1.10.0.md
@@ -31,7 +31,7 @@ For more information, see [Bundle documentation](https://github.com/ezsystems/ez
 
 #### API: Simplified usage with translations
 
-As part of ongoing effort to simplify everyday aspects of the API for v2, [one notable part](https://issues.ibexa.co/browse/EZP-27428) that did not cause any BC was added to v1.10, enabling you to simplify how you deal with SiteAccess languages and translations.
+As part of ongoing effort to simplify everyday aspects of the API for v2, you can now simpler deal with SiteAccess languages and translations.
 
 ###### Example
 
@@ -64,8 +64,6 @@ $name = $content->getName();
 $value = $content->getFieldValue('body');
 ```
 
-*Further improvements such as getting the system to inject languages on API calls as shown in the first call above [are planned as part of the API epic](https://issues.ibexa.co/browse/EZP-26519)**, suggestions for further improvements are always welcome.*
-
 #### SOLR: Index time boosting & Improved Facets support
 
 One of the new features in 1.10 *(Solr Bundle 1.4)* is the possibility to [configure index time boosting](https://doc.ibexa.co/en/latest/guide/search/solr/#boost-configuration), which enables you to properly tune the search results to be relevant for your content architecture.
@@ -81,20 +79,19 @@ Starting with 1.10, a new command `ezplatform:io:migrate-files` has been added
 #### Miscellaneous
 
 -   Kernel: Don't store full User object in Sessions anymore, just User Id
-    -    [![](https://issues.ibexa.co/images/icons/issuetypes/bug.png)EZP-24852](https://issues.ibexa.co/browse/EZP-24852?src=confmacro) - Add UserReference support in Authentication/User providers Closed
 
 ### eZ Platform Enterprise Edition - Studio
 
--   Form deletion is managed more gracefully, including warnings and the option to download collected data before deleting a form ([EZEE-1400](https://issues.ibexa.co/browse/EZEE-1400))
+-   Form deletion is managed more gracefully, including warnings and the option to download collected data before deleting a form
 
 ![Deleting a form with data](delete-form.gif "Deleting a form with data")
 
--   [EZEE-1411](https://issues.ibexa.co/browse/EZEE-1411): Schedule block logic has been updated and improved.
+-   Schedule block logic has been updated and improved.
 
 ### eZ Platform Enterprise Edition - Studio Demo
 
--   [DEMO-102](https://issues.ibexa.co/browse/DEMO-102): [NovaeZSEOBundle](https://github.com/Novactive/NovaeZSEOBundle/) is now included in Studio Demo. NovaeZSEOBundle includes a new field type that lets you manage your SEO strategy in very advanced and powerful ways.
--   [DEMO-100](https://issues.ibexa.co/browse/DEMO-100): We also improved the way we provide personalization in the site using a profiling block and letting the end user manage their preferences by themselves. In this new version, the end user, once logged on the site, can access a page where they can define their content preferences. See [here](https://ez.no/Blog/Personalization-Does-Not-Have-to-Be-that-Complex) for more information.
+-   [NovaeZSEOBundle](https://github.com/Novactive/NovaeZSEOBundle/) is now included in Studio Demo. NovaeZSEOBundle includes a new field type that lets you manage your SEO strategy in very advanced and powerful ways.
+-   We also improved the way we provide personalization in the site using a profiling block and letting the end user manage their preferences by themselves. In this new version, the end user, once logged on the site, can access a page where they can define their content preferences. See [here](https://ez.no/Blog/Personalization-Does-Not-Have-to-Be-that-Complex) for more information.
 
 ## Full list of new features, improvements and bug fixes since v1.9.0
 

--- a/docs/release_notes/ez_platform_v1.11.0.md
+++ b/docs/release_notes/ez_platform_v1.11.0.md
@@ -12,13 +12,13 @@ If you're looking for the Long Term Support (LTS) release, see [https://ezplatfo
 
 #### Improved way of writing field type gateways
 
-[EZP-26885](https://issues.ibexa.co/browse/EZP-26885): you now have access to the Doctrine connection instead of
+You now have access to the Doctrine connection instead of
 the Zeta Components Database connection-like object which has been exposed to field types until now.
 The former way will be removed in a future major version.
 
 #### Content type limitation for Relation (single) field
 
-[EZP-24800](https://issues.ibexa.co/browse/EZP-24800): you can now specify a content type limitation for the Relation field,
+You can now specify a content type limitation for the Relation field,
 just like with the Relation List field. This enables you to limit what kind of relations Editors can select also on singular relation fields.
 
 ![Adding a new Relation (single) Field with allowed content types](relation_single_allowed_cts.png)
@@ -27,7 +27,7 @@ This has been made possible by initial legacy contribution from [@peterkeung](ht
 
 #### API endpoint for removing translations
 
-[EZP-27417](https://issues.ibexa.co/browse/EZP-27417) provides an API endpoint to remove a given translation completely from a content item.
+You can now use an API endpoint to remove a given translation completely from a content item.
 
 ### eZ Platform Enterprise Edition
 
@@ -53,8 +53,6 @@ instead of a new one each time a visitor arrives at the site.
 Fetching recommendations was also refactored to use the v2 of the Recommendation API.
 With this step the *clickrecommended* event now includes detailed feedback information about how recommendations were generated.
 This is very important for the analysis of statistics to measure the performance of recommendations.
-
-See [EZEE-1611](https://issues.ibexa.co/browse/EZEE-1611) for details.
 
 #### Official Enterprise Support for Legacy Bridge
 

--- a/docs/release_notes/ez_platform_v1.12.0.md
+++ b/docs/release_notes/ez_platform_v1.12.0.md
@@ -16,11 +16,9 @@ You also have new options to format your text using subscript, superscript, quot
 
 ![New text formatting options](oe-formatting-new-options.png)
 
-For more information, see [EZP-28030](https://issues.ibexa.co/browse/EZP-28030).
-
 #### Improved full text search capabilities
 
-For more information, see [EZP-26806](https://issues.ibexa.co/browse/EZP-26806).
+Added support for full-text search query syntax in Solr.
 
 #### Deleting translations
 
@@ -29,7 +27,6 @@ You can now remove translations from content item Versions through the PHP API.
 For more information, see the section on [deleting translations](https://doc.ibexa.co/en/latest/api/public_php_api_creating_content/#deleting-a-translation).
 
 You also have a new endpoint available for deleting a single Version.
-For more information, see [EZP-27864](https://issues.ibexa.co/browse/EZP-27864).
 
 #### Improved Security for password storage
 

--- a/docs/release_notes/ez_platform_v1.13.0_lts.md
+++ b/docs/release_notes/ez_platform_v1.13.0_lts.md
@@ -21,7 +21,7 @@ You can edit a link in the manager and it's updated automatically in all content
 
 ### Copying subtrees in the back office
 
-Following [EZP-27759](https://issues.ibexa.co/browse/EZP-27759) you can now copy a content item with all of its sub-items in the back office.
+You can now copy a content item with all of its sub-items in the back office.
 
 The maximum number of content items that can be copied this way can be set in configuration, see [Copy subtree limit](https://doc.ibexa.co/en/latest/guide/config_back_office/#copy-subtree-limit).
 
@@ -29,16 +29,16 @@ The maximum number of content items that can be copied this way can be set in co
 
 ### REST API improvements
 
-- [EZP-27752](https://issues.ibexa.co/browse/EZP-27752) adds a REST endpoint for deleting a translation from all versions of a content item.
-- [EZP-28253](https://issues.ibexa.co/browse/EZP-28253) adds a `fieldTypeIdentifier` field to the REST response for Version, which provides the field type.
+- Added a REST endpoint for deleting a translation from all versions of a content item.
+- Added s a `fieldTypeIdentifier` field to the REST response for Version, which provides the field type.
 
 ### ezplatform-http-cache extensibility
 
-[EZEE-1780](https://issues.ibexa.co/browse/EZEE-1780) makes ezplatform-http-cache extensible in third party bundles.
+Made ezplatform-http-cache extensible in third party bundles.
 
 ### Fastly
 
-Following [EZEE-1781](https://issues.ibexa.co/browse/EZEE-1781) you can [serve Varnish through Fastly](https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/http_cache/reverse_proxy/).
+You can [serve Varnish through Fastly](https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/http_cache/reverse_proxy/).
 
 ## Full list of new features, improvements and bug fixes since v1.12.0
 

--- a/docs/release_notes/ez_platform_v1.7.0_lts.md
+++ b/docs/release_notes/ez_platform_v1.7.0_lts.md
@@ -43,24 +43,24 @@ Community members are more than welcome to contribute to the translation process
 ##### Notable technical improvements:
 
 -   Search:
-    -   Solr Search Engine: Plugins, extend the Solr index with custom data on Content, Translation and Location block level ([EZP-26368](https://issues.ibexa.co/browse/EZP-26368))
+    -   Solr Search Engine: Plugins, extend the Solr index with custom data on Content, Translation and Location block level
         -   For when you need to extend the index with additional data not applicable for FieldType custom fields feature
         -   *[See Solr Bundle documentation for more info ](https://doc.ibexa.co/en/2.5/guide/search/solr/)*
-    -   Solr Search Engine: Support for FieldRelation on location search ([EZP-26756](http://jira.ez.no/browse/EZP-26756))
-    -   Legacy Search Engine: Improve word boundaries detection ([EZP-26499](http://jira.ez.no/browse/EZP-26499))
-    -   ezplatform:reindex added, a generic command for reindexing search index on the SiteAccess configured search engine ([EZP-26098](http://jira.ez.no/browse/EZP-26098))
+    -   Solr Search Engine: Support for FieldRelation on location search
+    -   Legacy Search Engine: Improve word boundaries detection
+    -   ezplatform:reindex added, a generic command for reindexing search index on the SiteAccess configured search engine
 -   Extensibility:
-    -    QueryType's now support using alias when being used as service so you can define several services with same  QueryType class ([EZP-26628](http://jira.ez.no/browse/EZP-26628))
+    -    QueryType's now support using alias when being used as service so you can define several services with same  QueryType class
         -    Example: Generic location child QueryType being reused several times for specific services for article or blog post listings 
 -   API:
-    -   New method:` Location->getSortClauses()` to get Sort Clauses based on what kind of sorting has been set on the Location ([EZP-26528](http://jira.ez.no/browse/EZP-26528))
-    -   Add Content Version archives limit by configuration & enforce on publish ([EZP-23281](http://jira.ez.no/browse/EZP-23281))
+    -   New method:` Location->getSortClauses()` to get Sort Clauses based on what kind of sorting has been set on the Location
+    -   Add Content Version archives limit by configuration & enforce on publish
 -   Debug:
-    -   ez-support-tools:dump-info command now able to dump system info in several formats, and default is now json ([EZP-26549](http://jira.ez.no/browse/EZP-26549))
+    -   ez-support-tools:dump-info command now able to dump system info in several formats, and default is now json
         -   *Making it more useful for attaching system info when reporting issues*
-    -   Add SiteAccess collector to debug toolbar ([EZP-26375](http://jira.ez.no/browse/EZP-26375))
-    -   Make IO exceptions more user friendly ([EZP-26683](http://jira.ez.no/browse/EZP-26683))
-    -   Make it possible to retrieve original exception when repo-&gt;commit() fails ([EZP-26407](http://jira.ez.no/browse/EZP-26407))
+    -   Add SiteAccess collector to debug toolbar
+    -   Make IO exceptions more user friendly
+    -   Make it possible to retrieve original exception when repo-&gt;commit() fails
 
  
 

--- a/docs/release_notes/ez_platform_v1.9.0.md
+++ b/docs/release_notes/ez_platform_v1.9.0.md
@@ -46,7 +46,7 @@ To reflect this change, the content tree button has been renamed **Content brows
 
 ### eZ Platform Enterprise Edition - Studio
 
--   It's now possible to configure landing page blocks used by the landing page editor in a simpler way. The configuration is done in a YAML file (see <https://issues.ibexa.co/browse/EZEE-1421>)
+-   It's now possible to configure landing page blocks used by the landing page editor in a simpler way. The configuration is done in a YAML file
 -   *..lots of other bug fixes and smaller improvements..*
 
 ### eZ Platform Enterprise Edition - Studio Demo
@@ -59,8 +59,8 @@ The eZ Enterprise Demo now uses the [Netgen Tags bundle](https://github.com/netg
 
 #### Miscellaneous
 
--   [DEMO-94](https://issues.ibexa.co/browse/DEMO-94): As an editor, I want to personalize content based on user persona
--   [DEMO-87](https://issues.ibexa.co/browse/DEMO-87): As an editor, I want to embed a video
+-   As an editor, I want to personalize content based on user persona
+-   As an editor, I want to embed a video
 
 ## Full list of new features, improvements and bug fixes since v1.8.0
 

--- a/docs/release_notes/ez_platform_v2.4.md
+++ b/docs/release_notes/ez_platform_v2.4.md
@@ -175,7 +175,7 @@ The biggest benefit of this feature is saving load time on complex landing pages
 
     ### Update eZ Enterprise v2.4 to v2.4.2
 
-    This release brings [full support for Map\Host matcher](https://issues.ibexa.co/browse/EZEE-2572) when SiteAccesses are configured for different domains.
+    This release brings full support for Map\Host matcher when SiteAccesses are configured for different domains.
 
     Token-based authentication (based on JSON Web Token specification) replaced cookie-based authentication that did not work with SiteAccesses configured for a different domains in the Page Builder.
     Authentication mechanizm is enabled by default in v2.4.2, however, the following steps are required during upgrade from v2.4 to v2.4.2+ Enterprise installation:

--- a/docs/search/search_engines/solr_search_engine/install_solr.md
+++ b/docs/search/search_engines/solr_search_engine/install_solr.md
@@ -382,4 +382,3 @@ Here are the most common issues you may encounter:
       to balance performance and load on your Solr instance against needs you have for "[NRT](https://solr.apache.org/guide/7_7/near-real-time-searching.html)".
 - Running out of memory during indexing
     - In general make sure to run indexing using the prod environment to avoid debuggers and loggers from filling up memory.
-    - Flysystem: You can find further info in https://issues.ibexa.co/browse/EZP-25325.

--- a/docs/update_and_migration/from_3.3/update_from_3.3.md
+++ b/docs/update_and_migration/from_3.3/update_from_3.3.md
@@ -491,7 +491,7 @@ There are no additional update steps to execute.
 
 ##### Remove duplicated entries in `ezcontentobject_attribute` table
 
-This release comes with a command to clean up duplicated entries in the `ezcontentobject_attribute` table, which were created due to an issue described in [IBX-8562](https://issues.ibexa.co/browse/IBX-8562).
+This release comes with a command to clean up duplicated entries in the `ezcontentobject_attribute` table, which were created due to an issue related to previewing content in different languages.
 
 If you're affected, remove the duplicated entries by running the following command:
 ``` bash

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -167,7 +167,7 @@ If the new bundle `ibexa/core-search` has not been added by the recipes, enable 
 
 ## v4.6.13
 
-This release comes with a command to clean up duplicated entries in the `ezcontentobject_attribute` table, which were created due to an issue described in [IBX-8562](https://issues.ibexa.co/browse/IBX-8562).
+This release comes with a command to clean up duplicated entries in the `ezcontentobject_attribute` table, which were created due to an issue related to previewing content in different languages.
 
 If you're affected, remove the duplicated entries by running the following command:
 ``` bash

--- a/docs/update_and_migration/migrate_to_ibexa_dxp/common_issues.md
+++ b/docs/update_and_migration/migrate_to_ibexa_dxp/common_issues.md
@@ -59,8 +59,6 @@ The command can be executed in two modes:
 - list / dry-run - prints table with all corrupted Relations that are deleted (to be executed first)
 - fix - executes clean up
 
-You can read more about this issue here: [EZP-27254](https://issues.ibexa.co/browse/EZP-27254)
-
 ## Always available flag set on all fields
 
 Always available flag is set on all fields, instead of only on fields in the main language.
@@ -73,8 +71,6 @@ php bin/console ezpublish:update:legacy_storage_fix_fields_always_available_flag
 
 Only affected fields are processed by the cleanup command.
 
-You can read more about this issue here: [EZP-24882](https://issues.ibexa.co/browse/EZP-24882)
-
 ## Listing sub-content
 
 It's possible that after upgrade `sort_key_string` is left empty.
@@ -86,5 +82,3 @@ Execute the following command from the installation root directory:
 ```
 php bin/console ezpublish:update:legacy_storage_update_sort_keys
 ```
-
-You can read more about this issue here: [EZP-23924](https://issues.ibexa.co/browse/EZP-23924)

--- a/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
+++ b/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
@@ -447,8 +447,6 @@ When the conversion tool detects links with no reference it issues a warning and
 
 The `<literal>` tag isn't yet supported in eZ Platform.
 
-For more information, see [EZP-29328](https://issues.ibexa.co/browse/EZP-29328) and [EZP-29027](https://issues.ibexa.co/browse/EZP-29027).
-
 When you're ready to migrate your eZ Publish XmlText content to the eZ Platform RichText format and start using pure eZ Platform setup, start the conversion script without the `--dry-run` option. Execute the following from &lt;new-ez-root&gt;:
 
 `php -d memory_limit=1536M bin/console ezxmltext:convert-to-richtext --export-dir=ezxmltext-export --export-dir-filter=notice,warning,error --concurrency 4 -v`


### PR DESCRIPTION
Target: 4.6, 5.0

As suggested on Slack.

Looking at **https://issues.ibexa.co/browse/EZP-27987** , I think the issue was solved in https://issues.ibexa.co/browse/EZP-25487 - and we can remove this mention?
