### PR TITLE
[4.6] Added Rector downgradesets

### DIFF
--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -8,6 +8,7 @@ jobs:
         name: Validate code samples
         runs-on: "ubuntu-22.04"
         strategy:
+            fail-fast: false
             matrix:
                 php:
                     - "8.4" # Upper supported version
@@ -47,6 +48,12 @@ jobs:
 
             - name: Run PHPStan analysis
               run: composer phpstan
+  
+            - if: matrix.php == '8.4' # ibexa/rector supports PHP 8.3 and higher
+              name: Run Rector check
+              run: |
+                composer require --dev ibexa/rector:~4.6.x-dev
+                composer check-rector
 
     code-samples-inclusion-check:
         name: Check code samples inclusion

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ composer phpstan
 Code samples must be compatible with PHP 7.4.
 Rector is used to check and downgrade PHP 8.x syntax and functions to PHP 7.4-compatible equivalents.
 
-To check which files need downgrading (dry-run, no changes applied):
+To check which files need downgrading (dry-run, no changes applied), run:
 ```bash
 composer require --dev ibexa/rector:~4.6.x-dev
 composer check-rector

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ composer update
 composer phpstan
 ```
 
+## Downgrading code samples with Rector
+
+Code samples must be compatible with PHP 7.4.
+Rector is used to check and downgrade PHP 8.x syntax and functions to PHP 7.4-compatible equivalents.
+
+To check which files need downgrading (dry-run, no changes applied):
+```bash
+composer require --dev ibexa/rector:~4.6.x-dev
+composer check-rector
+```
+
+To refactor the code samples, run:
+
+``` bash
+vendor/bin/rector
+```
+
 ## Where to View
 
 https://doc.ibexa.co

--- a/code_samples/api/commerce/src/Command/PaymentCommand.php
+++ b/code_samples/api/commerce/src/Command/PaymentCommand.php
@@ -37,7 +37,7 @@ final class PaymentCommand extends Command
         UserService $userService,
         PaymentServiceInterface $paymentService,
         OrderServiceInterface $orderService,
-        PaymentMethodServiceInterface $paymentMethodService,
+        PaymentMethodServiceInterface $paymentMethodService
     ) {
         $this->paymentService = $paymentService;
         $this->permissionResolver = $permissionResolver;

--- a/code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
+++ b/code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php
@@ -18,7 +18,7 @@ class MySuggestionEventSubscriber implements EventSubscriberInterface, LoggerAwa
     private ProductServiceInterface $productService;
 
     public function __construct(
-        ProductServiceInterface $productService,
+        ProductServiceInterface $productService
     ) {
         $this->productService = $productService;
     }

--- a/code_samples/data_migration/src/Migrations/Step/ReplaceNameStepExecutor.php
+++ b/code_samples/data_migration/src/Migrations/Step/ReplaceNameStepExecutor.php
@@ -38,7 +38,7 @@ final class ReplaceNameStepExecutor extends AbstractStepExecutor
                     continue;
                 }
 
-                if (str_contains($field->value, 'Company Name')) {
+                if (strpos($field->value, 'Company Name') !== false) {
                     $newValue = str_replace('Company Name', $step->getReplacement(), $field->value);
                     $struct->setField($field->fieldDefIdentifier, new Value($newValue));
                 }

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",
         "check-cs": "@fix-cs --dry-run",
         "phpstan": "phpstan analyse",
-         "check-rector": "rector process --dry-run --ansi"
+        "check-rector": "rector process --dry-run --ansi"
     },
     "suggest": {
         "ibexa/rector": "Add Rector to check for code refactoring opportunities"

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
             "url": "https://updates.ibexa.co"
         }
     ],
+    "require": {
+        "php": "^7.4 || ^8.0"
+    },
     "require-dev": {
         "ibexa/automated-translation": "4.6.x-dev",
         "ibexa/code-style": "^1.0",
@@ -82,7 +85,14 @@
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",
         "check-cs": "@fix-cs --dry-run",
-        "phpstan": "phpstan analyse"
+        "phpstan": "phpstan analyse",
+         "check-rector": "rector process --dry-run --ansi"
+    },
+    "suggest": {
+        "ibexa/rector": "Add Rector to check for code refactoring opportunities"
+    },
+    "scripts-descriptions": {
+         "check-rector": "Check for code refactoring opportunities"
     },
     "config": {
         "allow-plugins": false

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Symfony\DowngradeSymfony70\Rector\Class_\DowngradeSymfonyCommandAttributeRector;
+use Rector\DowngradePhp82\Rector\FuncCall\DowngradeIteratorCountToArrayRector;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/code_samples',
+    ])
+    ->withSkip([
+        DowngradeIteratorCountToArrayRector::class,
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_46->value,
+    ])
+    ->withDowngradeSets(php74: true)
+    ->withRules([
+        DowngradeSymfonyCommandAttributeRector::class,
+    ]);


### PR DESCRIPTION
Target: 4.6 only!

Adding Rector downgrade sets to make downgrading the code to PHP 7.4 and Symfony 5 easier - something that we had to do recently a couple of times (Collaboration, Embeddings, and others).

Example failing build:
https://github.com/ibexa/documentation-developer/actions/runs/23595089391/job/68709646371?pr=3107

I have used Rector for downgrading the code samples from https://github.com/ibexa/documentation-developer/pull/3029

Both [str_contains](https://www.php.net/manual/en/function.str-contains.php) and [dangling comma in construtor](https://github.com/ibexa/visual-testing/pull/23) are PHP 8 features.
PHPStan doesn't detect them:

- str_contains is not detected because of the Symfon's polyfill
- there's no rule for the dangling comma: https://github.com/phpstan/phpstan/issues/4589

