### PR TITLE
5.0 tested PHP versions

### DIFF
--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -47,11 +47,11 @@ jobs:
             - name: Run PHPStan analysis
               run: composer phpstan
 
-            - name: Deptrac
+            - name: Run Deptrac analysis
               run: composer deptrac
 
-            - name: Run rector
-              run: vendor/bin/rector process --dry-run --ansi
+            - name: Run Rector check
+              run: composer check-rector
 
     code-samples-inclusion-check:
         name: Check code samples inclusion

--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -10,6 +10,7 @@ jobs:
         strategy:
             matrix:
                 php:
+                    - "8.4"
                     - "8.3"
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -10,8 +10,8 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - "8.4"
-                    - "8.3"
+                    - "8.4" # Upper supported version
+                    - "8.3" # Lower supported version
         steps:
             - uses: actions/checkout@v4
 

--- a/code_samples/back_office/search/src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php
+++ b/code_samples/back_office/search/src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php
@@ -16,7 +16,7 @@ class ProductSuggestionNormalizer implements
     /**
      * @return array<string, string|null>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         /** @var \App\Search\Model\Suggestion\ProductSuggestion $object */
         return [

--- a/code_samples/data_migration/src/Migrations/Action/AssignSectionDenormalizer.php
+++ b/code_samples/data_migration/src/Migrations/Action/AssignSectionDenormalizer.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 
 final class AssignSectionDenormalizer extends AbstractActionDenormalizer
 {
-    protected function supportsActionName(string $actionName, string $format = null): bool
+    protected function supportsActionName(string $actionName, ?string $format = null): bool
     {
         return $actionName === AssignSection::TYPE;
     }
@@ -22,7 +22,7 @@ final class AssignSectionDenormalizer extends AbstractActionDenormalizer
      *
      * @return \App\Migrations\Action\AssignSection
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): AssignSection
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): AssignSection
     {
         Assert::keyExists($data, 'value');
 

--- a/code_samples/data_migration/src/Migrations/Step/ReplaceNameStepNormalizer.php
+++ b/code_samples/data_migration/src/Migrations/Step/ReplaceNameStepNormalizer.php
@@ -14,7 +14,7 @@ final class ReplaceNameStepNormalizer extends AbstractStepNormalizer
 {
     protected function normalizeStep(
         StepInterface $object,
-        string $format = null,
+        ?string $format = null,
         array $context = []
     ): array {
         assert($object instanceof ReplaceNameStep);

--- a/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueDenormalizer.php
+++ b/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueDenormalizer.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class ValueDenormalizer implements DenormalizerInterface
 {
-    public function denormalize($data, string $class, string $format = null, array $context = []): mixed
+    public function denormalize($data, string $class, ?string $format = null, array $context = []): mixed
     {
         if (isset($data['x']) && isset($data['y'])) {
             // Support for old format

--- a/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueNormalizer.php
+++ b/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueNormalizer.php
@@ -11,7 +11,7 @@ final class ValueNormalizer implements NormalizerInterface
     /**
      * @return array<?float, ?float>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         return [
             $object->getX(),

--- a/composer.json
+++ b/composer.json
@@ -88,13 +88,15 @@
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",
         "check-cs": "@fix-cs --dry-run",
         "phpstan": "phpstan analyse",
-        "deptrac": "deptrac analyse"
+        "deptrac": "deptrac analyse",
+        "check-rector": "rector process --dry-run --ansi"
     },
     "scripts-descriptions": {
         "fix-cs": "Automatically fixes code style in all files",
         "check-cs": "Run code style checker for all files",
         "phpstan": "Run static code analysis",
-        "deptrac": "Run Deptrac architecture testing"
+        "deptrac": "Run Deptrac architecture testing",
+        "check-rector": "Check for code refactoring opportunities"
     },
     "config": {
         "allow-plugins": false

--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -135,9 +135,9 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
     - 8.4
     - 8.3
     - 8.2
-    - 8.1
-    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
-    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
+    - 8.1 (PHP 8.1 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
 
 === "[[= product_name =]] v3.3"
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 5.0
| Edition       | N/A

Test with upper and lower versions of PHP

- Add PHP 8.4 to `code-samples-validation` CI test suite
- Fixes to satisfy both PHP 8.3 and 8.4 tests
- Add Rector check to Composer scripts

Related PR: #3097

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
