### PR TITLE
Replace ddev get with ddev add-on get

### DIFF
--- a/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
@@ -67,7 +67,7 @@ fi
 cp vendor/ibexa/http-cache/docs/varnish/vcl/$vcl_file .ddev/varnish/
 ddev dotenv set .ddev/.env.varnish --varnish-docker-image=varnish:$VARNISH_VERSION --varnish-varnishd-params " -p $vcl_path=/etc/varnish -f /etc/varnish/$vcl_file"
 
-ddev get ddev/ddev-varnish
+ddev add-on get ddev/ddev-varnish
 
 ddev config --web-environment-add HTTPCACHE_PURGE_SERVER=http://varnish
 ddev config --web-environment-add HTTPCACHE_PURGE_TYPE=varnish


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | 5.0, 4.6
| Edition       | <!-- Content/Headless, Experience, Commerce -->

`Command "get" is deprecated, use 'ddev add-on get' instead`

Fixed once in #2645 but then a deprecated one was added in #2999 😓

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
