### PR TITLE
4.6 Requirements: PHP 8.1 End of Life

### DIFF
--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -135,9 +135,9 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
     - 8.4
     - 8.3
     - 8.2
-    - 8.1
-    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
-    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
+    - 8.1 (PHP 8.1 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
 
 === "[[= product_name =]] v3.3"
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 4.6 (but all branches)
| Edition       | All

[PHP 8.1 as reached End of Life on December 2025](https://www.php.net/eol.php).


#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
