### PR TITLE
IBX-11485: Update doc for Symfony 7.4

### DIFF
--- a/docs/infrastructure_and_maintenance/backup.md
+++ b/docs/infrastructure_and_maintenance/backup.md
@@ -20,20 +20,25 @@ cd /path/to/ibexa
 
 2\. Clear all caches:
 
-```
-var/cache/*
-var/logs/*
+``` bash
+rm -rf var/cache/*
+rm -rf var/share/*
+rm -rf var/logs/*
 ```
 
 3\. Create a dump of the database:
 
-```
-# MySQL
-mysqldump -u <database_user> --add-drop-table <database_name> > db_backup.sql
+=== "MySQL"
 
-# PostgreSQL
-pg_dump -c --if-exists <database_name> > db_backup.sql
-```
+    ``` bash
+    mysqldump -u <database_user> --add-drop-table <database_name> > db_backup.sql
+    ```
+
+=== "PostgreSQL"
+
+    ``` bash
+    pg_dump -c --if-exists <database_name> > db_backup.sql
+    ```
 
 4\. In parent directory create a tar archive of the files (including the database dump) using the "tar" command:
 

--- a/docs/infrastructure_and_maintenance/support_and_maintenance_faq.md
+++ b/docs/infrastructure_and_maintenance/support_and_maintenance_faq.md
@@ -76,12 +76,12 @@ php bin/console cache:pool:clear cache.redis
 
 ```bash
 rm -rf var/cache/*
+rm -rf var/share/*
 ```
 
 !!! caution "Clearing cache manually"
 
-    Manual cache clearing should be executed with caution.
-    `rm -rf var/cache/*` wipes all the files and unlike `cache:clear` doesn't warm up the cache.
+    Manual cache clearing should be executed with caution, as it doesn't warm up the cache.
     It results in a significant performance drop on first request, so it shouldn't be called on a production environment.
     Besides, it could lead to issues with file ownership after running `cache:clear` as a root.
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -341,7 +341,7 @@ curl -fs https://get.symfony.com/cloud/configurator | bash
 This version of [[= product_name =]] requires [Symfony 7.4](https://symfony.com/releases/7.4).
 Update Symfony constraints in `composer.json` before updating the packages.
 
-1. In `composer.json`, update `extra.symfony.require` to allow installing higher Symfony version:
+1. In `composer.json`, update `extra.symfony.require` to allow installing a higher Symfony version:
 
     ```json
     "extra": {
@@ -361,7 +361,7 @@ Update Symfony constraints in `composer.json` before updating the packages.
 3. Review your code, configuration, and third-party bundles for Symfony 7.4 compatibility.
 
     For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
-    Among the changes are:
+    Key changes include:
 
     - Array-based PHP configuration format
 
@@ -397,7 +397,7 @@ Update Symfony constraints in `composer.json` before updating the packages.
         composer recipes:install ibexa/commerce --force -v
         ```
 
-5. Restore manually the entry for `JMSTranslationBundle` in `config/bundles.php` to [its previous position](https://github.com/ibexa/commerce-skeleton/blob/v5.0.6/config/bundles.php#L14):
+5. Manually restore the entry for `JMSTranslationBundle` in `config/bundles.php` to [its previous position](https://github.com/ibexa/commerce-skeleton/blob/v5.0.6/config/bundles.php#L14):
 
     ``` hl_lines="2"
         FOS\HttpCacheBundle\FOSHttpCacheBundle::class => ['all' => true],

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -360,7 +360,20 @@ Update Symfony constraints in `composer.json` before updating the packages.
 
 3. Review your code, configuration, and third-party bundles for Symfony 7.4 compatibility.
 
-4. Update packages by running:
+    For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
+    Among the changes are:
+
+    - Array-based PHP configuration format
+
+        As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
+        You should commit this file to the repository.
+
+    - Independent application cache directory
+
+        Symfony 7.4 introduces a new [share directory](https://symfony.com/blog/new-in-symfony-7-4-share-directory), dedicated for storing application cache on the file system.
+        If you decide to configure it (for example, by setting the `APP_SHARE_DIR` environment variable), review your existing scripts for explicit `var/cache` usage (for example, `rm -rf var/cache`) and decide whether to include `var/share` in the script.
+
+4. Update Ibexa packages by running:
 
     === "[[= product_name_headless =]]"
 
@@ -392,18 +405,7 @@ Update Symfony constraints in `composer.json` before updating the packages.
         Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     ```
 
-For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
-Among the changes are:
-
-- Array-based PHP configuration format
-
-    As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
-    You should commit this file to the repository.
-
-- Independent application cache directory
-
-    Symfony 7.4 introduces a new [share directory](https://symfony.com/blog/new-in-symfony-7-4-share-directory), dedicated for storing application cache on the file system.
-    If you decide to configure it (for example, by setting the `APP_SHARE_DIR` environment variable), review your existing scripts for explicit `var/cache` usage (for example, `rm -rf var/cache`) and decide whether to include `var/share` in the script.
+You're now running [Symfony 7.4, the current long-term support version](https://symfony.com/releases/7.4).
 
 ## LTS Updates and additional packages
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -334,6 +334,56 @@ Additionally, you must remove the following line from your `.platform.app.yaml` 
 curl -fs https://get.symfony.com/cloud/configurator | bash
 ```
 
+## v5.0.7
+
+### Update Symfony from 7.3 to 7.4
+
+This version of [[= product_name =]] requires [Symfony 7.4](https://symfony.com/releases/7.4).
+Update Symfony constraints in `composer.json` before updating the packages.
+
+1. In `composer.json`, update `extra.symfony.require` to allow installing higher Symfony version:
+
+    ```json
+    "extra": {
+        "symfony": {
+            "require": "7.4.*"
+        }
+    }
+    ```
+
+2. Review your code, configuration, and third-party bundles for Symfony 7.4 compatibility.
+
+3. Update packages by running:
+
+=== "[[= product_name_headless =]]"
+
+    ``` bash
+    yarn upgrade @ibexa/frontend-config @ibexa/ts-config
+    composer require ibexa/headless:v5.0.7 --with-all-dependencies --no-scripts
+    composer recipes:install ibexa/headless --force -v
+    ```
+=== "[[= product_name_exp =]]"
+
+    ``` bash
+    yarn upgrade @ibexa/frontend-config @ibexa/ts-config
+    composer require ibexa/experience:v5.0.7 --with-all-dependencies --no-scripts
+    composer recipes:install ibexa/experience --force -v
+    ```
+=== "[[= product_name_com =]]"
+
+    ``` bash
+    yarn upgrade @ibexa/frontend-config @ibexa/ts-config
+    composer require ibexa/commerce:v5.0.7 --with-all-dependencies --no-scripts
+    composer recipes:install ibexa/commerce --force -v
+    ```
+
+!!! tip
+
+    As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
+    You should commit this file to the repository.
+
+For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
+
 ## LTS Updates and additional packages
 
 [LTS Updates](editions.md#lts-updates) are standalone packages with their own update procedures.

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -351,7 +351,7 @@ Update Symfony constraints in `composer.json` before updating the packages.
     }
     ```
 
-2. To allow installing Symfony 7.4, update the requirements for `symfony` packages in `composer.json` as in the example below::
+2. To allow installing Symfony 7.4, update the requirements for `symfony` packages in `composer.json` as in the example below:
 
     ``` diff
     -        "symfony/console": "7.3.*",

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -351,31 +351,48 @@ Update Symfony constraints in `composer.json` before updating the packages.
     }
     ```
 
-2. Review your code, configuration, and third-party bundles for Symfony 7.4 compatibility.
+2. To allow installing Symfony 7.4, update the requirements for `symfony` packages in `composer.json` as in the example below::
 
-3. Update packages by running:
-
-=== "[[= product_name_headless =]]"
-
-    ``` bash
-    yarn upgrade @ibexa/frontend-config @ibexa/ts-config
-    composer require ibexa/headless:v5.0.7 --with-all-dependencies --no-scripts
-    composer recipes:install ibexa/headless --force -v
+    ``` diff
+    -        "symfony/console": "7.3.*",
+    +        "symfony/console": "7.4.*",
     ```
-=== "[[= product_name_exp =]]"
 
-    ``` bash
-    yarn upgrade @ibexa/frontend-config @ibexa/ts-config
-    composer require ibexa/experience:v5.0.7 --with-all-dependencies --no-scripts
-    composer recipes:install ibexa/experience --force -v
-    ```
-=== "[[= product_name_com =]]"
+3. Review your code, configuration, and third-party bundles for Symfony 7.4 compatibility.
 
-    ``` bash
-    yarn upgrade @ibexa/frontend-config @ibexa/ts-config
-    composer require ibexa/commerce:v5.0.7 --with-all-dependencies --no-scripts
-    composer recipes:install ibexa/commerce --force -v
+4. Update packages by running:
+
+    === "[[= product_name_headless =]]"
+
+        ``` bash
+        yarn upgrade @ibexa/frontend-config @ibexa/ts-config
+        composer require ibexa/headless:v5.0.7 --with-all-dependencies --no-scripts
+        composer recipes:install ibexa/headless --force -v
+        ```
+    === "[[= product_name_exp =]]"
+
+        ``` bash
+        yarn upgrade @ibexa/frontend-config @ibexa/ts-config
+        composer require ibexa/experience:v5.0.7 --with-all-dependencies --no-scripts
+        composer recipes:install ibexa/experience --force -v
+        ```
+    === "[[= product_name_com =]]"
+
+        ``` bash
+        yarn upgrade @ibexa/frontend-config @ibexa/ts-config
+        composer require ibexa/commerce:v5.0.7 --with-all-dependencies --no-scripts
+        composer recipes:install ibexa/commerce --force -v
+        ```
+
+5. Restore manually the entry for `JMSTranslationBundle` in `config/bundles.php` to [its previous position](https://github.com/ibexa/commerce-skeleton/blob/v5.0.6/config/bundles.php#L14):
+
+    ``` hl_lines="2"
+        FOS\HttpCacheBundle\FOSHttpCacheBundle::class => ['all' => true],
+        JMS\TranslationBundle\JMSTranslationBundle::class => ['all' => true],
+        Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     ```
+
+
 
 !!! tip
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -392,14 +392,18 @@ Update Symfony constraints in `composer.json` before updating the packages.
         Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],
     ```
 
+For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
+Among the changes are:
 
-
-!!! tip
+- Array-based PHP configuration format
 
     As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
     You should commit this file to the repository.
 
-For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
+- Independent application cache directory
+
+    Symfony 7.4 introduces a new [share directory](https://symfony.com/blog/new-in-symfony-7-4-share-directory), dedicated for storing application cache on the file system.
+    If you decide to configure it (for example, by setting the `APP_SHARE_DIR` environment variable), review your existing scripts for explicit `var/cache` usage (for example, `rm -rf var/cache`) and decide whether to include `var/share` in the script.
 
 ## LTS Updates and additional packages
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1001,7 +1001,7 @@ extra:
   latest_tag_4_6: '4.6.28'
   latest_tag_5_0: '5.0.6'
 
-  symfony_doc: 'https://symfony.com/doc/7.3'
+  symfony_doc: 'https://symfony.com/doc/7.4'
   user_doc: 'https://doc.ibexa.co/projects/userguide/en/5.0'
   connect_doc: 'https://doc.ibexa.co/projects/connect/en/latest'
 


### PR DESCRIPTION
Target: Link change is for 5.0 only, but update instructions are 4.6 and 5.0

Adding update instructions for Symfony 7.4

Status: needs to be merged together with the 5.0.7 release.

JIRA: https://ibexa.atlassian.net/browse/IBX-11485