### PR TITLE
Raptor Add/Update buy event

### DIFF
--- a/code_samples/recommendations/events/buy_event.html.twig
+++ b/code_samples/recommendations/events/buy_event.html.twig
@@ -1,5 +1,3 @@
-
-
 {% set buyContext = {
     'subtotal': '10.00',
     'currency': 'EUR',

--- a/code_samples/recommendations/events/buy_event.html.twig
+++ b/code_samples/recommendations/events/buy_event.html.twig
@@ -1,0 +1,8 @@
+
+
+{% set buyContext = {
+    'subtotal': '10.00',
+    'currency': 'EUR',
+    'quantity': 1
+} %}
+{{ ibexa_tracking_track_event('buy', product, buyContext) }}

--- a/docs/recommendations/raptor_integration/tracking_php_api.md
+++ b/docs/recommendations/raptor_integration/tracking_php_api.md
@@ -21,18 +21,13 @@ This method receives an [`EventType`](/api/php_api/php_api_reference/classes/Ibe
 
 For more information, see the same arguments of the Twig function [`ibexa_tracking_track_event`](recommendations_twig_functions.md#ibexa_tracking_track_event-function).
 
-| Event type                 | Data class              | Context keys                                                                                                                                   |
-|:---------------------------|:------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------------|
-| `EventType::VISIT`         | `ProductInterface`      | (optional) `EventContext::CATEGORY_IDENTIFIER`,<br>(optional) `EventContext::WEBSITE_ID`                                                       |
-| `EventType::CONTENT_VISIT` | `Content`               | (optional) `EventContext::WEBSITE_ID`                                                                                                          |
+| Event type                 | Data class              | Context keys                                                                                                                                                                                      |
+|:---------------------------|:------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `EventType::VISIT`         | `ProductInterface`      | (optional) `EventContext::CATEGORY_IDENTIFIER`,<br>(optional) `EventContext::WEBSITE_ID`                                                                                                          |
+| `EventType::CONTENT_VISIT` | `Content`               | (optional) `EventContext::WEBSITE_ID`                                                                                                                                                             |
 | `EventType::BUY`           | `ProductInterface`      | `EventContext::SUBTOTAL`,<br>`EventContext::CURRENCY`,<br>`EventContext::QUANTITY`,<br>(optional) `EventContext::CATEGORY_IDENTIFIER`,<br>(optional) `EventContext::WEBSITE_ID`                   |
 | `EventType::BASKET`        | `ProductInterface`      | `EventContext::BASKET_CONTENT`,<br>`EventContext::BASKET_ID`,<br>(optional) `EventContext::CATEGORY_IDENTIFIER`,<br>(optional) `EventContext::QUANTITY`,<br>(optional) `EventContext::WEBSITE_ID` |
-| `EventType::ITEM_CLICK`    | `string` (product code) | `EventContext::MODULE_NAME`,<br>`EventContext::REDIRECT_URL`                                                                                   |
-
-!!! caution
-
-    The `EventType::BUY` type and the `BuyEventData` class aren't production-ready yet, they're missing the [`BrandId` parameter (P8)](https://content.raptorservices.com/help-center/tracking-events-for-recommendation), and their usage may change in the future.
-
+| `EventType::ITEM_CLICK`    | `string` (product code) | `EventContext::MODULE_NAME`,<br>`EventContext::REDIRECT_URL`                                                                                                                                      |
 
 Check the following example:
 
@@ -62,10 +57,6 @@ Check the following example:
 - if `CategoryId` is missing, use the `CategoryName`, for example, `Electronics;Smartphones`
 
 For more information, see the available events in the [tracking event namespace](/api/php_api/php_api_reference/namespaces/ibexa-contracts-connectorraptor-tracking-event.html).
-
-!!! caution
-
-    The `BuyEventData` class isn't production-ready yet, it's missing the [`BrandId` parameter (P8)](https://content.raptorservices.com/help-center/tracking-events-for-recommendation), and its usage may change in the future.
 
 ### Example - event subscriber
 

--- a/docs/recommendations/raptor_integration/tracking_php_api.md
+++ b/docs/recommendations/raptor_integration/tracking_php_api.md
@@ -17,7 +17,7 @@ For more information, see the available events in the [tracking event namespace]
 ### Mapping event data
 
 The recommended method is [`EventMapperInterface::map()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-EventMapperInterface.html#method_map).
-This method receives an [`EventType`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-EventType.html#cases) case, a data depending on the event type, and a context's associative array that uses [`EventContext`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-EventContext.html) constants as keys.
+This method receives an [`EventType`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-EventType.html#cases) case, a data depending on the event type (a [`ProductInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-ProductInterface.html), a [`Content`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-Content.html), or a `string`), and a context's associative array that uses [`EventContext`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-EventContext.html) constants as keys.
 
 For more information, see the same arguments of the Twig function [`ibexa_tracking_track_event`](recommendations_twig_functions.md#ibexa_tracking_track_event-function).
 

--- a/docs/templating/twig_function_reference/recommendations_twig_functions.md
+++ b/docs/templating/twig_function_reference/recommendations_twig_functions.md
@@ -170,7 +170,7 @@ In this case, `context` allows to override the product category by passing a cat
 {% endblock %}
 ```
 
-For another usage example, see the [Basket event](#basket-event).
+For another usage example, see the [Basket event](#product-basket-event).
 
 ### Custom templates
 

--- a/docs/templating/twig_function_reference/recommendations_twig_functions.md
+++ b/docs/templating/twig_function_reference/recommendations_twig_functions.md
@@ -170,7 +170,7 @@ In this case, `context` allows to override the product category by passing a cat
 {% endblock %}
 ```
 
-For another usage examples, see the [`buy`](#product-buy-event) and [`basket`](#product-basket-event) events.
+For other usage examples, see the [`buy`](#product-buy-event) and [`basket`](#product-basket-event) events.
 
 ### Custom templates
 

--- a/docs/templating/twig_function_reference/recommendations_twig_functions.md
+++ b/docs/templating/twig_function_reference/recommendations_twig_functions.md
@@ -111,7 +111,7 @@ Example:
 This event tracks when a product is bought.
 
 - **Product object** defines the product being purchased.
-- **Context array with purchase conditions** - provide optional data about the product purchase context, like quantity, price, or currency.
+- **Context array with purchase conditions** - provides optional data about the product purchase context, like quantity, price, or currency.
 
 ``` html+twig
 [[= include_file('code_samples/recommendations/events/buy_event.html.twig') =]]
@@ -140,7 +140,7 @@ This event tracks when a user clicks a Raptor recommendation, including adding p
 
 Required data:
 
-- **Product code** - defines the product code added to the cart.
+- **Product code** - code of the product the visitor interacted with.
 - **Context** - provides optional data, like `moduleName` or `redirectUrl`, to provide context for the event.
 
 Example:

--- a/docs/templating/twig_function_reference/recommendations_twig_functions.md
+++ b/docs/templating/twig_function_reference/recommendations_twig_functions.md
@@ -170,7 +170,7 @@ In this case, `context` allows to override the product category by passing a cat
 {% endblock %}
 ```
 
-For another usage example, see the [Basket event](#product-basket-event).
+For another usage examples, see the [`buy`](#product-buy-event) and [`basket`](#product-basket-event) events.
 
 ### Custom templates
 

--- a/docs/templating/twig_function_reference/recommendations_twig_functions.md
+++ b/docs/templating/twig_function_reference/recommendations_twig_functions.md
@@ -106,22 +106,18 @@ Example:
 [[= include_file('code_samples/recommendations/events/content_visit_event.html.twig') =]]
 ```
 
-### `itemclicked` event
+### Product `buy` event
 
-This event tracks when a user clicks a Raptor recommendation, including adding products to the cart from the recommendation module.
+This event tracks when a product is bought.
 
-Required data:
-
-- **Product code** - defines the product code added to the cart.
-- **Context** - provides optional data, like `moduleName` or `redirectUrl`, to provide context for the event.
-
-Example:
+- **Product object** defines the product being purchased.
+- **Context array with purchase conditions** - provide optional data about the product purchase context, like quantity, price, or currency.
 
 ``` html+twig
-[[= include_file('code_samples/recommendations/events/itemclicked_event.html.twig') =]]
+[[= include_file('code_samples/recommendations/events/buy_event.html.twig') =]]
 ```
 
-### Basket event
+### Product `basket` event
 
 This event tracks when a product is added to the [cart](cart.md).
 
@@ -136,6 +132,21 @@ Example:
 
 ``` html+twig
 [[= include_file('code_samples/recommendations/events/basket_event.html.twig') =]]
+```
+
+### `itemclicked` event
+
+This event tracks when a user clicks a Raptor recommendation, including adding products to the cart from the recommendation module.
+
+Required data:
+
+- **Product code** - defines the product code added to the cart.
+- **Context** - provides optional data, like `moduleName` or `redirectUrl`, to provide context for the event.
+
+Example:
+
+``` html+twig
+[[= include_file('code_samples/recommendations/events/itemclicked_event.html.twig') =]]
 ```
 
 ### `context` parameter - example usage


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

After test, Raptor tracking event `buy` can be used.
- Rm caution block from PHP API
- Twig `ibexa_tracking_track_event`
    - Add `buy` event case
    - Sort events in the same order than PHP API: move `itemclicked` at bottom as it's a very particular one.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
