### PR TITLE
Markdownlint: more rules vol. 2

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -54,6 +54,7 @@ config:
 #   indent: 4
 # no-trailing-spaces: true
 # no-multiple-blanks: true
+  no-multiple-blanks: true
 # commands-show-output: true
 
 ignores:

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -55,7 +55,7 @@ config:
 # no-trailing-spaces: true
 # no-multiple-blanks: true
   no-multiple-blanks: true
-# commands-show-output: true
+  commands-show-output: true
 
 ignores:
   - "docs/snippets/**"

--- a/code_samples/templates/field_twig_functions/render_content.html.twig
+++ b/code_samples/templates/field_twig_functions/render_content.html.twig
@@ -1,0 +1,9 @@
+{{ ibexa_render_field(content, 'title') }}
+
+{{ ibexa_render_field(content, 'image', {
+    'template': '@ibexadesign/fields/image.html.twig',
+    'attr': {class: 'thumbnail-image'},
+    'parameters': {
+        'alias': 'small'
+    }
+}) }}

--- a/code_samples/templates/field_twig_functions/render_product.html.twig
+++ b/code_samples/templates/field_twig_functions/render_product.html.twig
@@ -1,0 +1,9 @@
+{{ ibexa_render_field(product, 'name') }}
+
+{{ ibexa_render_field(product, 'image', {
+    'template': '@ibexadesign/fields/image.html.twig',
+    'attr': {class: 'thumbnail-image'},
+    'parameters': {
+        'alias': 'small'
+    }
+}) }}

