### PR TITLE
Fix collaboration deptrac errors

### DIFF
--- a/code_samples/collaboration/src/Collaboration/Cart/CartResolverDecorator.php
+++ b/code_samples/collaboration/src/Collaboration/Cart/CartResolverDecorator.php
@@ -6,6 +6,7 @@ use Ibexa\Contracts\Cart\CartResolverInterface;
 use Ibexa\Contracts\Cart\Value\CartInterface;
 use Ibexa\Contracts\Collaboration\SessionServiceInterface;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
+use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
 use Ibexa\Contracts\Core\Repository\Values\User\User;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -39,7 +40,7 @@ final readonly class CartResolverDecorator implements CartResolverInterface
             }
 
             return $session->getCart();
-        } catch (NotFoundException|\Ibexa\ProductCatalog\Exception\UnauthorizedException) {
+        } catch (NotFoundException|UnauthorizedException) {
             return null;
         }
     }

--- a/deptrac.baseline.yaml
+++ b/deptrac.baseline.yaml
@@ -12,6 +12,30 @@ deptrac:
       - Ibexa\Checkout\Value\Workflow\Workflow
     App\Checkout\Workflow\Strategy\NewWorkflowConditionalStep:
       - Ibexa\Checkout\Value\Workflow\Workflow
+    App\Collaboration\Cart\Mapper\CartProxyMapper:
+      - Ibexa\Core\Repository\ProxyFactory\ProxyGeneratorInterface
+    App\Collaboration\Cart\Mapper\CartSessionDomainMapper:
+      - Ibexa\Collaboration\Mapper\Domain\ParticipantCollectionDomainMapperInterface
+      - Ibexa\Collaboration\Mapper\Domain\SessionDomainMapperInterface
+      - Ibexa\Collaboration\Mapper\Domain\UserProxyDomainMapperInterface
+      - Ibexa\Collaboration\Persistence\Values\AbstractSession
+    App\Collaboration\Cart\Mapper\CartSessionPersistenceMapper:
+      - Ibexa\Collaboration\Persistence\Values\AbstractSessionCreateStruct
+      - Ibexa\Collaboration\Persistence\Values\AbstractSessionUpdateStruct
+      - Ibexa\Collaboration\Mapper\Persistence\SessionPersistenceMapperInterface
+    App\Collaboration\Cart\Persistence\Gateway\DatabaseGateway:
+      - Ibexa\Collaboration\Persistence\Session\Inner\GatewayInterface
+      - Ibexa\Collaboration\Persistence\Values\AbstractSessionCreateStruct
+      - Ibexa\Collaboration\Persistence\Values\AbstractSessionUpdateStruct
+    App\Collaboration\Cart\Persistence\Mapper:
+      - Ibexa\Collaboration\Persistence\Values\AbstractSession
+      - Ibexa\Collaboration\Persistence\Session\Inner\MapperInterface
+    App\Collaboration\Cart\Persistence\Values\CartSession:
+      - Ibexa\Collaboration\Persistence\Values\AbstractSession
+    App\Collaboration\Cart\Persistence\Values\CartSessionCreateStruct:
+      - Ibexa\Collaboration\Persistence\Values\AbstractSessionCreateStruct
+    App\Collaboration\Cart\Persistence\Values\CartSessionUpdateStruct:
+      - Ibexa\Collaboration\Persistence\Values\AbstractSessionUpdateStruct
     App\Command\AddMissingAltTextCommand:
       - Ibexa\Core\FieldType\Image\Value
       - Ibexa\Core\IO\IOBinarydataHandler


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Remove `DependsOnDisallowedLayer` deptrac errors in collaboration example.
- Move from `Ibexa\ProductCatalog\Exception\UnauthorizedException` to more generic parent [`Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Exceptions-UnauthorizedException.html)
- Ignore `Ibexa\Collaboration` classes having no `Ibexa\Contracts` parent

Errors observed first in https://github.com/ibexa/documentation-developer/actions/runs/23237413770/job/67544741044?pr=3090
They might have been already there in #3055 but I didn't pay attention to it, sorry.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
