### PR TITLE
CartCommand.php: Fix `getTotalCount` desc

### DIFF
--- a/code_samples/api/commerce/src/Command/CartCommand.php
+++ b/code_samples/api/commerce/src/Command/CartCommand.php
@@ -54,7 +54,7 @@ final class CartCommand extends Command
         $cartsList = $this->cartService->findCarts($cartQuery);
 
         $cartsList->getCarts(); // array of CartInterface objects
-        $cartsList->getTotalCount(); // number of matching carts regardless limit
+        $cartsList->getTotalCount(); // number of matching carts regardless of the limit
 
         foreach ($cartsList as $cart) {
             $output->writeln($cart->getIdentifier() . ': ' . $cart->getName());

--- a/code_samples/api/commerce/src/Command/CartCommand.php
+++ b/code_samples/api/commerce/src/Command/CartCommand.php
@@ -54,7 +54,7 @@ final class CartCommand extends Command
         $cartsList = $this->cartService->findCarts($cartQuery);
 
         $cartsList->getCarts(); // array of CartInterface objects
-        $cartsList->getTotalCount(); // number of returned carts
+        $cartsList->getTotalCount(); // number of matching carts regardless limit
 
         foreach ($cartsList as $cart) {
             $output->writeln($cart->getIdentifier() . ': ' . $cart->getName());


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | 5.0, 4.6
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Fix `getTotalCount()` description comment.
If the user own 25 carts, the limited result slice contains 20 carts, but `getTotalCount()` returns `25`, not `20`

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
