### PR TITLE
Fix excluded_uri_prefixes usage

### DIFF
--- a/docs/customer_management/cp_page_builder.md
+++ b/docs/customer_management/cp_page_builder.md
@@ -52,7 +52,7 @@ ibexa:
             content:
                 tree_root:
                     location_id: location_id_of_customer_portal
-                    excluded_uri_prefixes: [ /media, /images ]
+                    excluded_uri_prefixes: [ /media/, /images/ ]
 ```
 
 Next, under the `ibexa.system.admin.page_builder` [configuration key](configuration.md#configuration-files), add `custom_portal` to [the SiteAccess list available to Page Builder](multisite_configuration.md#siteaccesses-and-page-builder):
@@ -136,7 +136,7 @@ ibexa:
             content:
                 tree_root:
                     location_id: location_id_of_customer_portals_root_folder
-                    excluded_uri_prefixes: [ /media, /images ]
+                    excluded_uri_prefixes: [ /media/, /images/ ]
 ```
 
 Next, under the `ibexa.system.admin.page_builder` [configuration key](configuration.md#configuration-files), add `custom_portal` to [the SiteAccess list available to Page Builder](multisite_configuration.md#siteaccesses-and-page-builder):
@@ -234,7 +234,7 @@ ibexa:
             content:
                 tree_root:
                     location_id: location_id_of_customer_portals_root_folder
-                    excluded_uri_prefixes: [ /media, /images ]
+                    excluded_uri_prefixes: [ /media/, /images/ ]
 ```
 
 To generate the Customer Portal menu you should use `customer_portal.menu.main` key:

--- a/docs/multisite/multisite_configuration.md
+++ b/docs/multisite/multisite_configuration.md
@@ -184,13 +184,14 @@ ibexa:
             content:
                 tree_root:
                     location_id: 42
-                    excluded_uri_prefixes: [/media, /images]
+                    excluded_uri_prefixes: [/media/, /images/]
             index_page: /EventFrontPage
 ```
 
 - `location_id` defines the location ID of the content root for the SiteAccess.
 - `excluded_uri_prefixes` defines which URIs ignore the root limit set by using `location_id`.
-In the example above, to access the Media and Images folders, you can use their own URI, even though they're outside the location provided in `content.tree_root.location_id`.
+  In the example above, to access the Media and Images folders, you can use their own URI, even though they're outside the location provided in `content.tree_root.location_id`.
+  It's an array of prefixes. So, for example, `[/media]` would also exclude `/mediation` from root limit.
 - `index_page` is the page shown when you access the root index `/`.
 
 !!! note

--- a/docs/multisite/set_up_campaign_siteaccess.md
+++ b/docs/multisite/set_up_campaign_siteaccess.md
@@ -51,7 +51,7 @@ Thanks to this configuration, you can access `<your site>/campaign/Articles/Arti
 ## Reuse content
 
 Finally, reuse some content between sites, for example "Logos" from "Images/Media".
-You can allow the `campaign` site to access them, even though they're in a different part of the tree, via `excluded_uri_prefixes`:
+You can allow the `campaign` site to access them, even though they're in a different part of the tree, via [`excluded_uri_prefixes`](multisite_configuration.md#location-tree):
 
 ``` yaml
 ibexa:

--- a/docs/multisite/set_up_campaign_siteaccess.md
+++ b/docs/multisite/set_up_campaign_siteaccess.md
@@ -60,7 +60,7 @@ ibexa:
             content:
                 tree_root:
                     location_id: 57
-                    excluded_uri_prefixes: [ /media/images/logos ]
+                    excluded_uri_prefixes: [ /media/images/logos/ ]
 ```
 
 Now, when you use the `campaign` SiteAccess, you can reach `<your site>/campaign/Media/Images/Logos`, despite the fact that it's not a sub-item of the "Campaign" location.


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | [IBX-11449](https://ibexa.atlassian.net/browse/IBX-11449)
| Versions      | 5.0, 4.6
| Edition       | All

Insist on `excluded_uri_prefixes` being an array of **prefixes**, add trailing slashes to avoid side effects.

Previews:
- [Multisite configuration > Location tree](https://ez-systems-developer-documentation--3129.com.readthedocs.build/en/3129/multisite/multisite_configuration/#location-tree): Explain why trailing slashes.
- [Set up campaign SiteAccess > Reuse content](https://ez-systems-developer-documentation--3129.com.readthedocs.build/en/3129/multisite/set_up_campaign_siteaccess/#reuse-content): Link `excluded_uri_prefixes` to "Multisite configuration > Location tree".
- [Create Customer Portal](https://ez-systems-developer-documentation--3129.com.readthedocs.build/en/3129/customer_management/cp_page_builder/): Add trailing slashes to `excluded_uri_prefixes` in 3 config examples where there is no highlight on this part of the config.


#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR


[IBX-11449]: https://ibexa.atlassian.net/browse/IBX-11449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