### PR TITLE
4.6 tested PHP versions

### DIFF
--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -10,7 +10,9 @@ jobs:
         strategy:
             matrix:
                 php:
-                    - "8.3"
+                    - "8.4" # Upper supported version
+                    - "8.2" # Lower supported that haven't reached end of live
+                    - "7.4" # Lower supported version but reached end of life, 8.2 is recommended instead
         steps:
             - uses: actions/checkout@v4
 

--- a/code_samples/ai_actions/src/AI/Handler/WhisperAudioToTextActionHandler.php
+++ b/code_samples/ai_actions/src/AI/Handler/WhisperAudioToTextActionHandler.php
@@ -31,7 +31,7 @@ final class WhisperAudioToTextActionHandler implements ActionHandlerInterface
 
         $arguments = ['whisper'];
 
-        $language = $action->getRuntimeContext()?->get('languageCode');
+        $language = $action->hasRuntimeContext() ? $action->getRuntimeContext()->get('languageCode') : null;
         if ($language !== null) {
             $arguments[] = sprintf('--language=%s', substr($language, 0, 2));
         }
@@ -49,10 +49,10 @@ final class WhisperAudioToTextActionHandler implements ActionHandlerInterface
 
         $output = $process->getOutput();
 
-        $includeTimestamps = $action->getActionContext()
-            ?->getActionTypeOptions()
+        $includeTimestamps = $action->hasActionContext() ? $action->getActionContext()
+            ->getActionTypeOptions()
             ->get('include_timestamps', false)
-            ?? false;
+            : false;
 
         if (!$includeTimestamps) {
             $output = $this->removeTimestamps($output);

--- a/code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php
+++ b/code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php
@@ -86,7 +86,8 @@ class ViewContentMetaDataCommand extends Command
             $output->writeln(' in ' . $versionInfo->getInitialLanguage()->name);
         }
 
