### PR TITLE
Cards macro: correct links on ReadTheDocs preview

### DIFF
--- a/main.py
+++ b/main.py
@@ -62,6 +62,12 @@ def define_env(env):
         version = force_version or version
         version = os.getenv("READTHEDOCS_VERSION_NAME", version)
 
+        rtd_canonical = os.getenv("READTHEDOCS_CANONICAL_URL", "")
+        if rtd_canonical:
+            rtd_domain = re.search("//([^/]+)/", rtd_canonical)
+            if rtd_domain:
+                site = rtd_domain.group(1)
+
         if isinstance(pages, str):
             pages = [pages]
         cards = []


### PR DESCRIPTION
Target: all versions (and user doc)

This PR makes the card preview links work in RTD previews, for example in https://ez-systems-developer-documentation--3117.com.readthedocs.build/en/3117/ai_actions/ai_actions/
