### PR TITLE
Documented adding custom fields to CDP export

### DIFF
--- a/code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php
+++ b/code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php
@@ -34,23 +34,20 @@ final class DateOfBirthUserItemProcessor extends AbstractUserItemProcessor
             throw new InvalidArgumentException('$userContent', 'User content does not contain user field');
         }
 
+        $dateOfBirth = '';
         $dateOfBirthField = $userContent->getField($this->dateOfBirthFieldIdentifier);
 
-        if (null === $dateOfBirthField || !$dateOfBirthField->value instanceof DateValue) {
-            return $processedItemData;
-        }
-
-        /** @var \Ibexa\Core\FieldType\Date\Value $dateValue */
-        $dateValue = $dateOfBirthField->value;
-
-        if (null === $dateValue->date) {
-            return $processedItemData;
+        if ($dateOfBirthField !== null
+            && $dateOfBirthField->value instanceof DateValue
+            && $dateOfBirthField->value->date !== null
+        ) {
+            $dateOfBirth = $dateOfBirthField->value->date->format('Y-m-d');
         }
 
         return array_merge(
             $processedItemData,
             [
-                'date_of_birth' => $dateValue->date->format('Y-m-d'),
+                'date_of_birth' => $dateOfBirth,
             ]
         );
     }

--- a/code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php
+++ b/code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace App\Export\User;
+
+use Ibexa\Contracts\Cdp\Export\User\AbstractUserItemProcessor;
+use Ibexa\Contracts\Core\Repository\Values\Content\Content;
+use Ibexa\Core\Base\Exceptions\InvalidArgumentException;
+use Ibexa\Core\FieldType\Date\Value as DateValue;
+
+final class DateOfBirthUserItemProcessor extends AbstractUserItemProcessor
+{
+    private string $dateOfBirthFieldIdentifier;
+
+    public function __construct(
+        string $dateOfBirthFieldIdentifier,
+        string $userFieldTypeIdentifier
+    ) {
+        $this->dateOfBirthFieldIdentifier = $dateOfBirthFieldIdentifier;
+
+        parent::__construct($userFieldTypeIdentifier);
+    }
+
+    protected function doProcess(array $processedItemData, Content $userContent): array
+    {
+        $userField = $this->getUserField($userContent);
+
+        if (null === $userField) {
+            throw new InvalidArgumentException('$userContent', 'User content does not contain user field');
+        }
+
+        $dateOfBirthField = $userContent->getField($this->dateOfBirthFieldIdentifier);
+
+        if (null === $dateOfBirthField || !$dateOfBirthField->value instanceof DateValue) {
+            return $processedItemData;
+        }
+
+        /** @var \Ibexa\Core\FieldType\Date\Value $dateValue */
+        $dateValue = $dateOfBirthField->value;
+
+        if (null === $dateValue->date) {
+            return $processedItemData;
+        }
+
+        return array_merge(
+            $processedItemData,
+            [
+                'date_of_birth' => $dateValue->date->format('Y-m-d'),
+            ]
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
         "ibexa/messenger": "~4.6.x-dev",
         "ibexa/collaboration": "~4.6.x-dev",
         "ibexa/share": "~4.6.x-dev",
-        "ibexa/phpstan": "~4.6.-dev"
+        "ibexa/phpstan": "~4.6.-dev",
+        "ibexa/cdp": "~4.6.x-dev"
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",

--- a/docs/cdp/cdp_activation/cdp_data_export.md
+++ b/docs/cdp/cdp_activation/cdp_data_export.md
@@ -45,6 +45,9 @@ There are two versions of this command `--draft/--no-draft`.
 The first one is used to send the test user data to the Data Manager.
 If it passes a validation test in the **Activation** section, use the latter one to send a full version.
 
+You can extend exported user data with custom fields from your user content, such as date of birth, preferences, or other profile information.
+For more information, see [Data customization](../cdp_data_customization.md#export-additional-user-data).
+
 Next, go back to [[= product_name_cdp =]] and select **Validate & download**.
 If the file passes, you can see a confirmation message.
 Now, you can go to the **File mapping** section.
@@ -62,6 +65,9 @@ If you make any alterations, select the **Parse File** to generate columns with 
 
 In the **Transform & Map** section you transform data and map it to a schema.
 At this point, you can map **email** to **email** and **id** to **integer**  fields to get custom columns.
+
+If you have [extended user data export with custom fields](cdp_data_customization.md#export-additional-user-data), those fields appear as additional columns in this section.
+Make sure to add them to your schema in Raptor so they can be used for segmentation and personalization.
 
 Next, select **Create schema based on the downloaded columns**.
 It moves you to Schema Creator.

--- a/docs/cdp/cdp_data_customization.md
+++ b/docs/cdp/cdp_data_customization.md
@@ -5,14 +5,14 @@ edition: experience
 
 # Data customization
 ​
-You can customize content and product data exported to CDP and you can control what field type information you want to export.
+You can customize user, content, and product data exported to CDP and you can control what field type information you want to export.
 By default, custom field types have basic export functionality.
 It casts their `Value` object to string, thanks to `\Stringable` implementation.
 ​
 ## Export additional user data
 
-You can extend user data exported to CDP by attaching custom information from user content fields, such as date of birth, preferences, or custom profile data.
-Use it for for advanced customer segmentation and personalization in marketing campaigns.
+You can extend user data exported to CDP by attaching custom information, for example user content fields or user preferences.
+Use it for advanced customer segmentation and personalization in marketing campaigns.
 
 To add custom data to user exports, create a class that extends [`\Ibexa\Contracts\Cdp\Export\User\AbstractUserItemProcessor`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Cdp-Export-User-AbstractUserItemProcessor.html) and implement the `doProcess()` method.
 The base class handles user field validation and provides helper methods for working with user content.

--- a/docs/cdp/cdp_data_customization.md
+++ b/docs/cdp/cdp_data_customization.md
@@ -36,7 +36,7 @@ Register your processor as a Symfony service and tag it with `ibexa.cdp.export.u
 
 The `priority` parameter controls the order of execution when multiple processors are registered.
 Higher priority values run first.
-Your custom processor merges data with `$processedItemData` from previous processors, allowing you to chain multiple processors together.
+Your custom processor can modify the data returned from the previous processors, for example by adding new entries or modifying the existing ones.
 
 The exported user data includes your custom fields:
 

--- a/docs/cdp/cdp_data_customization.md
+++ b/docs/cdp/cdp_data_customization.md
@@ -9,10 +9,51 @@ You can customize content and product data exported to CDP and you can control w
 By default, custom field types have basic export functionality.
 It casts their `Value` object to string, thanks to `\Stringable` implementation.
 ​
+## Export additional user data
+
+You can extend user data exported to CDP by attaching custom information from user content fields, such as date of birth, preferences, or custom profile data.
+Use it for for advanced customer segmentation and personalization in marketing campaigns.
+
+To add custom data to user exports, create a class that extends [`\Ibexa\Contracts\Cdp\Export\User\AbstractUserItemProcessor`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Cdp-Export-User-AbstractUserItemProcessor.html) and implement the `doProcess()` method.
+The base class handles user field validation and provides helper methods for working with user content.
+
+The following example adds a custom date of birth field to the exported data:
+
+``` php
+[[= include_file('code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php') =]]
+```
+
+Register your processor as a Symfony service and tag it with `ibexa.cdp.export.user.item_processor`:
+
+``` yaml
+    App\Export\User\DateOfBirthUserItemProcessor:
+        parent: Ibexa\Contracts\Cdp\Export\User\AbstractUserItemProcessor
+        arguments:
+            $dateOfBirthFieldIdentifier: 'date_of_birth'
+        tags:
+            - { name: 'ibexa.cdp.export.user.item_processor', priority: 100 }
+```
+
+The `priority` parameter controls the order of execution when multiple processors are registered.
+Higher priority values run first.
+Your custom processor merges data with `$processedItemData` from previous processors, allowing you to chain multiple processors together.
+
+The exported user data includes your custom fields:
+
+```json
+{
+    "date_of_birth": "2000-01-01",
+    "id": 1,
+    "login": "example",
+    "email": "example@example.org",
+    "name": "John Doe",
+}
+```
+
 ## Export field types
 ​
 Field types are exported with metadata, for example, ID, field definition name, type, or value.
-You can also provide your own `\Ibexa\Contracts\Cdp\Export\Content\FieldProcessorInterface` instance to extend metadata.
+You can also provide your own [`\Ibexa\Contracts\Cdp\Export\Content\FieldProcessorInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Cdp-Export-Content-FieldProcessorInterface.html) instance to extend metadata.
 The provided implementation has to be defined as a service and tagged with `ibexa.cdp.export.content.field_processor`.
 Additionally, you can specify `priority` to override the default behavior.
 All system Field Processors use `-100` priority, and any higher priority value overrides them.
@@ -47,7 +88,7 @@ You can only use scalar values.
 ​
 You can provide your own CDP export functionality by using one of the system Field Processors:
 
-#### `\Ibexa\Cdp\Export\Content\FieldProcessor\SkippingFieldProcessor`.
+#### `\Ibexa\Cdp\Export\Content\FieldProcessor\SkippingFieldProcessor`
 ​
 It results in the field type being excluded from the exported payload.
 To avoid adding the field type data to the payload, register a new service as follows:
@@ -64,7 +105,7 @@ custom_fieldtype.cdp.export.field_processor:
 ​
 ## Export field type values
 ​
-To customize export of field type values, provide your own `\Ibexa\Contracts\Cdp\Export\Content\FieldValueProcessorInterface` instance.
+To customize export of field type values, provide your own [`\Ibexa\Contracts\Cdp\Export\Content\FieldValueProcessorInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Cdp-Export-Content-FieldValueProcessorInterface.html) instance.
 New implementation has to be registered as a service manually or by using autoconfiguration.
 The service has to use the tag `ibexa.cdp.export.content.field_value_processor`.
 You can also provide `priority` property to override other Field Value Processors.
@@ -85,7 +126,7 @@ This Processor is a default one, as long as no other Processor with higher prior
 ​
 #### `\Ibexa\Cdp\Export\Content\FieldValueProcessor\JsonHashFieldValueProcessor`
 ​
-This Processor generates JSON data from hash representation of the field type (it uses `\Ibexa\Contracts\Core\FieldType\FieldType::toHash` method).
+This Processor generates JSON data from hash representation of the field type (it uses [`\Ibexa\Contracts\Core\FieldType\FieldType::toHash`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-FieldType-FieldType.html#method_toHash) method).
 
 !!! caution
 


### PR DESCRIPTION
Target: 4.6, 5.0

The doc is missing the extension points introduced in https://github.com/ibexa/corporate-account/pull/174 and https://github.com/ibexa/cdp/pull/11

This PR focuses on showing how to add custom fields to user data export, as this is something that has been raised by partners.

Tested locally:
```
~/Desktop/Sites/4.6 main !5028 ?140 ❯ php bin/console ibexa:cdp:stream-user-data -vv --draft --user-content-type user                                                                 24.4.0 14:32:09
Data will be streamed as a draft
Stream ID: 00000000-00000000-00000000-00000000
array(2) {
  [0]=>
  array(6) {
    ["date_of_birth"]=>
    string(0) ""
    ["companies"]=>
    array(0) {
    }
    ["id"]=>
    int(10)
    ["login"]=>
    string(9) "anonymous"
    ["email"]=>
    string(22) "anonymous@link.invalid"
    ["name"]=>
    string(14) "Anonymous User"
  }
  [1]=>
  array(6) {
    ["date_of_birth"]=>
    string(10) "2026-02-17"
    ["companies"]=>
    array(0) {
    }
    ["id"]=>
    int(14)
    ["login"]=>
    string(5) "admin"
    ["email"]=>
    string(18) "admin@link.invalid"
    ["name"]=>
    string(18) "Administrator User"
  }
}
```
