### PR TITLE
Added option to remove indent from code samples

### DIFF
--- a/docs/administration/recent_activity/recent_activity.md
+++ b/docs/administration/recent_activity/recent_activity.md
@@ -190,7 +190,7 @@ In the following example, several actions are logged into one context group, eve
     - `complete`
 
 ``` php
-[[= include_file('code_samples/recent_activity/src/Command/ActivityLogContextTestCommand.php', 46, 66) =]]
+[[= include_file('code_samples/recent_activity/src/Command/ActivityLogContextTestCommand.php', 46, 66, remove_indent=True) =]]
 ```
 
 Context groups can't be nested.

--- a/docs/ai_actions/extend_ai_actions.md
+++ b/docs/ai_actions/extend_ai_actions.md
@@ -14,7 +14,7 @@ For example, you can create a handler that connects to a translation model and u
 You can execute AI Actions by using the [ActionServiceInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionServiceInterface.html) service, as in the following example:
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/Command/AddMissingAltTextCommand.php', 86, 105) =]]
+[[= include_file('code_samples/ai_actions/src/Command/AddMissingAltTextCommand.php', 86, 105, remove_indent=True) =]]
 ```
 
 The `GenerateAltTextAction` is a built-in action that implements the [ActionInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionInterface.html), takes an [Image](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Action-DataType-Image.html) as an input, and generates the alternative text in the response.
@@ -77,7 +77,7 @@ See [Action Configuration Search Criteria reference](action_configuration_criter
 The following example creates a new Action Configuration:
 
 ``` php hl_lines="3 17"
-[[= include_file('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 46, 63) =]]
+[[= include_file('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 46, 63, remove_indent=True) =]]
 ```
 
 Actions Configurations are tied to a specific Action Type and are translatable.
@@ -88,7 +88,7 @@ Reuse existing Action Configurations to simplify the execution of AI Actions.
 You can pass one directly to the `ActionServiceInterface::execute()` method:
 
 ``` php hl_lines="7-8"
-[[= include_file('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 64, 72) =]]
+[[= include_file('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 64, 72, remove_indent=True) =]]
 ```
 
 The passed Action Configuration is only taken into account if the Action Context was not passed to the Action directly using the [ActionInterface::setActionContext()](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionInterface.html#method_hasActionContext) method.

--- a/main.py
+++ b/main.py
@@ -29,11 +29,12 @@ def define_env(env):
     """
 
     @env.macro
-    def include_file(filename, start_line=0, end_line=None, glue=''):
+    def include_file(filename, start_line=0, end_line=None, glue='', remove_indent=False):
         """
         Include a file,
         optionally indicating start_line and end_line (start counting from 0)
         optionally set a glue string to lead every string except the first one (can be used for indent)
+        optionally remove common leading whitespace from all lines (remove_indent=True)
         The path is relative to the top directory of the documentation
         project.
         """
@@ -41,6 +42,13 @@ def define_env(env):
         with open(full_filename, 'r') as f:
             lines = f.readlines()
         line_range = lines[start_line:end_line]
+
+        if remove_indent:
+            non_empty = [l for l in line_range if l.strip()]
+            if non_empty:
+                indent = min(len(l) - len(l.lstrip()) for l in non_empty)
+                line_range = [l[indent:] if l.strip() else l for l in line_range]
+
         return glue.join(line_range)
 
     @env.macro


### PR DESCRIPTION
Target: 4.6, 5.0

Improving readability of the code samples by reducing their indent where it's not meaningful.

It should not be enabled by default, because it can result in wrong indent when a code sample is composed of multiple include_file calls (the indentation would break then).

I've decided to keep the indent for YAML services - it might make things easier when copy/pasting (assuming someone is using 4-spaces indent)

Before:

<img width="1010" height="533" alt="Screenshot 2026-03-11 at 11 38 57" src="https://github.com/user-attachments/assets/d8ecb28e-711d-4d54-b58d-3e51750e9543" />


After:

<img width="1066" height="530" alt="Screenshot 2026-03-11 at 11 39 03" src="https://github.com/user-attachments/assets/9e38c69f-2c16-4377-a36b-a8274e5e3c2c" />

