### PR TITLE
.readthedocs.yml: Upgrade build's OS (5.0)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ mkdocs:
   fail_on_warning: true
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.13"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mkdocs==1.6.1
-Pygments==2.19.1
-pymdown-extensions==10.16.1
+Pygments==2.20.0
+pymdown-extensions==10.21.2
 Markdown==3.8.1
 mkdocs-material==9.6.5
 mkdocs-macros-plugin==1.3.7


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | 5.0, ~~4.6, 3.3, 2.5~~
| Edition       | N/A

https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/

Related PRs:
- ibexa/documentation-developer#3111
- ibexa/documentation-developer#3112
- ibexa/documentation-developer#3113
- ibexa/documentation-developer#3114
- ibexa/documentation-user#394
- ibexa/documentation-user#395
- ibexa/documentation-user#396
- ibexa/documentation-user#397
- ibexa/documentation-developer#3115
- ibexa/documentation-user#398