--- a/docs/administration/back_office/back_office_elements/extending_thumbnails.md
+++ b/docs/administration/back_office/back_office_elements/extending_thumbnails.md
@@ -60,7 +60,6 @@ At this point you can go to the back office and check the results.
     This strategy overrides all generated thumbnails. You can specify a specific content type.
     See the example [here](https://github.com/ibexa/user/blob/5.0/src/lib/Strategy/DefaultThumbnailStrategy.php)
 
-
 ## Other fields as thumbnails
 
 Any field type can generate a thumbnail, for example:

--- a/docs/administration/back_office/back_office_elements/reusable_components.md
+++ b/docs/administration/back_office/back_office_elements/reusable_components.md
@@ -135,7 +135,6 @@ The table component consists of the following blocks:
 - `thead` - table header content
 - `tbody` - table body content
 
-
 ### Override specific cell
 
 For the `twig` table component to have full control over rendering the rows of specific cells, only data are passed to it.
@@ -250,7 +249,6 @@ See the example:
 ```
 
 - `empty_table_info_text` and `empty_table_action_text` specify texts which are displayed when the table is empty.
-
 
 ```html+twig
 {{ form_start(form_remove, {

--- a/docs/administration/back_office/content_tab_switcher.md
+++ b/docs/administration/back_office/content_tab_switcher.md
@@ -33,7 +33,6 @@ ibexa:
 
 ![Meta tab](tab_switcher.png)
 
-
 ### Configure field groups for Meta tab
 
 The default configuration makes the `ibexa_taxonomy_entry_assignment` field always visible in the Meta tab in the content form.
@@ -65,7 +64,6 @@ ibexa:
                 content_edit:
                     meta_field_groups_list: []
 ```
-
 
 The `meta_field_groups_list` configuration can be overridden.
 

--- a/docs/administration/project_organization/bundles.md
+++ b/docs/administration/project_organization/bundles.md
@@ -116,7 +116,6 @@ To remove a bundle (either one you created yourself, or an out-of-the-box one th
 |ibexa/site-factory|Enables configuration of sites from UI|
 |ibexa/engage|Enables integration with [Qualifio Engage platform](https://developers.qualifio.com/docs/engage/)|
 
-
 ## [[= product_name_com =]] packages
 
 |Bundle|Description|

--- a/docs/ai/ai_actions/extend_ai_actions.md
+++ b/docs/ai/ai_actions/extend_ai_actions.md
@@ -152,7 +152,6 @@ The Action Handler and Action Type options are rendered in the back office using
 
 ![Custom Action Handler options rendered using the default Twig options formatter](img/action_handler_options.png "Custom Action Handler options rendered using the default Twig options formatter")
 
-
 You can create your own formatting by creating a class implementing the [OptionsFormatterInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionConfiguration-OptionsFormatterInterface.html) interface and aliasing it to `Ibexa\Contracts\ConnectorAi\ActionConfiguration\OptionsFormatterInterface`.
 
 The following service definition switches the options rendering to the other built-in options formatter, displaying the options as JSON.
@@ -288,7 +287,6 @@ The resolver is activated when `application/vnd.ibexa.api.ai.AudioText` media ty
 
 - A visitor converting the response value object into a serialized REST response:
 
-
 ``` php
 [[= include_code('code_samples/ai_actions/src/AI/REST/Output/ValueObjectVisitor/AudioText.php') =]]
 ```
@@ -324,7 +322,6 @@ The last step in fully integrating the Transcribe Audio Action Type embeds it di
 
 Extend the default editing template of the `ibexa_binaryfile` fieldtype by creating a new file called `templates/themes/admin/admin/ui/fieldtype/edit/form_fields_binary_ai.html.twig`.
 This template embeds the AI component, but only if a dedicated `transcript` field (of `ibexa_text` type) is available in the same content type to store the content of the transcription.
-
 
 ``` twig
 [[= include_file('code_samples/ai_actions/templates/themes/admin/admin/ui/fieldtype/edit/form_fields_binary_ai.html.twig') =]]

--- a/docs/ai/mcp/mcp_guide.md
+++ b/docs/ai/mcp/mcp_guide.md
@@ -6,7 +6,6 @@ month_change: true
 
 # MCP Servers product guide
 
-
 ## What is MCP Servers
 
 MCP ([Model Context Protocol](https://modelcontextprotocol.io/docs/getting-started/intro)) is a protocol that standardizes how AI systems interact with external systems.

--- a/docs/api/graphql/graphql.md
+++ b/docs/api/graphql/graphql.md
@@ -114,7 +114,6 @@ mutation CreateToken {
 
 ![GraphiQL with a JWT token request and its response](jwt-graphiql.png "GraphiQL JWT token request and response")
 
-
 ## Usage
 
 You can access GraphQL with `<yourdomain>/graphql`.

--- a/docs/api/notification_channels.md
+++ b/docs/api/notification_channels.md
@@ -266,7 +266,6 @@ Visiting the controller's route in the default SiteAccess on Commerce edition (a
 
 ![Notification in storefront](notification-browser-storefront.png "Controller message displayed as a flash message in the browser")
 
-
 ## Create custom channel
 
 You may need to create new channels to subscribe to notifications and send them to new destinations.

--- a/docs/api/php_api/php_api.md
+++ b/docs/api/php_api/php_api.md
@@ -81,7 +81,6 @@ For instance, `ContentInfo` contains `currentVersionNo` or `remoteId`, while `Co
 
     Serialization of value objects, for example, `Ibexa\Contracts\Core\Repository\Values\Content\ContentInfo` /  `Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo` or `Ibexa\Contracts\Core\Repository\Values\Content\Location` results in memory limit exceeded error.
 
-
 ## Authentication
 
 One of the responsibilities of the repository is user authentication.

--- a/docs/commerce/payment/payum_integration.md
+++ b/docs/commerce/payment/payum_integration.md
@@ -73,7 +73,6 @@ When you implement the online payment solution, take the following consideration
 - When you modify the payment process, you may need to subscribe to events dispatched by Payum.
 For a list of events, see [Event dispatcher](https://github.com/Payum/Payum/blob/master/docs/event-dispatcher.md) in Payum documentation.
 
-
 !!! caution
 
     In certain cases, depending on the payment processing service, when a customer closes the payment page in a browser and the bank has not processed the payment yet, the payment status can remain unchanged.

--- a/docs/commerce/shipping_management/shipment_api.md
+++ b/docs/commerce/shipping_management/shipment_api.md
@@ -58,7 +58,6 @@ To update shipment information, use the `ShipmentService::updateShipment` method
 
 To delete a shipment from the system, use the `ShipmentService::deleteShipment` method:
 
-
 ``` php
 [[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 119, 119, remove_indent=True) =]]
 ```

--- a/docs/commerce/storefront/configure_storefront.md
+++ b/docs/commerce/storefront/configure_storefront.md
@@ -39,7 +39,6 @@ ibexa:
 
 3\. Specific catalog for the defined customer group
 
-
 You can expose different catalogs based on a customer group assigned to the current user.
 
 To do it, provide the following configuration:
@@ -63,7 +62,6 @@ The basic configuration of the Storefront can look as follows:
 ```
 
 ## Retrieve catalog assigned to user
-
 
 The `\Ibexa\Contracts\Storefront\Repository\CatalogResolverInterface` interface allows retrieving the product catalog available for a specific user.
 

--- a/docs/commerce/transactional_emails/transactional_emails.md
+++ b/docs/commerce/transactional_emails/transactional_emails.md
@@ -59,7 +59,6 @@ ibexa:
                 entity: <entity_name>
 ```
 
-
 4\. Define profile table in Actito database for storing notification attributes.
 
 !!! note
@@ -79,10 +78,8 @@ For a complete list of parameters, see [Transactional email variables reference]
 
     When you invent names for your campaigns, keep them simple, and don't use special characters or spaces.
 
-
 Campaign emails can be sent in one language only.
 To send emails in different languages, for example, because your application serves end-users from different locales, for each notification and language pair, you must create a separate campaign and [extend the solution to support that](extend_transactional_emails.md#send-emails-in-language-of-commerce-presence).
-
 
 ### Configure mapping
 

--- a/docs/content_management/collaborative_editing/configure_collaborative_editing.md
+++ b/docs/content_management/collaborative_editing/configure_collaborative_editing.md
@@ -95,7 +95,6 @@ The following settings are available:
 - session:
     - `public_link_enabled` - determines whether the public link is available, default value: `false`, available values: `true`, `false`
 
-
 #### `ibexa/share` configuration
 
 To share content model, you need to configure the `ibexa/share` package.

--- a/docs/content_management/content_api/managing_content.md
+++ b/docs/content_management/content_api/managing_content.md
@@ -195,7 +195,6 @@ When constructing a `ContentTypeQuery`, you can pass the following parameters:
 
 - `int $limit = 25` — maximum number of results to return
 
-
 ## Calendar events
 
 You can handle the calendar using `CalendarServiceInterface` (`Ibexa\Contracts\Calendar\CalendarServiceInterface`).

--- a/docs/content_management/data_migration/importing_data.md
+++ b/docs/content_management/data_migration/importing_data.md
@@ -574,7 +574,6 @@ If the content type associated with the tags is changed, the configuration shoul
 !!! note
     If there are multiple taxonomies, the `taxonomy` field is then necessary here (line 21).
 
-
 You can use the following example to assign tags to a Content (content type Article has an additional field):
 
 ``` yaml

--- a/docs/content_management/field_types/field_type_storage.md
+++ b/docs/content_management/field_types/field_type_storage.md
@@ -170,7 +170,6 @@ services:
 
 The `ibexa.api.storage_engine.legacy.connection` is of type `Doctrine\DBAL\Connection`. If your gateway still uses an implementation of `eZ\Publish\Core\Persistence\Database\DatabaseHandler` (`eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler`), instead of the `ibexa.api.storage_engine.legacy.connection`, you can pass the `ibexa.api.storage_engine.legacy.dbhandler` service.
 
-
 Also there can be several gateways per field type (one per storage engine).
 In this case it's recommended to either create base implementation which each gateway can inherit or create interface which each gateway must implement and reference it instead of specific implementation when type-hinting method arguments.
 

--- a/docs/content_management/field_types/form_and_template.md
+++ b/docs/content_management/field_types/form_and_template.md
@@ -131,7 +131,6 @@ you need to define a template containing a block for the field.
 
 By convention, your block must be named `<fieldTypeIdentifier>_field`.
 
-
 !!! tip
 
     Template blocks for built-in field types are available in [`Core/Resources/views/content_fields.html.twig`](https://github.com/ibexa/core/blob/5.0/src/bundle/Core/Resources/views/content_fields.html.twig).

--- a/docs/content_management/file_management/file_management.md
+++ b/docs/content_management/file_management/file_management.md
@@ -91,7 +91,6 @@ Default values:
                     service: ibexa.io.nfs.adapter.site_access_aware
     ```
 
-
 ### Native Flysystem v2 handler
 
 [[= product_name =]] uses it as the default way to read and write content in form of binary files.

--- a/docs/content_management/images/add_image_asset_from_dam.md
+++ b/docs/content_management/images/add_image_asset_from_dam.md
@@ -160,7 +160,6 @@ The `commons_search_tab` service uses the `GenericSearchTab` class as a base, an
 It is linked to the `commons` DAM source and uses the identifier `commons`. 
 The DAM search tab is registered in the `connector-dam-search` [tab group](back_office_tabs.md#tab-groups) using the `ibexa.admin_ui.tab` tag.
 
-
 ```yaml
 [[= include_file('code_samples/back_office/images/config/services.yaml', 22, 33) =]]
 ```

--- a/docs/content_management/rich_text/create_custom_richtext_block.md
+++ b/docs/content_management/rich_text/create_custom_richtext_block.md
@@ -29,7 +29,6 @@ In line 32, `my_block` is the same name of the block that you defined in line 3 
 Line 32 also implements the `PreRender` method.
 Lines 41-51 handle the conversion of content into an XML string:
 
-
 ``` php hl_lines="32 41 42 43 44 45 46 47 48 49 50 51"
 [[= include_code('code_samples/back_office/online_editor/src/event/subscriber/RichTextBlockSubscriber.php') =]]
 ```
@@ -64,7 +63,6 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 ```
-
 
 You have successfully created a custom RichText block.
 You can now add your block in the **Site** tab.

--- a/docs/content_management/url_management/url_management.md
+++ b/docs/content_management/url_management/url_management.md
@@ -20,7 +20,6 @@ Edit the entry to update the URL address in all the occurrences throughout the w
 
     When you edit the details of an entry to update the URL address, the status automatically changes to valid.
 
-
 ## External URL validation
 
 You can validate all the addresses from the URL table by executing the `ibexa:check-urls` command.
@@ -203,7 +202,6 @@ Use it when:
 
     Before you apply the command, back up your database and make sure it's not modified while the command is running.
 
-
 Execute the following command to regenerate aliases:
 
 ``` bash
@@ -244,7 +242,6 @@ The **URL wildcards** tab contains all the information about each URL wildcard. 
 
     To be able to modify wildcard support settings in the user interface, you must have the `content/urltranslator` policy.
     For more information about permissions, see [Permissions](permissions.md).
-
 
 ### Configuring URL wildcards with the public PHP API
 

--- a/docs/customer_management/cp_configuration.md
+++ b/docs/customer_management/cp_configuration.md
@@ -56,7 +56,6 @@ ibexa_corporate_account:
 
     If you decide to change deafult names of content types, during migration you have to adjust files accordingly.
 
-
 ## Registration
 
 You can define what fields are required in the Customer Portal registration form.

--- a/docs/getting_started/install_with_ddev.md
+++ b/docs/getting_started/install_with_ddev.md
@@ -211,7 +211,6 @@ DDEV offers several ways to get the same result, offering different levels of fl
 
     Learn more about DDEV configuration from [`ddev config` command documentation](https://docs.ddev.com/en/stable/users/usage/commands/#config) and [advanced configuration files documentation](https://docs.ddev.com/en/stable/users/configuration/config/).
 
-
 ### Using `auth.json`
 
 An `auth.json` file can be used for one project, or globally for all projects, with the [DDEV `homeaddition` feature](https://docs.ddev.com/en/stable/users/extend/in-container-configuration/).

--- a/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
@@ -288,7 +288,6 @@ In the event when a new version of `Child` is published, the following keys are 
 In summary, HTTP Cache for any location representing `[Child]`, any Content that relates to the Content `[Child]`, the location for `[Child]`, any children of `[Child]`, any location that relates to the location `[Child]`, location for `[Parent1]`, any children on `[Parent1]`.
 Effectively, in this example HTTP cache for `[Parent1]` and `[Child]` is cleared.
 
-
 ### Tags purged on move event
 
 With the same content structure as above, the `[Child]` location is moved below `[Parent2]`.

--- a/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
@@ -433,7 +433,7 @@ To simulate the requests the HTTP cache sends to [[= product_name =]], you need 
 To obtain it, use `curl`.
 
 ```bash
-    $ curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "accept: application/vnd.fos.user-context-hash" --header "x-fos-original-url: /" https://www.staging.foobar.com.us-2.platformsh.site/_fos_user_context_hash
+curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "accept: application/vnd.fos.user-context-hash" --header "x-fos-original-url: /" https://www.staging.foobar.com.us-2.platformsh.site/_fos_user_context_hash
 ```
 
 Some notes about each of these parameters:
@@ -476,7 +476,7 @@ The header `X-User-Context-Hash` is the one of the interest here, but you may al
 Now you have the user-context-hash, and you can ask origin for the actual resource you're after:
 
 ```bash
-    $ curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" https://www.staging.foobar.com.us-2.platformsh.site/
+curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" https://www.staging.foobar.com.us-2.platformsh.site/
 ```
 
 The output :
@@ -510,7 +510,7 @@ So, first let's see if there are any ESIs here.
 We remove the `-IXGET` options (to see content of the response, not only headers) to curl and search for esi:
 
 ```bash
-    $ curl --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" https://www.staging.foobar.com.us-2.platformsh.site/ | grep esi
+curl --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" https://www.staging.foobar.com.us-2.platformsh.site/ | grep esi
 ```
 
 The output is:
@@ -527,7 +527,7 @@ It's important to put that URL in single quotes as the URLS to the ESIs include 
 #### 1st&nbsp;ESI
 
 ```bash
-    $ curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" 'https://www.staging.foobar.com.us-2.platformsh.site/_fragment?_hash=B%2BLUWB2kxTCc6nc5aEEn0eEqBSFar%2Br6jNm8fvSKdWU%3D&_path=locationId%3D2%26contentId%3D52%26blockId%3D11%26versionNo%3D3%26languageCode%3Deng-GB%26serialized_siteaccess%3D%257B%2522name%2522%253A%2522site%2522%252C%2522matchingType%2522%253A%2522default%2522%252C%2522matcher%2522%253Anull%252C%2522provider%2522%253Anull%257D%26serialized_siteaccess_matcher%3Dnull%26_format%3Dhtml%26_locale%3Den_GB%26_controller%3DEzSystems%255CEzPlatformPageFieldTypeBundle%255CController%255CBlockController%253A%253ArenderAction'
+curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" 'https://www.staging.foobar.com.us-2.platformsh.site/_fragment?_hash=B%2BLUWB2kxTCc6nc5aEEn0eEqBSFar%2Br6jNm8fvSKdWU%3D&_path=locationId%3D2%26contentId%3D52%26blockId%3D11%26versionNo%3D3%26languageCode%3Deng-GB%26serialized_siteaccess%3D%257B%2522name%2522%253A%2522site%2522%252C%2522matchingType%2522%253A%2522default%2522%252C%2522matcher%2522%253Anull%252C%2522provider%2522%253Anull%257D%26serialized_siteaccess_matcher%3Dnull%26_format%3Dhtml%26_locale%3Den_GB%26_controller%3DEzSystems%255CEzPlatformPageFieldTypeBundle%255CController%255CBlockController%253A%253ArenderAction'
 ```
 
 This ESI is handled by a controller in the `FieldTypePage` bundle provided by [[= product_name =]].
@@ -555,7 +555,7 @@ The second ESI has a similar response.
 #### 3rd&nbsp;ESI
 
 ```bash
-    $ curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" 'https://www.staging.foobar.com.us-2.platformsh.site//_fragment?_hash=lnKTnmv6bb1XpaMPWRjV3sNazbn9rDXskhjGae1BDw8%3D&_path=locationId%3D2%26contentId%3D52%26blockId%3D13%26versionNo%3D3%26languageCode%3Deng-GB%26serialized_siteaccess%3D%257B%2522name%2522%253A%2522site%2522%252C%2522matchingType%2522%253A%2522default%2522%252C%2522matcher%2522%253Anull%252C%2522provider%2522%253Anull%257D%26serialized_siteaccess_matcher%3Dnull%26_format%3Dhtml%26_locale%3Den_GB%26_controller%3DEzSystems%255CCustomBundle%255CController%255CFooController%253A%253AcustomAction'
+curl -IXGET --resolve www.staging.foobar.com.us-2.platformsh.site:443:1.2.3.4 --header "Surrogate-Capability: abc=ESI/1.0" --header "x-user-context-hash: daea248406c0043e62997b37292bf93a8c91434e8661484983408897acd93814" 'https://www.staging.foobar.com.us-2.platformsh.site//_fragment?_hash=lnKTnmv6bb1XpaMPWRjV3sNazbn9rDXskhjGae1BDw8%3D&_path=locationId%3D2%26contentId%3D52%26blockId%3D13%26versionNo%3D3%26languageCode%3Deng-GB%26serialized_siteaccess%3D%257B%2522name%2522%253A%2522site%2522%252C%2522matchingType%2522%253A%2522default%2522%252C%2522matcher%2522%253Anull%252C%2522provider%2522%253Anull%257D%26serialized_siteaccess_matcher%3Dnull%26_format%3Dhtml%26_locale%3Den_GB%26_controller%3DEzSystems%255CCustomBundle%255CController%255CFooController%253A%253AcustomAction'
 ```
 
 This ESI is handled by a custom `FooController::customAction` and the output of the command is:

--- a/docs/infrastructure_and_maintenance/cache/http_cache/fastly.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/fastly.md
@@ -372,7 +372,6 @@ Last edited (UTC): 2023-07-03 10:33
 
 In the example above, the ID is `ltC6Rg4pqw4qaNKF5tEW`.
 
-
 ### Create record in dictionary
 
 Add username and password to the dictionary:

--- a/docs/infrastructure_and_maintenance/clustering/clustering.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering.md
@@ -189,7 +189,6 @@ ibexa:
                 binarydata_handler: nfs
 ```
 
-
 !!! tip
 
     If you're looking to [set up S3](clustering_with_aws_s3.md) or other [Flysystem](https://flysystem.thephpleague.com/docs/)/third-party adapters like Google Cloud Storage, this needs to be configured as binary handler.

--- a/docs/infrastructure_and_maintenance/request_lifecycle.md
+++ b/docs/infrastructure_and_maintenance/request_lifecycle.md
@@ -4,7 +4,6 @@ description: See the lifecycle of an HTTP request in Ibexa DXP, from request to 
 
 # Request lifecycle: from request to response
 
-
 ## Beginning of HTTP request
 
 When entering the server infrastructure, the HTTP request can be handled by several component such as a firewall, a load balancer, or a reverse proxy before arriving on the web server itself.
@@ -22,7 +21,6 @@ The front controller transforms the HTTP request into a PHP [`Request` object]([
 
 The schemas start with a regular `Request` object from a browser that enters Symfony and [[= product_name =]].
 There is no ESI, no REST, and no GraphQL request performed.
-
 
 ## Lifecycle flowcharts
 
@@ -59,7 +57,6 @@ This schema is described below event by event.
     ```bash
     php bin/console debug:container --tag=router
     ```
-
 
 ## Kernel's request event
 
@@ -122,7 +119,6 @@ The `locale_listener` (priority 16) sets the request's **`_locale`** attribute.
 
 Now, when the `Request` knows its controller, the `HttpKernel` dispatches the `kernel.controller` event.
 
-
 ## Kernel's controller event
 
 ### View building and matching
@@ -150,7 +146,6 @@ The `ViewControllerListener` eventually updates the request's `_controller` attr
 
 The `HttpKernel` then dispatches a `kernel.controller_arguments` (`KernelEvents::CONTROLLER_ARGUMENTS`) but nothing from [[= product_name =]] is listening to it.
 
-
 ## Controller execution
 
 The `HttpKernel` extracts from the request the controller and the arguments to pass to the controller.
@@ -167,14 +162,12 @@ As a reminder, the controller and its argument can be:
 
     See [Permissions for custom controller](permission_overview.md#permissions-for-custom-controllers).
 
-
 ## Kernel's view event and `ContentView` rendering
 
 If the controller returns something other than `Response`, the `HttpKernel` dispatches a `kernel.view` event (`KernelEvents::VIEW`).
 In the case of a URL Alias, the controller most likely returns a ContentView.
 The `ViewRendererListener` (`Ibexa\Bundle\Core\EventListener\ViewRendererListener`) uses the `ContentView` and the `TemplateRenderer` (`Ibexa\Core\MVC\Symfony\View\Renderer\TemplateRenderer`) to get the content of the `Response` and attach this new `Response` to the event.
 The `HttpKernel` retrieves the response attached to the event and continues.
-
 
 ## Summary
 
@@ -230,7 +223,6 @@ The `HttpKernel` retrieves the response attached to the event and continues.
 | kernel.controller                 | Ibexa\Bundle\Core\EventListener\ViewControllerListener | _controller              | ibexa_content::viewAction                  |
 | (controller execution)            | http_kernel                                            |                          | ContentView                                |
 | kernel.view                       | Ibexa\Bundle\Core\EventListener\ViewRendererListener   | response                 | Response                                   |
-
 
 ## End of HTTP response
 

--- a/docs/infrastructure_and_maintenance/security/development_security.md
+++ b/docs/infrastructure_and_maintenance/security/development_security.md
@@ -166,7 +166,6 @@ Out of the box, JWT tokens are created by using HMAC (Hash-based Message Authent
 
 You can use PEM (Privacy-enhanced Electronic Mail) keys and the `RS256` (RSA-SHA256) algorithm instead.
 
-
 1. Set the `JWT_PASSPHRASE` secret
 
 In an `.env` file, you should have the following variables:

--- a/docs/multisite/multisite.md
+++ b/docs/multisite/multisite.md
@@ -9,7 +9,6 @@ A multisite setup enables you to create more than one site in one installation o
 
 Multisite configuration is done using [SiteAccesses](siteaccess.md).
 
-
 To quickly set up new sites with predefined site templates, use [Site Factory](site_factory.md).
 
 [[= cards([

--- a/docs/permissions/limitation_reference.md
+++ b/docs/permissions/limitation_reference.md
@@ -391,7 +391,6 @@ The supported policies are:
 |------|------|------|
 |Taxonomy identifiers|Taxonomy names|List of allowed taxonomies|
 
-
 ## Taxonomy Subtree limitation
 
 The taxonomy subtree (`TaxonomySubtree`) limitation specifies whether the user has access to a specific subtree within the [taxonomy](taxonomy.md) tree.

--- a/docs/permissions/permissions.md
+++ b/docs/permissions/permissions.md
@@ -13,4 +13,3 @@ The permission system of [[= product_name =]] enables you to control in detail w
     "permissions/permission_use_cases",
     "permissions/limitations",
 ], columns=4) =]]
-

--- a/docs/permissions/policies.md
+++ b/docs/permissions/policies.md
@@ -134,7 +134,6 @@ The [discount](discounts.md) policies decide which actions can be executed by gi
     Customers don't need any policies to use the discounts on the [storefront](storefront.md).
     Even the `discount/view` policy would allow them to access all the discount details, including the coupon codes to activate them, which could lead to system abuse.
 
-
 | Module               | Function                 | Effect                      | Possible limitations                                         |
 |----------------------|--------------------------|-----------------------------|----------------------------------------------------|
 | <nobr>`discount`</nobr> | <nobr>`create`</nobr> | create a discount           | [DiscountOwner](limitation_reference.md#discount-owner-limitation) |
@@ -249,7 +248,6 @@ The [discount](discounts.md) policies decide which actions can be executed by gi
 |----------------------|-----------------------|--------------------------------------------------------------------------|----------------------|
 | <nobr>`content`</nobr> | <nobr>`share`</nobr> | share content drafts with internal and external users through [collaborative editing](collaborative_editing.md)    |[Owner](limitation_reference.md#collaborative-editing-owner-limitation)</br>[PublicLink](limitation_reference.md#collaborative-editing-publiclink-limitation)</br>[Scope](limitation_reference.md#collaborative-editing-scope-limitation) |
 | <nobr>`rte`</nobr> | <nobr>`edit`</nobr> | use [Real-time editing](collaborative_editing_guide.md#real-time-editing)    |
-
 
 #### Content types
 

--- a/docs/personalization/api_reference/user_api.md
+++ b/docs/personalization/api_reference/user_api.md
@@ -68,7 +68,6 @@ For example:
 |---------------------|-------------------------|---------------------------|
 | `Customer<12.2014>` | `Customer%3C12.2014%3E` | `Customer&lt;12.2014&gt;` |
 
-
 ## DELETE request
 
 Use the following request to run an opt-out option to delete the user and all data related to this user. After this request, the user is deleted from the database.

--- a/docs/personalization/attribute_search_in_elasticsearch.md
+++ b/docs/personalization/attribute_search_in_elasticsearch.md
@@ -22,7 +22,6 @@ ibexa:
                         title: <item_name>
 ```
 
-
 See the example:
 
 ```yaml

--- a/docs/personalization/enable_personalization.md
+++ b/docs/personalization/enable_personalization.md
@@ -163,7 +163,6 @@ The `BEARER_TOKEN` is the newest one in `ibexa_token` table having `type=1` and 
 
 You can use this token to check what is provided to the Personalization Engine:
 
-
 ```bash
 curl --location '{PERSONALIZATION_HOST_URI}/api/ibexa/v2/personalization/v1/content/id/{contentId}?lang={comma_separated_languages}' \
 --header 'Accept: application/vnd.ibexa.api.Content+json' \

--- a/docs/personalization/personalization.md
+++ b/docs/personalization/personalization.md
@@ -23,8 +23,3 @@ To provide online recommendations, the service must at least:
     "personalization/integrate_recommendation_service",
     "personalization/api_reference/api_reference",
 ], columns=3) =]]
-
-
-
-
-

--- a/docs/personalization/personalization_guide.md
+++ b/docs/personalization/personalization_guide.md
@@ -24,9 +24,7 @@ Now, you can start collecting data and boost your business.
 
 ## How does Personalization work
 
-
 ![How it works](how_perso_works.png)
-
 
 Personalization with tracking scripts, monitors  individual sessions from user’s behavior and interest data through events (clicks, viewed articles, pages, purchases) and demographic data (location, industry, occupation).
 
@@ -58,7 +56,6 @@ Personalization service includes the following model types:
 
 ![Structure](categories.png)
 
-
 ### Scenarios
 
 Scenarios are sequences of events.
@@ -73,7 +70,6 @@ Segments calculate models based on the segment attribute factor. Assign users to
 ![Segments](perso_segment_group_or.png)
 
 ![Recommendations](recommendations.png)
-
 
 ### REST API
 
@@ -120,7 +116,6 @@ Apply collaborative models with predictive analysis and find out what motivates 
 Start building predictions of their behaviors and suggest items, products your visitors are willing to buy.
 
 ![Dashboard](perso_dashboard_revenue.png)
-
 
 ### Measure your return and boost conversion rates
 

--- a/docs/product_catalog/add_remote_pim_support.md
+++ b/docs/product_catalog/add_remote_pim_support.md
@@ -63,4 +63,3 @@ Install the `ibexa/example-in-memory-product-catalog` package:
 composer config repositories.remote-pim vcs https://github.com/ibexa/example-in-memory-product-catalog
 composer require ibexa/example-in-memory-product-catalog:
 ```
-

--- a/docs/product_catalog/quable/quable_guide.md
+++ b/docs/product_catalog/quable/quable_guide.md
@@ -45,7 +45,6 @@ All product management operations remain handled in [[= pim_product_name =]].
 
 [[= pim_product_name =]] is the authoritative system for product data, including attributes, classifications, variants, and translations.
 
-
 [[= product_name =]] consumes this data and makes it available for use within content and back office interfaces, enabling editorial teams to enrich content by reusing product information.
 
 ## Use cases

--- a/docs/release_notes/ez_platform_v1.10.0.md
+++ b/docs/release_notes/ez_platform_v1.10.0.md
@@ -2,7 +2,6 @@
 
 # eZ Platform v1.10.0
 
-
 **The FAST TRACK v1.10.0 release of eZ Platform and eZ Platform Enterprise Edition is available as of June 28, 2017.**
 
 If you're looking for the Long Term Support (LTS) release, see [https://ezplatform.com/Blog/Long-Term-Support-is-Here](https://ezplatform.com/Blog/Long-Term-Support-is-Here)
@@ -18,8 +17,6 @@ This release introduces the ability to add tables in the RichText editor, enabli
 ![""](platformui-table.gif)
 
 This is a first step. We aim to provide more in terms of table support in the editor later. For the time being images and embedding aren't supported within the table, as you won't be able to move them out or edit them. We also don't provide yet ability to style the table within the editor.
-
- 
 
 #### New Design Engine
 

--- a/docs/release_notes/ez_platform_v1.7.0_lts.md
+++ b/docs/release_notes/ez_platform_v1.7.0_lts.md
@@ -2,7 +2,6 @@
 
 # eZ Platform v1.7.0 LTS
 
-
 **The v1.7.0 release of eZ Platform and eZ Platform Enterprise Edition is available as of December 15, 2016.**
 
 **<https://ezplatform.com/Blog/Long-Term-Support-is-Here>**
@@ -14,7 +13,6 @@ eZ Platform Enterprise Edition v1.7.0 is the first version of the 2017 Long Ter
 As of v1.7.0, PHP requirements have been updated to remove PHP 5.5, leaving PHP 5.6 and 7.0 as supported PHP versions.
 
 With the LTS release, the [new product naming](http://ez.no/Blog/eZ-Announces-Name-Changes-to-Product-Portfolio) takes effect: "eZ Platform" for the Open Source edition, and "eZ Platform Enterprise Edition" for subscribers.
-
 
 ## Notable Changes Since v1.6.0
 
@@ -60,8 +58,6 @@ Community members are more than welcome to contribute to the translation process
     - Add SiteAccess collector to debug toolbar
     - Make IO exceptions more user friendly
     - Make it possible to retrieve original exception when repo-&gt;commit() fails
-
- 
 
 *For more fixes and improvements scroll down for full change log.*
 

--- a/docs/release_notes/ez_platform_v1.8.0.md
+++ b/docs/release_notes/ez_platform_v1.8.0.md
@@ -58,8 +58,6 @@ If you're looking for the Long Term Support (LTS) release, see[https://ezplatfor
     - Captcha
     - File Upload
 
- 
-
 ![""](formb.png)
 
 #### Under the Hood
@@ -79,7 +77,6 @@ If you're looking for the Long Term Support (LTS) release, see[https://ezplatfor
 | [List of changes for final of eZ Platform v1.8.0 on GitHub](https://github.com/ezsystems/ezplatform/releases/tag/v1.8.0)         | [List of changes for final for eZ Platform Enterprise Edition v1.8.0 on GitHub](https://github.com/ezsystems/ezplatform-ee/releases/tag/v1.8.0)       |
 | [List of changes for rc1 of eZ Platform v1.8.0 on GitHub](https://github.com/ezsystems/ezplatform/releases/tag/v1.8.0-rc1)         | [List of changes for rc1 for eZ Platform Enterprise Edition v1.8.0 on GitHub](https://github.com/ezsystems/ezplatform-ee/releases/tag/v1.8.0-rc1)       |
 | [List of changes for beta1 of eZ Platform v1.8.0 on GitHub](https://github.com/ezsystems/ezplatform/releases/tag/v1.8.0-beta1)         | [List of changes for beta2 of eZ Platform Enterprise Edition v1.8.0 on GitHub](https://github.com/ezsystems/ezplatform-ee/releases/tag/v1.8.0-beta2)       |
-
 
 ### Installation
 

--- a/docs/release_notes/ez_platform_v1.9.0.md
+++ b/docs/release_notes/ez_platform_v1.9.0.md
@@ -2,11 +2,9 @@
 
 # eZ Platform v1.9.0
 
-
 **The FAST TRACK v1.9.0 release of eZ Platform and eZ Platform Enterprise Edition is available as of April 19, 2017.**
 
 If you're looking for the Long Term Support (LTS) release, see[https://ezplatform.com/Blog/Long-Term-Support-is-Here](https://ezplatform.com/Blog/Long-Term-Support-is-Here)
-
 
 ## Notable changes since v1.8.0
 
@@ -69,7 +67,6 @@ The eZ Enterprise Demo now uses the [Netgen Tags bundle](https://github.com/netg
 | [List of changes for final of eZ Platform v1.9.0 on GitHub](https://github.com/ezsystems/ezplatform/releases/tag/v1.9.0)         | [List of changes for final for eZ Platform Enterprise Edition v1.9.0 on GitHub](https://github.com/ezsystems/ezplatform-ee/releases/tag/v1.9.0)       |
 | [List of changes for rc1 of eZ Platform v1.9.0 on GitHub](https://github.com/ezsystems/ezplatform/releases/tag/v1.9.0-rc1)         | [List of changes for rc1 for eZ Platform Enterprise Edition v1.9.0 on GitHub](https://github.com/ezsystems/ezplatform-ee/releases/tag/v1.9.0-rc1)       |
 | [List of changes for beta2 of eZ Platform v1.9.0 on GitHub](https://github.com/ezsystems/ezplatform/releases/tag/v1.9.0-beta2)         | [List of changes for beta1 of eZ Platform Enterprise Edition v1.9.0 on GitHub](https://github.com/ezsystems/ezplatform-ee/releases/tag/v1.9.0-beta1)       |
-
 
 ### Installation
 

--- a/docs/release_notes/ez_platform_v2.5.md
+++ b/docs/release_notes/ez_platform_v2.5.md
@@ -124,7 +124,6 @@ This release introduced several back office improvements to facilitate editorial
 - Responsive Sub-items table with selectable column layout
 - Simpler assigning of object states to content
 
-
 ![Back office improvements](2.5_back_office_improvements.png)
 
 ### Permissions
@@ -246,7 +245,6 @@ This section provides a list of deprecated features to be removed in eZ Platform
 - The `\EzSystems\PlatformInstallerBundle\Installer\CleanInstaller` class and its [service container](https://doc.ibexa.co/en/2.5/api/service_container) definition (`ezplatform.installer.clean_installer`) have been deprecated in favor of `EzSystems\PlatformInstallerBundle\Installer\CoreInstaller` which requires the [Doctrine Schema Bundle](https://github.com/ezsystems/doctrine-dbal-schema) to be enabled.
 - The `ezplatform.installer.db_based_installer` service container definition has been deprecated in favor of its FQCN-named equivalent (`EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller`).
 - `vendor/ezsystems/ezpublish-kernel/data/mysql/schema.sql` has been deprecated and isn't used by the installation process anymore.
-
 
 ## eZ Platform v2.5.6
 

--- a/docs/release_notes/ez_platform_v3.0_deprecations.md
+++ b/docs/release_notes/ez_platform_v3.0_deprecations.md
@@ -958,7 +958,6 @@ The following classes have been moved to `EzPlatformContentFormsBundle`:
 |`EzSystems\EzPlatformAdminUi\Validator\Constraints\UserPassword`|`EzSystems\EzPlatformUser\Validator\Constraints\UserPassword`|
 |`EzSystems\EzPlatformAdminUi\Validator\Constraints\UserPasswordValidator`|`EzSystems\EzPlatformUser\Validator\Constraints\UserPasswordValidator\ValidationErrorsProcessor`|
 
-
 The following methods have been moved to `EzPlatformUserBundle`:
 
 |Former method|Current method|
@@ -967,7 +966,6 @@ The following methods have been moved to `EzPlatformUserBundle`:
 |`EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory::forgotUserPassword`|`EzSystems\EzPlatformUser\Form\Factory\FormFactory::forgotUserPassword`|
 |`EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory::resetUserPassword`|`EzSystems\EzPlatformUser\Form\Factory\FormFactory::resetUserPassword`|
 |`EzSystems\EzPlatformAdminUi\Form\Factory\FormFactory::updateUserSetting`|`EzSystems\EzPlatformUser\Form\Factory\FormFactory::updateUserSetting`|
-
 
 The following classes have been moved to `EzPlatformContentFormsBundle`.
 

--- a/docs/release_notes/ibexa_dxp_v4.0_deprecations.md
+++ b/docs/release_notes/ibexa_dxp_v4.0_deprecations.md
@@ -236,7 +236,6 @@ The following Twig functions and filter have been renamed, including:
     | `unserialize` | `ibexa_commerce_unserialize` |
     | `youtube_video_id` | `ibexa_commerce_youtube_video_id` |
 
-
 ## URL Alias route name
 
 URL Alias route name has changed from `ez_urlalias` to `ibexa.url.alias`.

--- a/docs/release_notes/ibexa_dxp_v5.0.md
+++ b/docs/release_notes/ibexa_dxp_v5.0.md
@@ -748,7 +748,6 @@ The PHP API has been expanded with the following:
     - [`Ibexa\Contracts\Discounts\Value\Query\Criterion\IndexedAtCriterion`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-Value-Query-Criterion-IndexedAtCriterion.html)
     - [`Ibexa\Contracts\Discounts\Value\Query\Criterion\UpdatedAtCriterion`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-Value-Query-Criterion-UpdatedAtCriterion.html)
 
-
 ??? note "Sort clauses"
     - [`Ibexa\Contracts\Collaboration\Invitation\Query\SortClause\CreatedAt`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-Invitation-Query-SortClause-CreatedAt.html)
     - [`Ibexa\Contracts\Collaboration\Invitation\Query\SortClause\Id`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-Invitation-Query-SortClause-Id.html)

--- a/docs/release_notes/ibexa_dxp_v5.0_deprecations.md
+++ b/docs/release_notes/ibexa_dxp_v5.0_deprecations.md
@@ -142,7 +142,6 @@ Several field type identifiers have changed.
 | `ezurl`                           | `ibexa_url`                       |
 | `ezuser`                          | `ibexa_user`                      |
 
-
 ## PHP API classes and methods
 
 !!! note "[[= product_name_base =]] Rector"
@@ -607,7 +606,6 @@ In `migrations`, it makes it easier to integrate custom data types, especially w
 | `Ibexa\Migration\Generator\UserGroup\StepBuilder\Update` | `build` |
 | `Ibexa\Migration\StepExecutor\ReferenceDefinition\Resolver` | `resolve` |
 | `Ibexa\Migration\StepExecutor\ReferenceDefinition\ResolverInterface` | `resolve` |
-
 
 ??? note "Changes in `Ibexa\Migration\Generator\StepBuilder\StepFactoryInterface`"
 

--- a/docs/release_notes/release_notes.md
+++ b/docs/release_notes/release_notes.md
@@ -7,7 +7,6 @@ page_type: landing_page
 
 The latest stable and LTS (Long Term Support) version of [[= product_name =]] is [[[= product_name =]] v5.0](ibexa_dxp_v5.0.md).
 
-
 [[= cards([
     "release_notes/ibexa_dxp_v5.0",
     "release_notes/ibexa_dxp_v4.6",

--- a/docs/resources/contributing/package_structure.md
+++ b/docs/resources/contributing/package_structure.md
@@ -75,7 +75,6 @@ class Ibexa[ProductGroup]<PackageName>Bundle // ...
 
 Examples:
 
-
 ```php
 namespace Ibexa\Bundle\Search;
 

--- a/docs/resources/contributing/report_and_follow_issues.md
+++ b/docs/resources/contributing/report_and_follow_issues.md
@@ -14,4 +14,3 @@ This ensures the issue can be quickly prioritized according to its impact.
 !!! caution "Security issues"
 
     If you discover a security issue, please don't report it through regular channels, but instead take a look at the [Security section](reporting_issues.md).
-

--- a/docs/resources/new_in_doc.md
+++ b/docs/resources/new_in_doc.md
@@ -359,7 +359,6 @@ We want to thank
 
     - [`Ibexa\Contracts\AutomatedTranslation\Exception\ClientNotConfiguredException`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-AutomatedTranslation-Exception-ClientNotConfiguredException.html)
 
-
 ## August 2025
 
 ### Security

--- a/docs/search/content_type_search_reference/content_type_sort_clauses.md
+++ b/docs/search/content_type_search_reference/content_type_sort_clauses.md
@@ -16,7 +16,6 @@ Sort Clauses are found in the [`Ibexa\Contracts\Core\Repository\Values\ContentTy
 | [Identifier](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-SortClause-Identifier.html)| Sort by content type's identifier |
 | [Name](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-Query-SortClause-Name.html)| Sort by content type's name |
 
-
 The following example shows how to use them to sort the searched content types:
 
 ```php hl_lines="34-36"

--- a/docs/search/embeddings_reference/embeddings_reference.md
+++ b/docs/search/embeddings_reference/embeddings_reference.md
@@ -93,7 +93,6 @@ These fields can be used by the search engine to perform vector similarity compa
 
 Once you create a field, subscribe to the `ContentIndexCreateEvent` indexing event that [adds the field to the index](index_custom_elasticsearch_data.md).
 
-
 - [`Ibexa\Contracts\Core\Search\FieldType\EmbeddingFieldFactory`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Search-FieldType-EmbeddingFieldFactory.html) creates dedicated search fields that store embedding vectors
 
 ## Validation

--- a/docs/search/extensibility/create_custom_aggregation.md
+++ b/docs/search/extensibility/create_custom_aggregation.md
@@ -78,7 +78,6 @@ In this example, the field is `priority_i` which exists only for locations.
 
     For content-based aggregations, use the `ibexa.search.elasticsearch.query.content.aggregation.visitor` tag.
 
-
 For the result extractor, you can use the built-in `RangeAggregationResultExtractor` and provide it with the aggregation class in the `aggregationClass` parameter.
 
 === "Solr"
@@ -182,7 +181,6 @@ Finally, register the aggregation visitor as a service.
 
     For content-based aggregations, use the `ibexa.search.elasticsearch.query.content.aggregation.visitor` tag.
 
-
 ### Create result extractor
 
 === "Solr"
@@ -212,7 +210,6 @@ Finally, register the aggregation visitor as a service.
     The `supports()` method checks whether the provided aggregation is of the supported type (in this case, your custom `PriorityRangeAggregation`).
 
     The `extract()` method converts the [raw data provided by the search engine](https://www.elastic.co/docs/explore-analyze/query-filter/aggregations) to a `RangeAggregationResult` object.
-
 
 Finally, register the result extractor as a service.
 

--- a/docs/search/search_api.md
+++ b/docs/search/search_api.md
@@ -304,7 +304,6 @@ Even though the location B is hidden, the query finds the content because both c
 - the content item has location B
 - the content item is visible (it has the visible location A)
 
-
 ## Sort results
 
 To sort the results of a query, use one of more [Sort Clauses](sort_clause_reference.md).
@@ -384,7 +383,6 @@ $query->aggregations[] = new IntegerRangeAggregation('range', 'person', 'age',
 See [Aggregation reference](aggregation_reference.md) for details of all available aggregations.
 
 ## Search with embeddings
-
 
 !!! note "Feature support"
 

--- a/docs/search/search_engines/elasticsearch/configure_elasticsearch.md
+++ b/docs/search/search_engines/elasticsearch/configure_elasticsearch.md
@@ -131,7 +131,6 @@ For more information and a list of available choices, see [Node pool](https://ww
 
     If you change the node pool settings, it's recommended that you perform load tests to check whether the change doesn't negatively impact the performance of your environment.
 
-
 ##### Number of retries
 
 The `retries` setting configures the number of attempts that [[= product_name =]] makes to connect to the nodes of the cluster before it throws an exception.

--- a/docs/templating/image_variations.md
+++ b/docs/templating/image_variations.md
@@ -75,4 +75,3 @@ In addition to [filters exposed by LiipImagineBundle](https://symfony.com/bundle
     ``` bash
     php bin/console liip:imagine:cache:remove -v
     ```
-

--- a/docs/templating/layout/customize_storefront_layout.md
+++ b/docs/templating/layout/customize_storefront_layout.md
@@ -201,7 +201,6 @@ JavaScript class:
 
 - `@ibexa-cart/src/bundle/Resources/public/js/component/summary`
 
-
 ### Minicart
 
 You could modify the minicart widget by changing its icon, title or other elements.
@@ -227,7 +226,6 @@ with parameters:
 !!! tip
 
     For templates related to product rendering, see [Customize product view](customize_product_view.md#available-templates).
-
 
 ### Summary
 

--- a/docs/templating/templates/view_matcher_reference.md
+++ b/docs/templating/templates/view_matcher_reference.md
@@ -34,7 +34,6 @@ You can use the following matchers to [match content views](template_configurati
 | [Taxonomy entry level](#taxonomy-entry-level) | Level of taxonomy entry. |
 | [Taxonomy type](#taxonomy-type) | Taxonomy type. |
 
-
 !!! tip
 
     Each matcher has a scalar value or an array of scalar values. When an array is passed, it matches on one of its values.

--- a/docs/templating/twig_function_reference/cart_twig_functions.md
+++ b/docs/templating/twig_function_reference/cart_twig_functions.md
@@ -17,4 +17,3 @@ It also eliminates products that have variants but aren't one of those variants.
 ``` html+twig
 {% set is_disabled = (is_disabled or ibexa_can_be_added_to_cart(product) == false)|default(false) %}
 ```
-

--- a/docs/templating/twig_function_reference/catalog_twig_functions.md
+++ b/docs/templating/twig_function_reference/catalog_twig_functions.md
@@ -11,7 +11,6 @@ With the catalog Twig functions you can get catalog location and render catalog 
 
 The `ibexa_get_product_catalog_root()` function gets a root location of the product catalog (configured in `ibexa_product_catalog.engines.default.type.options.root_location_remote_id`).
 
-
 ``` html+twig
 {{ ibexa_url(ibexa_get_product_catalog_root()) }}
 ```

--- a/docs/templating/twig_function_reference/field_twig_functions.md
+++ b/docs/templating/twig_function_reference/field_twig_functions.md
@@ -36,27 +36,11 @@ The field is rendered with the default template, but you can optionally pass a d
 | `params` | `hash` | (optional) Hash of parameters passed to the template block. |
 
 ``` html+twig
-{{ ibexa_render_field(content, 'title') }}
-
-{{ ibexa_render_field(content, 'image', {
-    'template': '@ibexadesign/fields/image.html.twig',
-    'attr': {class: 'thumbnail-image'},
-    'parameters': {
-        'alias': 'small'
-    }
-}) }}
+[[= include_code('code_samples/templates/field_twig_functions/render_content.html.twig') =]]
 ```
 
 ``` html+twig
-{{ ibexa_render_field(product, 'name') }}
-
-{{ ibexa_render_field(product, 'image', {
-    'template': '@ibexadesign/fields/image.html.twig',
-    'attr': {class: 'thumbnail-image'},
-    'parameters': {
-        'alias': 'small'
-    }
-}) }}
+[[= include_code('code_samples/templates/field_twig_functions/render_product.html.twig') =]]
 ```
 
 #### Parameters

--- a/docs/templating/twig_function_reference/field_twig_functions.md
+++ b/docs/templating/twig_function_reference/field_twig_functions.md
@@ -22,7 +22,6 @@ You can get additional information about a field by using the following Twig fun
 - [`ibexa_field_group_name()`](#ibexa_field_group_name) returns a human-readable name of the field group.
 - [`ibexa_has_field()`](#ibexa_has_field) checks whether a field is present in the content item.
 
-
 ## Field rendering
 
 ### `ibexa_render_field()`
@@ -144,7 +143,6 @@ If the content item doesn't have a translation in the prioritized or passed lang
 | `fieldDefIdentifier` | `string` | Identifier of the field. |
 | `forcedLanguage` | `string` | (optional) Language to use (for example, `fre-FR`). |
 
-
 ``` html+twig
 {{ ibexa_field_name(content, 'title') }}
 
@@ -223,7 +221,6 @@ For example, use `ibexa_field_is_empty()` to check whether a field is empty or f
 | Argument | Type | Description |
 |---------------|------|-------------|
 | `fieldGroupIdentifier` | `string` | Field group [identifier](repository_configuration.md#field-groups-configuration). |
-
 
 ``` html+twig
 {{ ibexa_field_group_name('content') }}

--- a/docs/templating/twig_function_reference/image_twig_functions.md
+++ b/docs/templating/twig_function_reference/image_twig_functions.md
@@ -13,7 +13,7 @@ page_type: reference
 To render images, use the [`ibexa_render_field()`](field_twig_functions.md#ibexa_render_field) Twig function with the variation name passed as an argument, for example:
 
 ``` html+twig
-[[= include_code('docs/templating/twig_function_reference/field_twig_functions.md', 42, 48) =]]
+[[= include_code('code_samples/templates/field_twig_functions/render_content.html.twig', 3, 9, remove_indent=True) =]]
 ```
 
 ## Image information

--- a/docs/templating/urls_and_routes/urls_and_routes.md
+++ b/docs/templating/urls_and_routes/urls_and_routes.md
@@ -86,7 +86,6 @@ The following built-in routes are available for the front of the website.
 
 ### Registration
 
-
 |Route name|Path|Description|
 |---|---|---|
 | `ibexa.user.user_register` | `/user/register` | User registration form |

--- a/docs/tutorials/beginner_tutorial/7_embed_content.md
+++ b/docs/tutorials/beginner_tutorial/7_embed_content.md
@@ -195,7 +195,6 @@ Add the following lines at the end of `templates/full/ride.html.twig`, before th
 
 You can now check the Ride page again to see all the connected Landmarks.
 
-
 !!! tip
 
     You can use `dump()` in Twig templates to display all available variables.

--- a/docs/update_and_migration/from_1.x_2.x/update_db_to_2.5.md
+++ b/docs/update_and_migration/from_1.x_2.x/update_db_to_2.5.md
@@ -649,7 +649,6 @@ defined in the [Enterprise Beginner tutorial](page_and_form_tutorial.md)
                 - { name: ezplatform.fieldtype.ezlandingpage.migration.attribute.converter, block_type: random }
     ```
 
-
 ### B. Update to v2.3
 
 #### Database update script
@@ -717,7 +716,6 @@ ezrichtext:
 ```
 
 The old configuration is deprecated, so if you use custom tags, you need to modify your config accordingly.
-
 
 ### D. Update to v2.5
     
@@ -895,7 +893,6 @@ Run the following SQL queries to optimize workflow performance:
 CREATE INDEX idx_workflow_co_id_ver ON ezeditorialworkflow_workflows(content_id, version_no);
 CREATE INDEX idx_workflow_name ON ezeditorialworkflow_workflows(workflow_name);
 ```
-
 
 ## 5. Finish the update
 

--- a/docs/update_and_migration/from_3.3/update_from_3.3.md
+++ b/docs/update_and_migration/from_3.3/update_from_3.3.md
@@ -331,7 +331,6 @@ composer ibexa:setup --platformsh
 Review the changes applied to `.platform.app.yaml`, `.platform/` and `bin/platformsh_prestart_cacheclear.sh`,
 merge with your custom settings if needed, and commit them to Git.
 
-
 ### v3.3.14
 
 #### VCL configuration

--- a/docs/update_and_migration/from_4.5/update_from_4.5.md
+++ b/docs/update_and_migration/from_4.5/update_from_4.5.md
@@ -193,7 +193,6 @@ To fix this, use the order from the skeleton you're using, and add any extra bun
 === "[[= product_name_com =]]"
     Use [https://github.com/ibexa/commerce-skeleton/blob/v[[= latest_tag_4_6 =]]/config/bundles.php](https://github.com/ibexa/commerce-skeleton/blob/v[[= latest_tag_4_6 =]]/config/bundles.php) as a reference.
 
-
 #### Non-existent service
 
 If you encounter the `You have requested a non-existent service "payum.storage.doctrine.orm".` error,

--- a/docs/update_and_migration/from_4.6/update_to_5.0.md
+++ b/docs/update_and_migration/from_4.6/update_to_5.0.md
@@ -974,7 +974,6 @@ Features which were optional 4.6 LTS Updates are now part of 5.0.0.
     psql <database_name> < schema_symbol-attribute.sql
     ```
 
-
 #### Install collaboration
 
 === "MySQL"

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -359,7 +359,6 @@ Update Symfony constraints in `composer.json` before updating the packages.
     For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
     Key changes include:
 
-
     - Independent application cache directory
 
         Symfony 7.4 introduces a new [share directory](https://symfony.com/blog/new-in-symfony-7-4-share-directory), dedicated for storing application cache on the file system.

--- a/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
+++ b/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
@@ -34,7 +34,6 @@ You can then proceed with consecutive upgrades to further versions: v1.13 LTS an
         While we have a strict backwards compatibility focus, some deprecated API features were removed and some changes were done to internal parts of the system.
         See [ezpublish-kernel:doc/bc/changes-6.0.md](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.0/doc/bc/changes-6.0.md)
 
-
 !!! caution "Unsupported legacy sorting methods"
 
     In older eZ Publish versions, sub-items of content items could be sorted by Class identifier (option value 6) or Class name (option value 7).
@@ -106,7 +105,6 @@ If you plan to use Legacy Bridge for a while before migrating content, you also 
 !!! note
 
     As of v1.3, be aware this field type now uses the Content View system introduced in eZ Platform 1.0, so make sure you adapt custom templates and override rules if you plan to use this for rendering content (in Legacy Bridge setup).
-
 
 ### 2.3. Config
 
@@ -190,7 +188,6 @@ ezpublish:
 Move over registration of _your_ bundles you have from src and from composer packages, from old to new kernel:
 
 `<old-ez-root>/ezpublish/EzPublishKernel.php => <new-ez-root>/app/AppKernel.php`
-
 
 ### 2.5. Optional: Install Legacy Bridge
 
@@ -350,7 +347,6 @@ But later realize the last identifier should be `profile`, not ``custom_image``,
 
 The last command would then ensure embedded objects with content type identifier `custom_image` are no longer tagged as images, while embedded objects with content type identifier `profile` are.
 
-
 Using the option `--export-dir`, the conversion exports problematic `ezxmltext` to files with the name pattern `[export-dir]/ezxmltext_[contentobject_id]_[contentobject_attribute_id]_[version]_[language].xml`. A corresponding `.log` file is also created which includes information about why the conversion failed. Be aware that the reported location of the problem may not be accurate or may be misleading.
 
 Below is an example of a xml dump, `ezxmltext_12_1234_2_eng-GB.xml`:
@@ -492,7 +488,6 @@ Below is a table of the tags that are currently supported, and their correspondi
 | `csssize4`    | Not supported |   Use `string` as workaround |
 | `cssborder`   | Not supported |   Use `string` as workaround |
 
-
 #### 3.2.2 Migrate page field to page (eZ Enterprise only)
 
 **If** you use page field (ezflow) and an eZ Enterprise subscription, and are ready to migrate your eZ Publish Flow content to the eZ Enterprise page format, you can use a script to migrate your old page content to new page, to start using a pure eZ Enterprise setup.
@@ -554,7 +549,6 @@ In case of URLs with extended UTF-encoded names, the workaround must make use of
             - '@ezpublish.api.storage_engine.transformation_processor'
             - { transformation: urlalias_iri }
 ```
-
 
 ## Migrating legacy page field (ezflow) to new page (Enterprise)
 

--- a/docs/users/user_management_guide.md
+++ b/docs/users/user_management_guide.md
@@ -143,4 +143,3 @@ By delivering content that resonates with different user segments, clients can i
 
 Clients can adapt the user management system to their unique needs.
 Custom policies and limitations enable tailored solutions that align with their specific use cases.
-


### PR DESCRIPTION
Adding more Markdownlint rules.

It's possible to review the changes commit by commit - each one introduces a new rule.

Some of them are still commented - but I want to keep this PR small to make it easier to review.

Please note https://github.com/ibexa/documentation-developer/pull/3148/changes/d9deae3b82328983a48c8cd3a1e7cdc205f66e29 - as the image field reference used to embed a file outside of snippets, it broke when the lines moved. I've extracted the code sample to avoid this happening in the future.

Enabled rules:

- `no-multiple-blanks`: https://github.com/DavidAnson/markdownlint/blob/0213a0274dfeaac589af389f6c9bc9e821655810/doc/md012.md
- ` commands-show-output`: https://github.com/DavidAnson/markdownlint/blob/0213a0274dfeaac589af389f6c9bc9e821655810/doc/md014.md