-        $versionInfoArray = iterator_to_array($this->contentService->loadVersions($contentInfo, VersionInfo::STATUS_ARCHIVED));
+        $versionInfoArray = $this->contentService->loadVersions($contentInfo, VersionInfo::STATUS_ARCHIVED);
+        if ($versionInfoArray instanceof \Traversable) { $versionInfoArray = iterator_to_array($versionInfoArray); }
         if (count($versionInfoArray)) {
             $output->writeln('Archived versions:');
             foreach ($versionInfoArray as $versionInfo) {

--- a/code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php
+++ b/code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php
@@ -88,7 +88,7 @@ class ViewContentMetaDataCommand extends Command
 
         $versionInfoArray = $this->contentService->loadVersions($contentInfo, VersionInfo::STATUS_ARCHIVED);
         if ($versionInfoArray instanceof \Traversable) {
-        $versionInfoArray = iterator_to_array($versionInfoArray);
+            $versionInfoArray = iterator_to_array($versionInfoArray);
         }
         if (count($versionInfoArray)) {
             $output->writeln('Archived versions:');

--- a/code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php
+++ b/code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php
@@ -87,7 +87,9 @@ class ViewContentMetaDataCommand extends Command
         }
 
         $versionInfoArray = $this->contentService->loadVersions($contentInfo, VersionInfo::STATUS_ARCHIVED);
-        if ($versionInfoArray instanceof \Traversable) { $versionInfoArray = iterator_to_array($versionInfoArray); }
+        if ($versionInfoArray instanceof \Traversable) {
+        $versionInfoArray = iterator_to_array($versionInfoArray);
+        }
         if (count($versionInfoArray)) {
             $output->writeln('Archived versions:');
             foreach ($versionInfoArray as $versionInfo) {

--- a/code_samples/back_office/limitation/src/Security/Limitation/CustomLimitationType.php
+++ b/code_samples/back_office/limitation/src/Security/Limitation/CustomLimitationType.php
@@ -57,7 +57,7 @@ class CustomLimitationType implements Type
      *
      * @return bool|null
      */
-    public function evaluate(Limitation $value, UserReference $currentUser, ValueObject $object, array $targets = null): ?bool
+    public function evaluate(Limitation $value, UserReference $currentUser, ValueObject $object, ?array $targets = null): ?bool
     {
         if (!$value instanceof CustomLimitationValue) {
             throw new InvalidArgumentException('$value', 'Must be of type: CustomLimitationValue');

--- a/code_samples/back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php
+++ b/code_samples/back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php
@@ -9,9 +9,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class HelpMenuSubscriber implements EventSubscriberInterface
 {
+    private bool $kernelDebug;
+
     public function __construct(
-        private readonly bool $kernelDebug
+        bool $kernelDebug
     ) {
+        $this->kernelDebug = $kernelDebug;
     }
 
     public static function getSubscribedEvents(): array

--- a/code_samples/back_office/search/src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php
+++ b/code_samples/back_office/search/src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php
@@ -15,7 +15,7 @@ class ProductSuggestionNormalizer implements
 {
     use NormalizerAwareTrait;
 
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         /** @var \App\Search\Model\Suggestion\ProductSuggestion $object */
         return [
@@ -27,7 +27,7 @@ class ProductSuggestionNormalizer implements
         ];
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $data instanceof ProductSuggestion;
     }

--- a/code_samples/data_migration/src/Migrations/Action/AssignSectionDenormalizer.php
+++ b/code_samples/data_migration/src/Migrations/Action/AssignSectionDenormalizer.php
@@ -9,7 +9,7 @@ use Webmozart\Assert\Assert;
 
 final class AssignSectionDenormalizer extends AbstractActionDenormalizer
 {
-    protected function supportsActionName(string $actionName, string $format = null): bool
+    protected function supportsActionName(string $actionName, ?string $format = null): bool
     {
         return $actionName === AssignSection::TYPE;
     }
@@ -22,7 +22,7 @@ final class AssignSectionDenormalizer extends AbstractActionDenormalizer
      *
      * @return \App\Migrations\Action\AssignSection
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): AssignSection
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): AssignSection
     {
         Assert::keyExists($data, 'value');
 

--- a/code_samples/data_migration/src/Migrations/Matcher/SectionIdentifierNormalizer.php
+++ b/code_samples/data_migration/src/Migrations/Matcher/SectionIdentifierNormalizer.php
@@ -25,7 +25,7 @@ class SectionIdentifierNormalizer extends AbstractCriterionNormalizer
         return new Criterion\SectionIdentifier($data['value']);
     }
 
-    public function supportsNormalization($data, string $format = null): bool
+    public function supportsNormalization($data, ?string $format = null): bool
     {
         return $data instanceof Criterion\SectionIdentifier;
     }

--- a/code_samples/data_migration/src/Migrations/Step/ReplaceNameStepNormalizer.php
+++ b/code_samples/data_migration/src/Migrations/Step/ReplaceNameStepNormalizer.php
@@ -14,7 +14,7 @@ final class ReplaceNameStepNormalizer extends AbstractStepNormalizer
 {
     protected function normalizeStep(
         StepInterface $object,
-        string $format = null,
+        ?string $format = null,
         array $context = []
     ): array {
         assert($object instanceof ReplaceNameStep);

--- a/code_samples/discounts/src/Discounts/Step/Step2/AnniversaryConditionStepEventSubscriber.php
+++ b/code_samples/discounts/src/Discounts/Step/Step2/AnniversaryConditionStepEventSubscriber.php
@@ -56,12 +56,17 @@ final class AnniversaryConditionStepEventSubscriber implements EventSubscriberIn
 
     public function addStepDataToStruct(DiscountStructEventInterface $event): void
     {
-        /** @var AnniversaryConditionStep $stepData */
-        $stepData = $event
-                        ->getData()
-                        ->getStepByIdentifier(AnniversaryConditionStep::IDENTIFIER)?->getStepData();
+        $step = $event->getData()
+                        ->getStepByIdentifier(AnniversaryConditionStep::IDENTIFIER);
 
-        if ($stepData === null || !$stepData->enabled) {
+        if ($step === null) {
+            return;
+        }
+
+        /** @var AnniversaryConditionStep $stepData */
+        $stepData = $step->getStepData();
+
+        if (!$stepData->enabled) {
             return;
         }
 

--- a/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueDenormalizer.php
+++ b/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueDenormalizer.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 
 final class ValueDenormalizer implements DenormalizerInterface
 {
-    public function denormalize($data, string $class, string $format = null, array $context = [])
+    public function denormalize($data, string $class, ?string $format = null, array $context = [])
     {
         if (isset($data['x']) && isset($data['y'])) {
             // Support for old format
@@ -18,7 +18,7 @@ final class ValueDenormalizer implements DenormalizerInterface
         return new $class($data);
     }
 
-    public function supportsDenormalization($data, string $type, string $format = null)
+    public function supportsDenormalization($data, string $type, ?string $format = null)
     {
         return $type === Value::class;
     }

--- a/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueNormalizer.php
+++ b/code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueNormalizer.php
@@ -8,7 +8,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class ValueNormalizer implements NormalizerInterface
 {
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize($object, ?string $format = null, array $context = [])
     {
         return [
             $object->getX(),
@@ -16,7 +16,7 @@ final class ValueNormalizer implements NormalizerInterface
         ];
     }
 
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, ?string $format = null)
     {
         return $data instanceof Value;
     }

--- a/code_samples/search/custom/src/Query/Criterion/Solr/CameraManufacturerVisitor.php
+++ b/code_samples/search/custom/src/Query/Criterion/Solr/CameraManufacturerVisitor.php
@@ -18,7 +18,7 @@ final class CameraManufacturerVisitor extends CriterionVisitor
     /**
      * @param \App\Query\Criterion\CameraManufacturerCriterion $criterion
      */
-    public function visit(Criterion $criterion, CriterionVisitor $subVisitor = null)
+    public function visit(Criterion $criterion, ?CriterionVisitor $subVisitor = null)
     {
         $expressions = array_map(
             function ($value): string {

--- a/docs/content_management/content_api/browsing_content.md
+++ b/docs/content_management/content_api/browsing_content.md
@@ -98,7 +98,7 @@ This method loads only the specified subset of relations to improve performance 
 You can get the current version's `VersionInfo` using [`ContentService::loadVersionInfo`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html#method_loadVersionInfo).
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 100, 107) =]]
+[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 103, 110) =]]
 ```
 
 You can also specify the version number as the second argument to get Relations for a specific version:
@@ -117,7 +117,7 @@ It also holds the [relation type](content_relations.md), and the optional field 
 You can use the `getOwner` method of the `ContentInfo` object to load the content item's owner as a `User` value object.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 109, 110) =]]
+[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 112, 113) =]]
 ```
 
 To get the creator of the current version and not the content item's owner, you need to use the `creatorId` property from the current version's `VersionInfo` object.
@@ -127,7 +127,7 @@ To get the creator of the current version and not the content item's owner, you 
 You can find the section to which a content item belongs through the [`getSection`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-ContentInfo.html#method_getSection) method of the ContentInfo object:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 112, 113) =]]
+[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 115, 116) =]]
 ```
 
 !!! note
@@ -142,7 +142,7 @@ You need to provide it with the object state group.
 All object state groups can be retrieved through [`loadObjectStateGroups`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ObjectStateService.html#method_loadObjectStateGroups).
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 115, 120) =]]
+[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 118, 123) =]]
 ```
 
 ## Viewing content with fields

--- a/docs/discounts/extend_discounts_wizard.md
+++ b/docs/discounts/extend_discounts_wizard.md
@@ -106,7 +106,7 @@ Expand the previously created `AnniversaryConditionStepEventSubscriber` to liste
 
 and add the `addStepDataToStruct()` method:
 
-``` php hl_lines="23-24 57-70"
+``` php hl_lines="23-24 57-75"
 [[= include_file('code_samples/discounts/src/Discounts/Step/Step2/AnniversaryConditionStepEventSubscriber.php') =]]
 ```
 

--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -135,9 +135,9 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
     - 8.4
     - 8.3
     - 8.2
-    - 8.1
-    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
-    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
+    - 8.1 (PHP 8.1 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
 
 === "[[= product_name =]] v3.3"
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,6 +121,12 @@ parameters:
 			path: code_samples/api/public_php_api/src/Controller/CustomFilterController.php
 
 		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: code_samples/api/rest_api/create_image.json.php
+
+		-
 			message: '#^Cannot access property \$nodeName on DOMNode\|null\.$#'
 			identifier: property.nonObject
 			count: 3
@@ -141,6 +147,12 @@ parameters:
 		-
 			message: '#^Cannot call method hasAttribute\(\) on DOMNode\|null\.$#'
 			identifier: method.nonObject
+			count: 1
+			path: code_samples/api/rest_api/create_image.xml.php
+
+		-
+			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/create_image.xml.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -199,7 +199,7 @@ parameters:
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php
 
 		-
-			message: '#^Parameter \#2 (\.\.\.\$arrays|\$args) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
+			message: '#^Parameter \#2 \.\.\.(\$arrays|\$args) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,13 +193,13 @@ parameters:
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php
 
 		-
-			message: '#^Parameter \#1 \.\.\.\$arrays of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
+			message: '#^Parameter \#1 (\.\.\.\$arrays|$arr1) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php
 
 		-
-			message: '#^Parameter \#2 \.\.\.\$arrays of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
+			message: '#^Parameter \#2 (\.\.\.\$arrays|$args) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,12 +121,6 @@ parameters:
 			path: code_samples/api/public_php_api/src/Controller/CustomFilterController.php
 
 		-
-			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
-			identifier: argument.type
-			count: 1
-			path: code_samples/api/rest_api/create_image.json.php
-
-		-
 			message: '#^Cannot access property \$nodeName on DOMNode\|null\.$#'
 			identifier: property.nonObject
 			count: 3
@@ -147,12 +141,6 @@ parameters:
 		-
 			message: '#^Cannot call method hasAttribute\(\) on DOMNode\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: code_samples/api/rest_api/create_image.xml.php
-
-		-
-			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
-			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/create_image.xml.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,7 +121,7 @@ parameters:
 			path: code_samples/api/public_php_api/src/Controller/CustomFilterController.php
 
 		-
-			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			message: '#^Parameter \#1 \$str(ing)? of function base64_encode expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/create_image.json.php
@@ -151,7 +151,7 @@ parameters:
 			path: code_samples/api/rest_api/create_image.xml.php
 
 		-
-			message: '#^Parameter \#1 \$string of function base64_encode expects string, string\|false given\.$#'
+			message: '#^Parameter \#1 \$str(ing)? of function base64_encode expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/create_image.xml.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -283,7 +283,7 @@ parameters:
 			path: code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
 
 		-
-			message: '#^Parameter \#2 \$string of function explode expects string, string\|null given\.$#'
+			message: '#^Parameter \#2 \$str(ing)? of function explode expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,13 +193,13 @@ parameters:
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php
 
 		-
-			message: '#^Parameter \#1 (\.\.\.\$arrays|$arr1) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
+			message: '#^Parameter \#1 (\.\.\.\$arrays|\$arr1) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php
 
 		-
-			message: '#^Parameter \#2 (\.\.\.\$arrays|$args) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
+			message: '#^Parameter \#2 (\.\.\.\$arrays|\$args) of function array_merge expects array, iterable\<Ibexa\\Contracts\\Core\\Repository\\Values\\Content\\URLAlias\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 4.6
| Edition       | N/A

Test with upper, lower alive, and lower dead versions of PHP
- Add PHP 8.4, 8.2, and 7.4 to `code-samples-validation` CI test suite
- Remove PHP 8.3
- Fixes to satisfy tests in all three versions


#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
