### PR TITLE
Markdownlint: more rules vol. 3

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -27,35 +27,15 @@ config:
   ul-indent:
     indent: 4
   heading-increment: true
-# table-column-count: true
   blanks-around-tables: true
   descriptive-link-text: true
-# table-column-style: aligned
-# link-fragments: true
-# no-alt-text: true
   single-trailing-newline: true
-# no-emphasis-as-heading: true
   no-space-in-code: true
   no-space-in-links: true
   fenced-code-language: true
-# first-line-heading: true
-# ol-prefix: one_or_ordered
-# list-marker-space: true
-# blanks-around-fences: true
-# blanks-around-lists: true
-# single-title: true
-# no-trailing-punctuation:
-#   punctuation: [".", ":", ";",]
-# no-multiple-space-atx: true
-# blanks-around-headings: true
-# heading-increment: true
-# ul-style: dash
-# ul-indent:
-#   indent: 4
-# no-trailing-spaces: true
-# no-multiple-blanks: true
   no-multiple-blanks: true
   commands-show-output: true
+  no-trailing-spaces: true
 
 ignores:
   - "docs/snippets/**"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -36,6 +36,7 @@ config:
   no-multiple-blanks: true
   commands-show-output: true
   no-trailing-spaces: true
+  blanks-around-lists: true
   no-trailing-punctuation:
     punctuation: [".", ":", ";",]
 

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -36,6 +36,8 @@ config:
   no-multiple-blanks: true
   commands-show-output: true
   no-trailing-spaces: true
+  no-trailing-punctuation:
+    punctuation: [".", ":", ";",]
 
 ignores:
   - "docs/snippets/**"

--- a/docs/administration/back_office/subitems_list.md
+++ b/docs/administration/back_office/subitems_list.md
@@ -10,7 +10,7 @@ It provides an interface for listing the sub-items of any location.
 
 ## Create custom sub-items list view
 
-You can extend the Sub-items List module to replace an existing view or add your own. 
+You can extend the Sub-items List module to replace an existing view or add your own.
 The example below adds a new timeline view to highlight the modification date.
 
 ![Sub-items List module using the new Timeline view](img/subitems/timeline_view.png "Sub-items List module using the new Timeline view")

--- a/docs/ai/ai_actions/configure_ai_actions.md
+++ b/docs/ai/ai_actions/configure_ai_actions.md
@@ -130,9 +130,9 @@ To use the connector with the Gemini services, you need to create an account, se
 1. Navigate to the Google Cloud Console's **Billing** page.
 1. If you do not have one, click **Add billing account** and add a payment method.
 1. In **Your projects** tab, locate your project, and in its line, from the **Actions** menu, select **Change billing**.
-1. Select your active billing account, and click **Set account**. 
+1. Select your active billing account, and click **Set account**.
 
-#### Enable the Gemini API 
+#### Enable the Gemini API
 
 1. Navigate to the Google Cloud Console's **APIs & Services** page.
 1. From the left-hand menu, select **Library** and search for the Generative Language API.

--- a/docs/ai/ai_actions/extend_ai_actions.md
+++ b/docs/ai/ai_actions/extend_ai_actions.md
@@ -106,7 +106,7 @@ The following example adds a new Action Handler connecting to a local AI run usi
 
 When creating an Action Handler for [[= product_name_connect =]], add the new handler identifier to the [`Ibexa AI handler` custom property](configure_ai_actions.md#initiate-integration) in [[= product_name_connect =]] user interface.
 
-### Register a custom Action Handler in the system.
+### Register a custom Action Handler in the system
 
 Create a class implementing the [ActionHandlerInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Action-ActionHandlerInterface.html) and register it as a service:
 

--- a/docs/ai/ai_actions/extend_ai_actions.md
+++ b/docs/ai/ai_actions/extend_ai_actions.md
@@ -32,7 +32,7 @@ Both `ActionContext` and `RuntimeContext` are passed to the Action Handler (an o
 
 You can pass the Action Handler directly to the `ActionServiceInterface::execute()` method, which overrides all the other ways of selecting the Action Handler.
 You can also specify the Action Handler by including it in the provided [Action Configuration](#action-configurations).
-In other cases, the Action Handler is selected automatically. 
+In other cases, the Action Handler is selected automatically.
 You can affect this choice by creating your own class implementing the [ActionHandlerResolverInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Action-ActionHandlerResolverInterface.html) or by listening to the [ResolveActionHandlerEvent](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Events-ResolveActionHandlerEvent.html) Event sent by the default implementation.
 
 You can influence the execution of an Action with two events:

--- a/docs/cdp/cdp_activation/cdp_data_export.md
+++ b/docs/cdp/cdp_activation/cdp_data_export.md
@@ -107,6 +107,7 @@ Go to the **Audience Builder** and select **Build new audience**.
 When naming the audience remember, you need to find it in a drop-down list during activation.
 There, you can choose conditions from `did`, `did not` or `have`.
 The conditions `did` and `did not` allow you to use events like buy, visit or add to a cart from online tracking.
+
 - `have` conditions are tied to personal characteristics and can be used to track the sum of all buys or top-visited categories.
 
 In the Audience Builder, you can also connect created audiences to the activations.

--- a/docs/cdp/cdp_data_customization.md
+++ b/docs/cdp/cdp_data_customization.md
@@ -110,7 +110,7 @@ To customize export of field type values, provide your own [`\Ibexa\Contracts\Cd
 New implementation has to be registered as a service manually or by using autoconfiguration.
 The service has to use the tag `ibexa.cdp.export.content.field_value_processor`.
 You can also provide `priority` property to override other Field Value Processors.
-​
+
 - `FieldValueProcessorInterface::process` - takes `Field` instance and returns an `array` with scalar values that are applied to export data payload.
 If the field type returns a single value, provides a `value` key in the array.
 You can return multiple values.

--- a/docs/content_management/field_types/field_type_reference/addressfield.md
+++ b/docs/content_management/field_types/field_type_reference/addressfield.md
@@ -17,7 +17,7 @@ provided by the `ibexa/fieldtype-address` package.
 
 ## PHP API field type
 
-### Inputs:
+### Inputs
 
 | Type     | Description                                   | Example           |
 |----------|-----------------------------------------------|-------------------|

--- a/docs/content_management/field_types/field_type_reference/field_type_reference.md
+++ b/docs/content_management/field_types/field_type_reference/field_type_reference.md
@@ -18,7 +18,7 @@ In addition, it's possible to extend the system by creating custom types for spe
 
     For general field type documentation, see [field type](field_types.md).
 
-Custom field types have to be programmed in PHP. 
+Custom field types have to be programmed in PHP.
 However, the built-in field types are usually enough for typical scenarios.
 The following table gives an overview of the supported field types that come with [[= product_name =]].
 

--- a/docs/content_management/field_types/field_type_reference/measurementfield.md
+++ b/docs/content_management/field_types/field_type_reference/measurementfield.md
@@ -1,6 +1,6 @@
 # Measurement field type
 
-The Measurement field type represents measurement information. 
+The Measurement field type represents measurement information.
 It stores the unit of measure, and either a single measurement value, or a pair of top and bottom values that defines a range.
 
 | Name          | Internal name       | Expected input type                                |
@@ -12,8 +12,8 @@ It stores the unit of measure, and either a single measurement value, or a pair 
 ### Input expectations
 
 To create a value, you use a service that implements `Ibexa\Contracts\Measurement\MeasurementServiceInterface`.
-You must inject the service directly with [dependency injection](php_api.md#service-container). 
-The service contains the following API endpoints: 
+You must inject the service directly with [dependency injection](php_api.md#service-container).
+The service contains the following API endpoints:
 
 - `buildSimpleValue` that is used to handle a single value
 - `buildRangeValue` that is used to handle a range
@@ -37,7 +37,7 @@ The Value class of this field type contains the following properties:
 
 #### Constructor
 
-The `Measurement\Value` constructor for this value object initializes a new value object with the value provided. 
+The `Measurement\Value` constructor for this value object initializes a new value object with the value provided.
 As its first argument it accepts an object of `Ibexa\Contracts\Measurement\Value\ValueInterface` type.
 
 Depending on the selected input type, the object resembles the following examples:

--- a/docs/content_management/forms/create_form_attribute.md
+++ b/docs/content_management/forms/create_form_attribute.md
@@ -106,7 +106,7 @@ Now, the attribute value can be stored in the new Form.
 
 ## Create submission converter
 
-The new field is based on a checkbox, so to display the submissions of this field, you can use the `BooleanFieldSubmissionConverter`. 
+The new field is based on a checkbox, so to display the submissions of this field, you can use the `BooleanFieldSubmissionConverter`.
 
 Create a `src/FormBuilder/FormSubmission/Converter/RichtextDescriptionFieldSubmissionConverter.php` file.
 

--- a/docs/content_management/forms/work_with_forms.md
+++ b/docs/content_management/forms/work_with_forms.md
@@ -44,7 +44,7 @@ For information about available options, see [Gregwar/CaptchaBundle's documentat
 
 ## Form submission purging
 
-You can purge all submissions of a given form. 
+You can purge all submissions of a given form.
 To do this, run the following command, where `form-id` stands for Content ID of the form for which you want to purge data:
 
 ```bash

--- a/docs/content_management/images/add_image_asset_from_dam.md
+++ b/docs/content_management/images/add_image_asset_from_dam.md
@@ -157,7 +157,7 @@ In this example, the search only uses the main text input.
 The tab and its corresponding panel are a service created by combining existing components, like in the case of other [back office tabs](back_office_tabs.md).
 
 The `commons_search_tab` service uses the `GenericSearchTab` class as a base, and the `GenericSearchType` form for search input.
-It is linked to the `commons` DAM source and uses the identifier `commons`. 
+It is linked to the `commons` DAM source and uses the identifier `commons`.
 The DAM search tab is registered in the `connector-dam-search` [tab group](back_office_tabs.md#tab-groups) using the `ibexa.admin_ui.tab` tag.
 
 ```yaml

--- a/docs/content_management/images/images.md
+++ b/docs/content_management/images/images.md
@@ -51,8 +51,8 @@ php bin/console liip:imagine:cache:remove
 With [image variations](image_variations.md) (image aliases) you can define and use different versions of the same image.
 You generate variations based on [filters](image_variations.md#available-variation-filters) that modify aspects such as size and proportions, quality or effects.
 
-Image variations are generated with [LiipImagineBundle](https://github.com/liip/LiipImagineBundle), by using the underlying [Imagine library](https://imagine.readthedocs.io/en/latest/). 
-The LiipImagineBundle bundle supports GD (default), Imagick or Gmagick PHP extensions, and enables you to define flexible filters in PHP. 
+Image variations are generated with [LiipImagineBundle](https://github.com/liip/LiipImagineBundle), by using the underlying [Imagine library](https://imagine.readthedocs.io/en/latest/).
+The LiipImagineBundle bundle supports GD (default), Imagick or Gmagick PHP extensions, and enables you to define flexible filters in PHP.
 Image files are stored by using the `IOService,` and are completely independent from the Image field type.
 They're generated only once and cleared on demand, for example, on content removal).
 

--- a/docs/content_management/pages/page_builder_guide.md
+++ b/docs/content_management/pages/page_builder_guide.md
@@ -206,7 +206,7 @@ Additionally, if you feel comfortable with your technical skills, you can config
 
 ### Increase sales with highly personalized campaigns
 
-Personalized campaigns are one of the factors that can increase your sales. 
+Personalized campaigns are one of the factors that can increase your sales.
 With Page Builder you can achieve it, by using customization and time Scheduler.
 Anytime you can edit your page and change a position of a block to enhance visibility.
 Additionally, Page Builder offers you a selection of ready-to-use page blocks that can help you to create content tailored to each individual customer:

--- a/docs/content_management/rich_text/create_custom_richtext_block.md
+++ b/docs/content_management/rich_text/create_custom_richtext_block.md
@@ -5,12 +5,12 @@ edition: experience
 
 # Create custom RichText block
 
-A RichText block is a specific example of a [custom block](create_custom_page_block.md) that you can use when you create a page. 
+A RichText block is a specific example of a [custom block](create_custom_page_block.md) that you can use when you create a page.
 To create a custom block, you must define the block's layout, provide templates, add a subscriber, and register the subscriber as a service.
 
 Follow the procedure below to create a RichText page block.
 
-First, provide the block configuration under the `ibexa_page_fieldtype.blocks` [configuration key](configuration.md#configuration-files). 
+First, provide the block configuration under the `ibexa_page_fieldtype.blocks` [configuration key](configuration.md#configuration-files).
 The following code defines a new block, its view and configuration templates.
 It also sets the attribute type to `richtext` (line 15):
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -7,7 +7,7 @@ month_change: false
 
 [[= product_name =]] users edit the contents of RichText fields, for example,  in the Content box of a Page, by using the Online Editor.
 
-You can extend the Online Editor by adding custom tags and styles, defining custom data attributes, re-arranging existing buttons, grouping buttons into custom toolbar, 
+You can extend the Online Editor by adding custom tags and styles, defining custom data attributes, re-arranging existing buttons, grouping buttons into custom toolbar,
 and creating [custom buttons](https://ckeditor.com/docs/ckeditor4/latest/guide/widget_sdk_tutorial_1.html#widget-toolbar-button) and [custom plugins](https://ckeditor.com/docs/ckeditor4/latest/guide/dev_plugins.html).
 
 Online Editor is based on the CKEditor5.
@@ -20,7 +20,7 @@ For more information about extending the back office, see [Extend back office](b
 With custom tags, you can enhance the Online Editor with features that go beyond the built-in ones.
 You configure custom tags under the `ibexa_richtext` key.
 
-Start preparing the tag by adding a configuration file: 
+Start preparing the tag by adding a configuration file:
 
 ```yaml
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml') =]]
@@ -32,7 +32,7 @@ Supported attribute types are:
 `choice` requires that you provide a list of options in the `choices` key.
 
 You must provide your own files for the Twig template and the icon.
-Place the `factbox.html.twig` template in the 
+Place the `factbox.html.twig` template in the
 `templates/themes/<your-theme>/field_type/ibexa_richtext/custom_tags` directory:
 
 ```html+twig
@@ -71,7 +71,7 @@ You can also place custom tags inline with the following configuration:
 ```
 
 `is_inline` is an optional key.
-The default value is `false`, therefore, if it's not set, the custom tag is 
+The default value is `false`, therefore, if it's not set, the custom tag is
 treated as a block tag.
 
 ### Use cases
@@ -107,7 +107,7 @@ Now you can use the tag.
 In the back office, create or edit a content item that has a RichText field type.
 In the Online Editor's toolbar, click **Show more items**, and from the list of available tags select the Link tag icon.
 
-![Link Tag](custom_tag_link.png "Link Tag in the Online Editor") 
+![Link Tag](custom_tag_link.png "Link Tag in the Online Editor")
 
 #### Acronym
 
@@ -167,7 +167,7 @@ Add labels for the new styles by providing translations in `translations/custom_
 
 ### Rendering
 
-The `template` key points to the template that is used to render the custom style. 
+The `template` key points to the template that is used to render the custom style.
 It's recommended that you use the [design engine](design_engine.md).
 
 The template files for the front end could look as follows:
@@ -198,7 +198,7 @@ You can create a custom style that places a paragraph in a note box:
 [[= include_file('code_samples/back_office/online_editor/config/packages/custom_styles_note_box.yaml') =]]
 ```
 
-The `note_box.html.twig` template wraps the content of the selected text 
+The `note_box.html.twig` template wraps the content of the selected text
 (`{{ content }}`) in a custom CSS class:
 
 ``` html+twig
@@ -241,7 +241,7 @@ You can create an inline custom style that highlights a part of a text:
 [[= include_file('code_samples/back_office/online_editor/config/packages/custom_styles_highlight.yaml') =]]
 ```
 
-The `highlight.html.twig` template wraps the content of the selected text 
+The `highlight.html.twig` template wraps the content of the selected text
 (`{{ content }}`) in a custom CSS class:
 
 ``` html+twig
@@ -337,7 +337,7 @@ Use the example below to add a class choice to the Paragraph element in the `adm
 ``` yaml
 [[= include_file('code_samples/back_office/online_editor/config/packages/custom_classes.yaml') =]]
 ```
- 
+
 !!! note "Label translations"
 
     If there are many custom attributes, to provide label translations for these attributes, you can use the `ez_online_editor_attributes` translation extractor to get a full list of all custom attributes for all elements in all scopes.

--- a/docs/content_management/rich_text/online_editor_guide.md
+++ b/docs/content_management/rich_text/online_editor_guide.md
@@ -17,14 +17,14 @@ Online Editor is available in all supported [[= product_name =]] versions and ed
 
 ## How to get started
 
-Online Editor is the default editing interface for all RichText fields. 
+Online Editor is the default editing interface for all RichText fields.
 To start using it, create any content item with a RichText field (for example, based on the built-in Article content type) and edit this field.
 
 ## Capabilities
 
 ### Rich Text editor
 
-Online Editor covers all fundamental formatting options for rich text, such as headings, lists, tables, inline text formatting, anchors, and links. 
+Online Editor covers all fundamental formatting options for rich text, such as headings, lists, tables, inline text formatting, anchors, and links.
 It also allows embedding other content from the repository, but also from Facebook, Twitter, or YouTube.
 
 <!--ARCADE EMBED START--><div style="position: relative; padding-bottom: calc(51.27314814814815% + 41px); height: 0; width: 100%;"><iframe src="https://demo.arcade.software/wkdL1r9PRunTeF6hPtEs?embed&embed_mobile=tab&embed_desktop=inline&show_copy_link=true" title="Online Editor - work in Rich Text field" frameborder="0" loading="lazy" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="clipboard-write" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; color-scheme: light;" ></iframe></div><!--ARCADE EMBED END-->

--- a/docs/content_management/taxonomy/taxonomy.md
+++ b/docs/content_management/taxonomy/taxonomy.md
@@ -178,7 +178,7 @@ php bin/console ibexa:reindex
 
 Once you enable the Taxonomy suggestions feature, you must [configure an AI action]([[= user_doc =]]/ai_actions/work_with_ai_actions/#create-ai-actions-that-control-taxonomy-suggestions) that handles the generation of embeddings for newly created or edited content items or products.
 
-That's where you decide which exact fields from which content type should be used as input for embedding generation, how many suggestions are being presenter to the editor, and so on. 
+That's where you decide which exact fields from which content type should be used as input for embedding generation, how many suggestions are being presenter to the editor, and so on.
 
 After you do it, your users are be able to assign tags and/or product categories by using suggestions provided by an AI engine.
 
@@ -260,7 +260,7 @@ ibexa:
     When you change the default suggestions generation model, ensure that you update the `ibexa.system.default.taxonomy.search.default_embedding_model` setting that is used for taxonomy indexing purposes.
     Otherwise the taxonomy suggestions feature fails to find matching entries.
 
-#### Change embeddings provider to Google Gemini [[% include 'snippets/lts-update_badge.md' %]] 
+#### Change embeddings provider to Google Gemini [[% include 'snippets/lts-update_badge.md' %]]
 
 Once you have installed and configured the [Google Gemini connector](configure_ai_actions.md#install-google-gemini-connector), you can modify the default configuration to use the `ibexa_gemini` embedding provider and one of the [supported models](https://ai.google.dev/gemini-api/docs/embeddings):
 

--- a/docs/content_management/workflow/workflow.md
+++ b/docs/content_management/workflow/workflow.md
@@ -9,7 +9,7 @@ The workflow functionality passes a content item version through a series of sta
 For example, an editorial workflow can pass a content item from draft stage through design and proofreading.
 
 By default, [[= product_name =]] comes pre-configured with a Quick Review workflow.
-You can disable the default workflow and define different workflows in configuration. 
+You can disable the default workflow and define different workflows in configuration.
 Workflows are permission-aware.
 
 ## Workflow configuration
@@ -32,7 +32,7 @@ Their configuration is optional.
 `content_type` contains an array of content type identifiers that use this workflow.
 
 `content_status` lists the statuses of content items which fall under this workflow.
-The available values are: `draft` and `published`. 
+The available values are: `draft` and `published`.
 
 If set to `draft`, applies for new content (newly created).
 
@@ -91,7 +91,7 @@ The notification is displayed in the user menu:
 
 #### Draft locking
 
-You can configure draft assignment in a way that when a user sends a draft to review, only the first editor of the draft can either edit the draft or unlock it for editing, and no other user can take it over. 
+You can configure draft assignment in a way that when a user sends a draft to review, only the first editor of the draft can either edit the draft or unlock it for editing, and no other user can take it over.
 
 Use the [Version Lock limitation](limitation_reference.md#version-lock-limitation), set to "Assigned only", together with the `content/edit` and `content/unlock` policies to prevent users from editing and unlocking drafts that are locked by another user.
 

--- a/docs/getting_started/troubleshooting.md
+++ b/docs/getting_started/troubleshooting.md
@@ -83,7 +83,7 @@ If you increase your requirement to that version, the conflict is resolved.
 
 In the rare case when there is no fixed version, you can revert your requirement to an older version which doesn't have the bug.
 If you have to use the version with the bug (not recommended) you can use `composer remove roave/security-advisories`.
-In such case, require it again when the bug is fixed and the package is updated: `composer require roave/security-advisories:dev-master` 
+In such case, require it again when the bug is fixed and the package is updated: `composer require roave/security-advisories:dev-master`
 
 ## [[= product_name_cloud =]] HTTP access credentials with Varnish
 

--- a/docs/infrastructure_and_maintenance/cache/http_cache/reverse_proxy.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/reverse_proxy.md
@@ -146,7 +146,7 @@ If the Varnish server is protected by Basic Auth, specify the Basic Auth credent
                 purge_servers: [http://myuser:mypasswd@my.varnish.server:8081]
 ```
 
-Varnish is enabled by default when using [[= product_name_cloud =]] and the `purge_servers` setting is set automatically. 
+Varnish is enabled by default when using [[= product_name_cloud =]] and the `purge_servers` setting is set automatically.
 To enable Basic Auth on [[= product_name_cloud =]] when using Varnish, specify the credentials using the following environment variables to make sure that Varnish is reachable:
 
 ``` bash

--- a/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
@@ -243,7 +243,7 @@ In the following examples:
 ### Install Redis or Valkey
 
 DDEV supports multiple Redis-compatible implementation, including Redis itself and Valkey.
-You can switch between them using the `ddev redis-backend <backend>` command after adding the `ddev/ddev-redis` add-on. 
+You can switch between them using the `ddev redis-backend <backend>` command after adding the `ddev/ddev-redis` add-on.
 For example, you can switch to Valkey by running `ddev add-on get ddev/ddev-redis; ddev redis-backend valkey/valkey:9`.
 For more information, see [Swappable Redis backends](https://github.com/ddev/ddev-redis?tab=readme-ov-file#swappable-redis-backends) in DDEV's `dddev-redis` add-on documentation.
 

--- a/docs/infrastructure_and_maintenance/devops.md
+++ b/docs/infrastructure_and_maintenance/devops.md
@@ -10,7 +10,7 @@ description: See various tools that can help you debug your Ibexa DXP installati
 
 Symfony provides a command for clearing cache.
 It deletes all file-based caches, which mainly consist of a Twig template, a [service container](php_api.md#service-container), and the Symfony route cache, but also everything else stored in the cache folder.
-Out of the box on a single-server setup this includes Content cache. 
+Out of the box on a single-server setup this includes Content cache.
 
 For further information on the command's use, see its help text:
 
@@ -30,7 +30,7 @@ php bin/console --env=prod cache:clear -h
 ### Clearing content cache on a cluster setup
 
 For a [cluster](clustering.md) setup, the content cache ([HTTP cache](http_cache.md) and [Persistence cache](persistence_cache.md)) must be set up to be shared among the servers.
-While all relevant cache is cleared for you on repository changes when using the APIs, there might be times where you need to clear cache manually: 
+While all relevant cache is cleared for you on repository changes when using the APIs, there might be times where you need to clear cache manually:
 
 - Varnish: [Cache purge](reverse_proxy.md#using-varnish-or-fastly)
 - Persistence Cache: [Using Cache service](persistence_cache.md#using-cache-service)

--- a/docs/infrastructure_and_maintenance/performance.md
+++ b/docs/infrastructure_and_maintenance/performance.md
@@ -77,7 +77,7 @@ You can build them by running `yarn encore prod`, or by setting the environmenta
 
     Check if your cloud provider has native service for Redis, as those might be better tuned.
 
-When using Redis or Valkey, make sure to tune it for in-memory cache usage. 
+When using Redis or Valkey, make sure to tune it for in-memory cache usage.
 The persistence feature isn't needed with cache and severely slows down execution time.
 [For use with sessions](sessions.md#cluster-setup) however, persistence can be a good fit if you want sessions to survive service interruptions.
 

--- a/docs/multisite/siteaccess/injecting_siteaccess.md
+++ b/docs/multisite/siteaccess/injecting_siteaccess.md
@@ -7,7 +7,7 @@ description: Inject the SiteAccess service to get SiteAccess information in your
 The [service container](php_api.md#service-container) exposes the SiteAccess through the `Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessService` service, which fulfills the `Ibexa\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface` contract.
 This means you can inject it into any custom service constructor, type hinting that contract.
 You can get the current SiteAccess from that service by calling the `SiteAccessServiceInterface::getCurrent` method.
-	
+
 For example, define a service which depends on the Repository's ContentService and the SiteAccessService.
 
 ``` yaml

--- a/docs/multisite/siteaccess/siteaccess_matching.md
+++ b/docs/multisite/siteaccess/siteaccess_matching.md
@@ -64,7 +64,7 @@ The matching configuration is passed to `setMatchingConfiguration()`.
 
 ### `URIElement`
 
-Maps a URI element to a SiteAccess.	
+Maps a URI element to a SiteAccess.
 
 In configuration, provide the element number you want to match (starting from 1).
 

--- a/docs/personalization/api_reference/recommendation_api.md
+++ b/docs/personalization/api_reference/recommendation_api.md
@@ -39,7 +39,7 @@ For the request to return recommendations, you must provide the following parame
 ### Customizing the recommendation request
 
 You can customize the recommendation request by using additional query string parameters.
-For example, you can send the following request to the Personalization server: 
+For example, you can send the following request to the Personalization server:
 
 `GET https://reco.perso.ibexa.co/api/v2/00000/john.doe/landing_page.json ?contextitems=123&categorypath=%2FCamera%2FCompact&attribute=title&attribute=deeplink,description&numrecs=8`
 
@@ -268,7 +268,7 @@ The recommendation service supports the following HTTP headers to enable cache c
 |Response|`Expires`|Gives the date/time after which the response is outdated|`Expires: Thu, 01 Dec 2013 16:00:00 GMT`|
 
 The last modification timestamp indicates a change that could influence the recommendation response.
-It depends on an updated recommendation calculation, an update of an item or certain scenario configuration changes. 
+It depends on an updated recommendation calculation, an update of an item or certain scenario configuration changes.
 
 The expiration timestamp is a best-effort prediction based on the model configuration and provided context.
 The shortest expiration period is 5 minutes from the request time, the longest is 24 hours.

--- a/docs/personalization/api_reference/tracking_api.md
+++ b/docs/personalization/api_reference/tracking_api.md
@@ -13,7 +13,7 @@ The most popular user events are:
 - Login - When a user logs in on a website
 - Clickrecommended - When a user clicks a recommendation
 
-For a complete list of events, see [Event types]([[= user_doc =]]/personalization/event_types/) in User Documentation. 
+For a complete list of events, see [Event types]([[= user_doc =]]/personalization/event_types/) in User Documentation.
 Depending on the event type, some additional parameters, such as item price or user rating, must be provided.
 
 Importing historical user data can help you reduce the delay in delivery of high quality recommendations.
@@ -61,14 +61,14 @@ For example:
 
 ### User identifier
 
-High quality recommendations can only be delivered if the underlying data is correct and consistent. 
+High quality recommendations can only be delivered if the underlying data is correct and consistent.
 For consistent tracking it's crucial to choose and use a consistent identifier for a user.
 A user usually visits a website anonymously.
-Therefore, their identifier is either a first-party cookie or a session ID provided by the website. 
+Therefore, their identifier is either a first-party cookie or a session ID provided by the website.
 If there is no existing user ID handling that can be re-used, it's recommended that you use your own cookie and set the expiry date to at least 90 days from the last usage.
 If there is a login mechanism, the user is usually tracked with a temporary identifier before the login.
 Immediately after a successful login process a Login event must be sent.
-At this point a [pseudonymous](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679&from=EN#d1e1489-1-1) user ID, for example, a system's internal registration id, must be used. 
+At this point a [pseudonymous](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32016R0679&from=EN#d1e1489-1-1) user ID, for example, a system's internal registration id, must be used.
 After logout, the anonymous user ID can be used again.
 
 !!! note
@@ -174,14 +174,14 @@ The format of the URL is:
 `GET https://event.perso.ibexa.co/api/[customerid]/blacklist/[userid]/[itemtypeid]/[itemid]`
 
 For a detailed description of embedded parameters, see [event parameters](#event-parameters).
-This event has no query string parameters. 
+This event has no query string parameters.
 
 ### Buy event
 
 As the name suggests, this event is used when an end user buys an item.
 It must be sent to the event tracker at the end of a successful check-out process to ensure that no further action of the user can result in an abort.
 
-The URL has the following format: 
+The URL has the following format:
 
 `GET https://event.perso.ibexa.co/api/[customerid]/buy/[userid]/[itemtypeid]/[itemid]?fullprice=2.50EUR&quantity=4`
 
@@ -202,7 +202,7 @@ If products are sold on a subscription basis, or the web presence is ad-sponsore
 
 Every Buy event can contain a price.
 If the price is set, it's stored with the event and used for calculating the revenue for statistics.
-The price must be a price the user paid for the item, including all taxes and discounts. 
+The price must be a price the user paid for the item, including all taxes and discounts.
 
 If product price filtering is activated, the information provided over the product import is used.
 
@@ -258,7 +258,7 @@ The following table lists the request parameters:
 |`percentage`|Informs how much of an item was consumed, for example, that an article was read only in 20%, a movie was watched in 90% or someone finished 3/4 of all levels of a game.|0-100|
 
 The logic for calculating the percentage is defined by the implementation.
-For articles, this could be by scrolling down, for a movie/video based on the consumption part. 
+For articles, this could be by scrolling down, for a movie/video based on the consumption part.
 You must decide what 100% consumption means.
 For example, a movie contains end titles that are almost never consumed.
 Therefore, they should not be part of the percentage calculation.
@@ -279,7 +279,7 @@ Based on this information, recommendations presented by the store can be more ac
 `GET https://event.perso.ibexa.co/api/[customerid]/deletefrombasket/[userid]/[itemtypeid]/[itemid]`
 
 For a detailed description of embedded parameters, see [event parameters](#event-parameters).
-This event has no query string parameters. 
+This event has no query string parameters.
 
 ### Deletefromwishlist event
 
@@ -290,7 +290,7 @@ Based on this information, recommendations presented by the store can be more ac
 `GET https://event.perso.ibexa.co/api/[customerid]/deletefromwishlist/[userid]/[itemtypeid]/[itemid]`
 
 For a detailed description of embedded parameters, see [event parameters](#event-parameters).
-This event has no query string parameters. 
+This event has no query string parameters.
 
 ### Login event
 
@@ -303,7 +303,7 @@ As a result, the user identifier changes from an anonymous visit-scoped ID (sour
 You should correlate both IDs to correlate the Buy events (account ID) with the preceding Click events (visit-scoped ID).
 The Login event serves exactly this purpose.
 
-The format of the URL is: 
+The format of the URL is:
 
 `GET https://event.perso.ibexa.co/api/[customerid]/login/[sourceuserid]/[targetuserid]`
 
@@ -444,7 +444,7 @@ The request parameters are:
 |`scenario`|Name of the scenario, where recommendations originated from. This parameter is required.|URL-encoded alphanumeric|
 
 The scenario parameter identifies the originating scenario to gain detailed statistics about the scenario that motivated the user to click on a recommendation.
-This information comes with the recommendation from the recommendation controller. 
+This information comes with the recommendation from the recommendation controller.
 
 The event is used for providing statistics about how often users accepted the recommendations of the configured recommendation scenario or considered them as valuable.
 

--- a/docs/personalization/api_reference/user_api.md
+++ b/docs/personalization/api_reference/user_api.md
@@ -5,7 +5,7 @@ description: Use HTTP methods to correlate metadata with user data and combine u
 # User API
 
 When generating recommendations, it's useful to have the ability to correlate metadata with user data and combine users into clusters of certain type.
-Such metadata can be gender, ZIP code, discount rate, and more. 
+Such metadata can be gender, ZIP code, discount rate, and more.
 You can use the following user metadata import format to enrich the tracked data with information that cannot be calculated and must be provided by the end-user.
 
 If you plan to import user metadata, contact support@ibexa.co to ensure that you're compliant with privacy regulations.
@@ -59,7 +59,7 @@ When you do that, and the source returned is different from the source passed in
 ### User ID
 
 User ID is a case-sensitive combination of characters.
-If transferred as part of the URL, the attribute must be URL-encoded. 
+If transferred as part of the URL, the attribute must be URL-encoded.
 If transferred in the XML object, the attribute must be XML-encoded.
 
 For example:
@@ -97,7 +97,7 @@ The attribute keys and values are chosen at random.
 </users>
 ```
 
-Attribute keys are POSIX alphanumeric codes that can consist of the following characters: `\[A-Z\]`, `\[0-9\]`, `"\_"` and `"-"`. 
+Attribute keys are POSIX alphanumeric codes that can consist of the following characters: `\[A-Z\]`, `\[0-9\]`, `"\_"` and `"-"`.
 Attribute keys are case sensitive.
 
 The following attribute types are supported:

--- a/docs/personalization/enable_personalization.md
+++ b/docs/personalization/enable_personalization.md
@@ -16,7 +16,7 @@ First, either you or another [[= product_name_base =]] user responsible for mana
 
 When you receive the credentials, add them to your configuration.
 
-In the root folder of your project, edit the `.env.local` file by adding the following lines with your customer ID and license key: 
+In the root folder of your project, edit the `.env.local` file by adding the following lines with your customer ID and license key:
 
 ```bash
 PERSONALIZATION_CUSTOMER_ID=12345

--- a/docs/personalization/legacy_recommendation_api.md
+++ b/docs/personalization/legacy_recommendation_api.md
@@ -55,7 +55,7 @@ Using additional query string parameters one can customize the recommendation re
 |`categorypath`|Base category path for providing recommendations. The format is the same as the category path for the event tracking. It's possible to add this parameter multiple times. The order of recommendations from the different categories is defined by the calculated relevance.|alphanumeric[/alphanumeric]*|
 |`jsonpcallback` (used only for JSONP request)|Function or method name for a JSONP request. It can be a function ("callme"), or a method ("obj.callme").|valid JavaScript function call (by default "jsonpCallback")|
 
-An example of the recommendation request: 
+An example of the recommendation request:
 
 **`https://reco.perso.ibexa.co/ebl/0000/smith/productpage.json?contextitems=123&categorypath=%2FCamera%2FCompact&numrecs=8`**
 
@@ -70,7 +70,7 @@ It fetches 8 recommendations for user Smith, who is watching the item 123 and th
 ## Response handling
 
 The recommendation request returns a list of item IDs that are JSON, JSONP or XML-formatted.
-The result can be integrated into any webpage by using some lines of script code. 
+The result can be integrated into any webpage by using some lines of script code.
 
 !!! tip
 

--- a/docs/personalization/tracking_integration.md
+++ b/docs/personalization/tracking_integration.md
@@ -8,7 +8,7 @@ month_change: false
 There are several ways to integrate event reporting into the webpage.
 The simplest way is to generate code of a tiny image and put it on the webpage where the event must be sent [pixel tracking](integrate_recommendation_service.md#track-events).
 
-For example, with HTML: 
+For example, with HTML:
 
 ``` html
 <img href="https://event.perso.ibexa.co/api/00000/click/johndoe/1/100?categorypath=/a/ab/abc" width="1" height="1">

--- a/docs/personalization/tracking_with_ibexa-tracker.md
+++ b/docs/personalization/tracking_with_ibexa-tracker.md
@@ -60,7 +60,7 @@ These can be any JavaScript value.
 
 ## Tracking code
 
-The `_ycq` global object can be used directly for asynchronous page tracking with the `push(...)` method. 
+The `_ycq` global object can be used directly for asynchronous page tracking with the `push(...)` method.
 
 ### `_ycq` object methods
 
@@ -68,9 +68,9 @@ The `_ycq` global object can be used directly for asynchronous page tracking wit
 
 `push(commandArray)`
 
-Executes the command array, which is a JavaScript array that conforms to the following format. 
-The first element of the array must be the name of a tracker object method passed as a string. 
-The rest of the array elements are the values to be passed in as arguments to the function. 
+Executes the command array, which is a JavaScript array that conforms to the following format.
+The first element of the array must be the name of a tracker object method passed as a string.
+The rest of the array elements are the values to be passed in as arguments to the function.
 
 Here is an example of typical usage of the method:
 

--- a/docs/release_notes/ez_platform_v1.7.0_lts.md
+++ b/docs/release_notes/ez_platform_v1.7.0_lts.md
@@ -48,7 +48,7 @@ Community members are more than welcome to contribute to the translation process
     - ezplatform:reindex added, a generic command for reindexing search index on the SiteAccess configured search engine
 - Extensibility:
     - QueryType's now support using alias when being used as service so you can define several services with same  QueryType class
-        - Example: Generic location child QueryType being reused several times for specific services for article or blog post listings 
+        - Example: Generic location child QueryType being reused several times for specific services for article or blog post listings
 - API:
     - New method:`Location->getSortClauses()` to get Sort Clauses based on what kind of sorting has been set on the Location
     - Add Content Version archives limit by configuration & enforce on publish
@@ -87,7 +87,7 @@ Submitted results can be previewed in the UI or downloaded in a CSV file, and a 
 
 The Enterprise demo site has been significantly improved featuring a new **Product content type** that is used to show products in the Tasteful Planet demo.
 The product we used are meals that, in a non-demo ideal world, would be available to order and consume.
-This ordering part isn't in the demo, nevertheless, the content looks really yummy... 
+This ordering part isn't in the demo, nevertheless, the content looks really yummy...
 Other improvements includes the good setup of all content type field categories and the demonstration of basic SEO field types. Demo content itself has also been upgraded with more content to better demonstrate the capabilities.
 
 ![""](productcontenttype.png)

--- a/docs/release_notes/ez_platform_v1.8.0.md
+++ b/docs/release_notes/ez_platform_v1.8.0.md
@@ -70,7 +70,7 @@ If you're looking for the Long Term Support (LTS) release, see[https://ezplatfor
 
 ![""](demo-product-filters.png)
 
-## Full list of new features, improvements and bug fixes since v1.7.0 LTS:
+## Full list of new features, improvements and bug fixes since v1.7.0 LTS
 
 | eZ Platform   | eZ Studio  |
 |--------------|------------|

--- a/docs/release_notes/ez_platform_v1.9.0.md
+++ b/docs/release_notes/ez_platform_v1.9.0.md
@@ -51,7 +51,7 @@ To reflect this change, the content tree button has been renamed **Content brows
 
 #### Tag and taxonomy management
 
-The eZ Enterprise Demo now uses the [Netgen Tags bundle](https://github.com/netgen/TagsBundle). This bundle was recently ported to eZ Platform and provides a powerful, solid and user-friendly way to categorize content using tags. The solution lets editors and administrators define their taxonomies in a dedicated interface. These taxonomies that are immediately available for editors working on content who want to categorize any content types. 
+The eZ Enterprise Demo now uses the [Netgen Tags bundle](https://github.com/netgen/TagsBundle). This bundle was recently ported to eZ Platform and provides a powerful, solid and user-friendly way to categorize content using tags. The solution lets editors and administrators define their taxonomies in a dedicated interface. These taxonomies that are immediately available for editors working on content who want to categorize any content types.
 
 ![""](eztags.gif)
 

--- a/docs/release_notes/ez_platform_v2.3.md
+++ b/docs/release_notes/ez_platform_v2.3.md
@@ -96,6 +96,7 @@ Improvements to the API cover:
 #### Back office translations
 
 There are three new ways you can now contribute to back office translations:
+
 - translate in-context with bookmarks
 - translate in-context with console
 - translate directly on the Crowdin website

--- a/docs/release_notes/ez_platform_v3.1.md
+++ b/docs/release_notes/ez_platform_v3.1.md
@@ -104,7 +104,7 @@ When users create or edit a content item or a Page, they can now save it without
 They can then return to editing, or pass the content to another contributor.
 Validation that used to happen at each save operation now, by default, happens when you click the **Publish** button.
 
-The `ContentService::validate()` method has been added that you can use to trigger validation of individual fields 
+The `ContentService::validate()` method has been added that you can use to trigger validation of individual fields
 or whole content items for completeness at other stages of the editing process.
 
 ### Search

--- a/docs/release_notes/ibexa_dxp_v3.2.md
+++ b/docs/release_notes/ibexa_dxp_v3.2.md
@@ -80,15 +80,15 @@ See [Install Ibexa Platform](https://doc.ibexa.co/en/latest/getting_started/inst
 
 ### Site Factory improvements [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 
-You can now define user group skeletons where you define policies and limitations that apply to a specific user group. 
-You can then associate a number of such skeletons with a site template. 
+You can now define user group skeletons where you define policies and limitations that apply to a specific user group.
+You can then associate a number of such skeletons with a site template.
 User group skeletons survive deleting a site.
 
 For more information, see [Configure user group skeleton](https://doc.ibexa.co/en/latest/guide/multisite/site_factory_configuration/#user-group-skeletons).
 
 ### Calendar widget improvements
 
-You can now see the scheduled blocks in the calendar after you configure the reveal and/or hide dates for them. 
+You can now see the scheduled blocks in the calendar after you configure the reveal and/or hide dates for them.
 This way you can envision what content will be available in the future.
 
 Also, you can now apply new filters that are intended to help you declutter the calendar view.

--- a/docs/release_notes/ibexa_dxp_v3.3.md
+++ b/docs/release_notes/ibexa_dxp_v3.3.md
@@ -29,8 +29,8 @@ See [the updated installation instruction](https://doc.ibexa.co/en/3.3/getting_s
 ### Image Editor
 
 With the Image Editor, users can now perform basic operations, such as cropping or flipping an image,
-or setting a point of focus. 
-The Image Editor is available when browsing the Media library, or creating or editing content items 
+or setting a point of focus.
+The Image Editor is available when browsing the Media library, or creating or editing content items
 that contain an `ezimage` or `ezimageasset` Field.
 
 You can modify the Image Editor's default settings to change its appearance or behavior.
@@ -87,7 +87,7 @@ See [list of changes in Symfony 5.2](https://symfony.com/blog/symfony-5-2-curate
 |--------------|------------|------------|
 | [[[= product_name_content =]] v3.3.0](https://github.com/ibexa/content/releases/tag/v3.3.0) | [[[= product_name_exp =]] v3.3.0](https://github.com/ibexa/experience/releases/tag/v3.3.0) | [[[= product_name_com =]] v3.3.0](https://github.com/ibexa/commerce/releases/tag/v3.3.0)|
 
-## v3.3.15 
+## v3.3.15
 
 ### Symfony 5.4
 

--- a/docs/release_notes/ibexa_dxp_v4.0.md
+++ b/docs/release_notes/ibexa_dxp_v4.0.md
@@ -40,14 +40,14 @@ Separate currencies enable you to set different price rules for different curren
 
 ### Taxonomy management
 
-You can now organize content adding tags and create taxonomy categories to make it easy for your 
+You can now organize content adding tags and create taxonomy categories to make it easy for your
 site users to browse and to deliver content appropriate for them.
 
 ### Separate recommendations for different websites
 
-Personalization service has been enhanced to allow returning separate recommendations 
-for different websites. 
-This way you can eliminate irrelevant recommendations when you set up stores that 
+Personalization service has been enhanced to allow returning separate recommendations
+for different websites.
+This way you can eliminate irrelevant recommendations when you set up stores that
 operate on different markets or under different brands.
 
 For more information, see [Support for multiple websites](https://doc.ibexa.co/projects/userguide/en/latest/personalization/use_cases/#multiple-website-hosting).
@@ -56,8 +56,8 @@ For more information, see [Support for multiple websites](https://doc.ibexa.co/p
 
 ### Draft locking
 
-You can now configure and use the locking feature to lock a draft of a content item, 
-so that only an assigned person can edit it, and no other user can take it over. 
+You can now configure and use the locking feature to lock a draft of a content item,
+so that only an assigned person can edit it, and no other user can take it over.
 
 For more information, see the [Draft locking](https://doc.ibexa.co/en/latest/guide/workflow/workflow/#draft-locking)
 and relevant [User Documentation](https://doc.ibexa.co/projects/userguide/en/latest/publishing/editorial_workflow/#releasing-locked-drafts).

--- a/docs/release_notes/ibexa_dxp_v4.0_deprecations.md
+++ b/docs/release_notes/ibexa_dxp_v4.0_deprecations.md
@@ -27,7 +27,7 @@ for a full comparison of old and new bundle names and namespaces.
 
 ### Richtext namespace
 
-The internal format of richtext has changed. 
+The internal format of richtext has changed.
 
 All namespace changes are listed in the
 [richtext](https://github.com/ibexa/fieldtype-richtext/blob/bf45e57ea1d2933cc02eb8d8bff76c0925de92de/src/bundle/Resources/config/default_settings.yaml#L60-L67) repository.

--- a/docs/release_notes/ibexa_dxp_v4.2.md
+++ b/docs/release_notes/ibexa_dxp_v4.2.md
@@ -164,7 +164,7 @@ Querying product attributes with GraphQL is improved with the option to [query b
 
 ### New ways to add images in Online Editor
 
-You can now drag and drop images directly into the Online Editor. 
+You can now drag and drop images directly into the Online Editor.
 To achieve the same result, you can also click the **Upload image** button and select a file from the disk.
 Images that you upload this way are automatically added to the Media library.
 

--- a/docs/release_notes/ibexa_dxp_v4.3.md
+++ b/docs/release_notes/ibexa_dxp_v4.3.md
@@ -38,7 +38,7 @@ By adding additional steps and options, you can build a process that perfectly m
 ### SEO configuration exposed
 
 SEO configuration gains a more prominent place on the content type editing screen.
-For example, to enable SEO, you now have to edit the content type that you want to modify, 
+For example, to enable SEO, you now have to edit the content type that you want to modify,
 scroll down to the SEO section and switch the **Enable SEO for this content type** toggle.
 
 For more information, see [Work with SEO](https://doc.ibexa.co/projects/userguide/en/latest/search_engine_optimization/work_with_seo/).
@@ -126,7 +126,7 @@ The `TaxonomyEntryId` Search Criterion isn't available in Legacy search Engine.
 
 ## v4.3.1
 
-### New REST API endpoints 
+### New REST API endpoints
 
 You can now use new REST API routes that confirm whether the User is logged in,
 without invoking any other route:
@@ -154,7 +154,7 @@ It allows REST API endpoints to work with cookie-based authentication.
 
 #### HTTP cache support for product-related responses
 
-Customer group is now part of user context, which enables HTTP cache to support 
+Customer group is now part of user context, which enables HTTP cache to support
 product-related responses.
 
 #### Ability to retrieve a customer group

--- a/docs/release_notes/ibexa_dxp_v4.4.md
+++ b/docs/release_notes/ibexa_dxp_v4.4.md
@@ -29,7 +29,7 @@ This release deprecates all Commerce packages that you've known from previous re
 - `ibexa/checkout`
 - `ibexa/storefront`
 
-As part of this effort, two all-new components have been created: Cart and Checkout, that you can use to build your own e-commerce presence. 
+As part of this effort, two all-new components have been created: Cart and Checkout, that you can use to build your own e-commerce presence.
 
 ![The new cart view](img/4.4_new_cart.png "The new cart view")
 

--- a/docs/release_notes/ibexa_dxp_v4.5.md
+++ b/docs/release_notes/ibexa_dxp_v4.5.md
@@ -29,16 +29,16 @@ Modules can interact with each other, for example, to decrease stock as a result
 
 #### Order management
 
-With order management in place, it's now possible to create orders, configure and customize the order processing workflow, and manage orders by using the APIs. 
+With order management in place, it's now possible to create orders, configure and customize the order processing workflow, and manage orders by using the APIs.
 
-New screens added to the back office user interface let [[= product_name =]] users search for orders and filter search results. 
+New screens added to the back office user interface let [[= product_name =]] users search for orders and filter search results.
 Users can also review order details and completion status, and cancel orders.
 
 ![The order list screen](img/4.5_order_list.png "The order list screen")
 
 #### Payment
 
-The all-new Payment module brings a possibility of tracking payment progress and defining a custom payment processing workflow. 
+The all-new Payment module brings a possibility of tracking payment progress and defining a custom payment processing workflow.
 New back office screens allow users to search for payment methods and payments, and also define, enable, and disable offline payment methods.
 
 Additionally, new APIs are available, which can be used for managing payment methods and payments.
@@ -50,7 +50,7 @@ Additionally, new APIs are available, which can be used for managing payment met
 With the arrival of the Shipping module, it's now possible to define and manage shipping methods of different types, together with their related costs, on a dedicated back office screen.
 You can now also configure and customize the shipment workflow.
 
-New APIs enable managing shipping methods and payments, while an extension point can be used to expand the default list of shipping method types. 
+New APIs enable managing shipping methods and payments, while an extension point can be used to expand the default list of shipping method types.
 
 ![The shipping methods screen](img/4.5_shipping_methods.png "The shipping methods screen")
 
@@ -109,7 +109,7 @@ B2B recurring purchase model anticipates and predicts purchase of products that 
 ### Segment management
 
 Now you can use segmentation logic with operators to build complex segment groups which enable precise filtering.
-With intuitive drag-and-drop interface, define rules, add logic operators and nest segments in segment 
+With intuitive drag-and-drop interface, define rules, add logic operators and nest segments in segment
 groups to get the most accurate, precise and targeted recommendations for your customers.
 
 ![Segment management](img/4.5_segment_management.png "Segment management logic")
@@ -119,7 +119,7 @@ For more information, see [Segment management](https://doc.ibexa.co/projects/use
 ## Other changes
 
 ### Customer Data Platform (CDP) configuration
- 
+
 In this release, the CDP configuration becomes more generic
 and allows supporting other transport types accepted by CDP.
 Currently, only `stream_file` transport is supported and can be initialized from the configuration.
@@ -156,7 +156,7 @@ To create a company with proper structure and shipping address by using PHP API,
 This release adds new endpoints that allow you to manage orders by using REST API:
 
 - GET `/orders/orders` - loads a list of orders
-- POST `/orders/orders` - creates an order 
+- POST `/orders/orders` - creates an order
 - GET `/orders/order` - loads an order by its identifier
 - GET `/orders/order/{id}` - loads an order
 - POST `/orders/orders/{id}` - cancels an order
@@ -170,8 +170,8 @@ The Order Management package provides the `Ibexa\Contracts\OrderManagement\Order
 
 The Checkout package provides the following services that are entrypoints to the backend API:
 
-- `Ibexa\Contracts\Shipping\ShipmentServiceInterface` for managing shipments 
-- `Ibexa\Contracts\Shipping\ShippingMethodServiceInterface` for managing shipment methods 
+- `Ibexa\Contracts\Shipping\ShipmentServiceInterface` for managing shipments
+- `Ibexa\Contracts\Shipping\ShippingMethodServiceInterface` for managing shipment methods
 
 #### PHP API for payment methods and payments [[% include 'snippets/commerce_badge.md' %]]
 

--- a/docs/release_notes/ibexa_dxp_v5.0.md
+++ b/docs/release_notes/ibexa_dxp_v5.0.md
@@ -200,7 +200,7 @@ For more information about Recommendation blocks in Page Builder, see the releva
 
 The [[= pim_product_name =]] integration add-on allows you to connect [[= product_name =]] with [[[= pim_product_name =]] Product Information Management (PIM)](https://www.quable.com/en), making [[= pim_product_name =]] the authoritative source of product information for every website powered by [[= product_name =]].
 
-[[= pim_product_name =]] can serve as the single source of truth for all product data, including attributes, classifications, variants, and translations. 
+[[= pim_product_name =]] can serve as the single source of truth for all product data, including attributes, classifications, variants, and translations.
 [[= product_name =]] consumes this data and makes it available for use in content and digital experiences.
 
 For more information, see [Quable PIM Integration](https://doc.ibexa.co/en/5.0/product_catalog/quable/quable/).
@@ -640,7 +640,7 @@ Internal and external users can be invited to a collaboration session, through d
 
 With Real-time editing, more advanced part of the feature, users can see each other’s changes in the real time, or work on the content asynchronously.
 
-Additionally, shared drafts can be accessed and managed through new dashboard tabs: **My shared drafts** and **Drafts shared with me**, helping users stay organized. 
+Additionally, shared drafts can be accessed and managed through new dashboard tabs: **My shared drafts** and **Drafts shared with me**, helping users stay organized.
 
 ### Discount indexing
 
@@ -902,7 +902,7 @@ This upgrade enhances maintainability, unlocks new UI capabilities, and simplifi
 
 ### Developer experience
 
-#### New packages 
+#### New packages
 
 The following packages have been introduced in [[= product_name =]] v5.0.0:
 

--- a/docs/release_notes/ibexa_dxp_v5.0.md
+++ b/docs/release_notes/ibexa_dxp_v5.0.md
@@ -519,7 +519,7 @@ For more information, see [Taxonomy suggestions](https://doc.ibexa.co/en/5.0/con
 
 The following additions were made to the PHP API:
 
-##### Real-time collaborative editing:
+##### Real-time collaborative editing
 
 - [`Ibexa\Contracts\Collaboration\Invitation\Query\Criterion\ParticipantScope`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-Invitation-Query-Criterion-ParticipantScope.html)
 - [`Ibexa\Contracts\Collaboration\Invitation\Query\Criterion\ParticipantType`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-Invitation-Query-Criterion-ParticipantType.html)
@@ -534,7 +534,7 @@ The following additions were made to the PHP API:
 - [`Ibexa\Contracts\FieldTypeRichTextRTE\ToS\ToSServiceInterface`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-FieldTypeRichTextRTE-ToS-ToSServiceInterface.html)
 - [`Ibexa\Contracts\Share\Mapper\Action\ShareActionItemsMapperInterface`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Share-Mapper-Action-ShareActionItemsMapperInterface.html)
 
-##### AI Taxonomy suggestions:
+##### AI Taxonomy suggestions
 
 - [`Ibexa\Contracts\ConnectorAi\Action\DataType\Taxonomy`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Action-DataType-Taxonomy.html)
 - [`Ibexa\Contracts\ConnectorAi\Action\DataType\TaxonomyEntry`](https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Action-DataType-TaxonomyEntry.html)

--- a/docs/release_notes/ibexa_dxp_v5.0_deprecations.md
+++ b/docs/release_notes/ibexa_dxp_v5.0_deprecations.md
@@ -153,7 +153,7 @@ Several field type identifiers have changed.
 
 | Old FQN                                              | New FQN / Comment                                                                |
 |:------------------------------------------------------|:------------------------------------------------------------------------|
-| `\Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface::getContentCreateLimitations`| `\Ibexa\AdminUi\Permission\LimitationResolverInterface::getContentCreateLimitations` | 
+| `\Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface::getContentCreateLimitations`| `\Ibexa\AdminUi\Permission\LimitationResolverInterface::getContentCreateLimitations` |
 | `\Ibexa\Contracts\AdminUi\Permission\PermissionCheckerInterface::getContentUpdateLimitations` | `\Ibexa\AdminUi\Permission\LimitationResolverInterface::getContentUpdateLimitations` |
 | `\Ibexa\Contracts\AdminUi\UniversalDiscovery\Provider::getRestFormat` | Removed |
 | `\Ibexa\AdminUi\Form\Type\Search\DateIntervalType` | `\Ibexa\AdminUi\Form\Type\Date\DateIntervalType`|

--- a/docs/resources/contributing/report_and_follow_issues.md
+++ b/docs/resources/contributing/report_and_follow_issues.md
@@ -5,7 +5,7 @@ description: You can report encountered issues to Service Portal
 # Report and follow issues
 
 If you have an [[= product_name =]] subscription, report your issues through the [Service portal](https://support.ibexa.co).
-To do it, log in to your Service portal at <https://support.ibexa.co/>, click "New Ticket", and report the issue as you would report a normal support request. 
+To do it, log in to your Service portal at <https://support.ibexa.co/>, click "New Ticket", and report the issue as you would report a normal support request.
 [[= product_name_base =]] Product Support will respond, take care of the report, and keep you informed of the developments.
 This ensures the issue can be quickly prioritized according to its impact.
 

--- a/docs/search/aggregation_reference/daterange_aggregation.md
+++ b/docs/search/aggregation_reference/daterange_aggregation.md
@@ -9,6 +9,7 @@ The field-based [DateRangeAggregation](/api/php_api/php_api_reference/classes/Ib
 ## Arguments
 
 [[= include_file('docs/snippets/aggregation_arguments.md') =]]
+
 - `ranges` - array of Range objects that define the borders of the specific range sets
 
 ## Example

--- a/docs/search/aggregation_reference/datetimerange_aggregation.md
+++ b/docs/search/aggregation_reference/datetimerange_aggregation.md
@@ -9,6 +9,7 @@ The field-based [DateTimeRangeAggregation](/api/php_api/php_api_reference/classe
 ## Arguments
 
 [[= include_file('docs/snippets/aggregation_arguments.md') =]]
+
 - `ranges` - array of Range objects that define the borders of the specific range sets
 
 ## Example

--- a/docs/search/aggregation_reference/floatrange_aggregation.md
+++ b/docs/search/aggregation_reference/floatrange_aggregation.md
@@ -9,6 +9,7 @@ The field-based [FloatRangeAggregation](/api/php_api/php_api_reference/classes/I
 ## Arguments
 
 [[= include_file('docs/snippets/aggregation_arguments.md') =]]
+
 - `ranges` - array of Range objects that define the borders of the specific range sets
 
 ## Example

--- a/docs/search/aggregation_reference/integerrange_aggregation.md
+++ b/docs/search/aggregation_reference/integerrange_aggregation.md
@@ -9,6 +9,7 @@ The field-based [IntegerRangeAggregation](/api/php_api/php_api_reference/classes
 ## Arguments
 
 [[= include_file('docs/snippets/aggregation_arguments.md') =]]
+
 - `ranges` - array of Range objects that define the borders of the specific range sets
 
 ## Example

--- a/docs/search/aggregation_reference/timerange_aggregation.md
+++ b/docs/search/aggregation_reference/timerange_aggregation.md
@@ -9,6 +9,7 @@ The field-based [TimeRangeAggregation](/api/php_api/php_api_reference/classes/Ib
 ## Arguments
 
 [[= include_file('docs/snippets/aggregation_arguments.md') =]]
+
 - `ranges` - array of Range objects that define the borders of the specific range sets
 
 ## Example

--- a/docs/search/search_engines/solr_search_engine/install_solr.md
+++ b/docs/search/search_engines/solr_search_engine/install_solr.md
@@ -132,7 +132,7 @@ Configure the spellcheck component in `solrconfig.xml`:
   </searchComponent>
 ```
 
-Add this `spellcheck` component to the `/select` request handler: 
+Add this `spellcheck` component to the `/select` request handler:
 
 ```xml
   <requestHandler name="/select" class="solr.SearchHandler">
@@ -375,7 +375,7 @@ Here are the most common issues you may encounter:
     - If your database is inconsistent in regards to file paths, try to update entries to be correct *(make sure to make a backup first)*.
 - Exception on unsupported field types
     - Make sure to implement all field types in your installation, or to configure missing ones as [NullType](nullfield.md) if implementation isn't needed.
-- Content isn't immediately available 
+- Content isn't immediately available
     - Solr Bundle on purpose doesn't commit changes directly on Repository updates *(on indexing)*,
       but lets you control this using Solr configuration. Adjust Solr's `autoSoftCommit` (visibility of changes to search index) and/or `autoCommit` (hard commit, for durability and replication)
       to balance performance and load on your Solr instance against needs you have for "[NRT](https://solr.apache.org/guide/7_7/near-real-time-searching.html)".

--- a/docs/tutorials/beginner_tutorial/2_create_the_content_model.md
+++ b/docs/tutorials/beginner_tutorial/2_create_the_content_model.md
@@ -42,16 +42,16 @@ In the main menu, go to **Content** -> **Content types**.
 You can see a list of **Content type groups**.
 They're used to group content types in a logical way.
 
-Select **Content** and then click the **Create** button. 
+Select **Content** and then click the **Create** button.
 
 ![Add a content type button](bike_tutorial_create_content_type.png)
 
-Fill the form with this basic info: 
+Fill the form with this basic info:
 
 - **Name**: Ride
 - **Identifier**: `ride`
 
-Then create all fields with the following information: 
+Then create all fields with the following information:
 
 | Field type   | Name             | Identifier       |  Required | Searchable | Translatable |
 | ------------ | ---------------- | ---------------- | --------- | ---------- | ------------ |

--- a/docs/tutorials/beginner_tutorial/7_embed_content.md
+++ b/docs/tutorials/beginner_tutorial/7_embed_content.md
@@ -21,7 +21,7 @@ Each Ride may be related to multiple Landmarks.
 - **Name**: Landmark
 - **Identifier**: landmark
 
-Then add all fields with the following information: 
+Then add all fields with the following information:
 
 | Field type   | Name             | Identifier       |  Required | Searchable | Translatable |
 | ------------ | ---------------- | ---------------- | --------- | ---------- | ------------ |

--- a/docs/update_and_migration/from_1.x_2.x/update_app_to_2.5.md
+++ b/docs/update_and_migration/from_1.x_2.x/update_app_to_2.5.md
@@ -15,7 +15,7 @@ latest_tag: '2.5.30'
 
 ## 3. Update the app
 
-If `EzSystemsPlatformEEAssetsBundle` is present in `app/AppKernel.php`, 
+If `EzSystemsPlatformEEAssetsBundle` is present in `app/AppKernel.php`,
 disable it by removing the `new EzSystems\PlatformEEAssetsBundle\EzSystemsPlatformEEAssetsBundle(),` entry.
 
 Since v2.5 eZ Platform uses [Webpack Encore]([[= symfony_doc =]]/frontend.html#webpack-encore) for asset management.

--- a/docs/update_and_migration/from_1.x_2.x/update_db_to_2.5.md
+++ b/docs/update_and_migration/from_1.x_2.x/update_db_to_2.5.md
@@ -88,7 +88,7 @@ In v2.2 Page Builder doesn't offer all blocks that landing page editor did. The 
 The Places block has been removed from the clean installation and is only available in the demo out of the box.
 If you use this block in your site, re-apply its configuration based on the [demo](https://github.com/ezsystems/ezplatform-ee-demo/blob/v2.2.2/app/config/blocks.yml).
 
-Later versions of Page Builder come with a Content Scheduler block and new Form Blocks, but migration of Schedule blocks to Content Scheduler blocks and of Form Blocks isn't supported. 
+Later versions of Page Builder come with a Content Scheduler block and new Form Blocks, but migration of Schedule blocks to Content Scheduler blocks and of Form Blocks isn't supported.
 
 If there are missing block definitions, such as Form Block or Schedule Block,
 you have an option to continue, but migrated landing pages come without those blocks.
@@ -112,7 +112,7 @@ See [documentation](render_page.md#render-a-layout) for an example on usage of t
 
 ###### Migrate custom blocks
 
-Landing page blocks (from v2.1 and earlier) were defined using a class implementing `EzSystems\LandingPageFieldTypeBundle\FieldType\LandingPage\Model\AbstractBlockType`. 
+Landing page blocks (from v2.1 and earlier) were defined using a class implementing `EzSystems\LandingPageFieldTypeBundle\FieldType\LandingPage\Model\AbstractBlockType`.
 In Page Builder (from v2.2 onwards), this interface is no longer present. Instead the logic of your block must be implemented in a [Listener](page_blocks.md#block-events).
 Typically, what you previously would do in `getTemplateParameters()`, you now do in the `onBlockPreRender()` event handler.
 
@@ -139,7 +139,7 @@ This converter is only needed when running the `ezplatform:page:migrate` script 
 
 ###### Page migration example
 
-Below is an example how to migrate a landing page Layout and Block to new Page Builder. The code is based on the Random block 
+Below is an example how to migrate a landing page Layout and Block to new Page Builder. The code is based on the Random block
 defined in the [Enterprise Beginner tutorial](page_and_form_tutorial.md)
 
 ??? tip "Landing page code"
@@ -718,7 +718,7 @@ ezrichtext:
 The old configuration is deprecated, so if you use custom tags, you need to modify your config accordingly.
 
 ### D. Update to v2.5
-    
+
 #### Database update script
 
 Apply the following database update script:
@@ -866,7 +866,7 @@ You do this manually by following this procedure:
 
 1. Update your project to v2.5.18 and run the `php bin/console cache:clear` command to generate the [service container](php_api.md#service-container).
 
-1. Run the following command to discover the names of the new entity managers. 
+1. Run the following command to discover the names of the new entity managers.
     Take note of the names that you discover:
 
     `php bin/console debug:container --parameter=doctrine.entity_managers --format=json | grep ibexa_`

--- a/docs/update_and_migration/from_2.5/adapt_code_to_v3.md
+++ b/docs/update_and_migration/from_2.5/adapt_code_to_v3.md
@@ -85,7 +85,7 @@ To properly refactor your code, you might need to run the Rector `process` comma
 
 `vendor/bin/rector process src --set symfony40`
 
-You can find all the available sets in [the Rector repository](https://github.com/rectorphp/rector/tree/v0.7.65/config/set). 
+You can find all the available sets in [the Rector repository](https://github.com/rectorphp/rector/tree/v0.7.65/config/set).
 Keep in mind that after automatic refactoring finishes there might be some code chunks that you need to fix manually.
 
 ### Update code for specific parts of the system

--- a/docs/update_and_migration/from_2.5/update_code/8_update_rest.md
+++ b/docs/update_and_migration/from_2.5/update_code/8_update_rest.md
@@ -20,7 +20,7 @@ If your project uses custom installer and has relied on Clean Installer service 
 you need to switch to Core Installer.
 
 **Use:**
-    
+
 ``` php
 services:
     Acme\App\Installer\MyCustomInstaller:
@@ -28,7 +28,7 @@ services:
 ```
 
 **instead of**:
-    
+
 ``` php
 services:
     Acme\App\Installer\MyCustomInstaller:

--- a/docs/update_and_migration/from_2.5/update_code/9_update_other.md
+++ b/docs/update_and_migration/from_2.5/update_code/9_update_other.md
@@ -21,7 +21,7 @@ security:
 ## Commands
 
 The `ContainerAwareCommand` class isn't available in Symfony 5. Therefore, if your custom commands use `Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand`
-as a base class, you must rewrite them to use `Symfony\Component\Console\Command\Command` instead. 
+as a base class, you must rewrite them to use `Symfony\Component\Console\Command\Command` instead.
 
 ## Permissions
 
@@ -32,7 +32,7 @@ If your code uses them, you must rewrite it to use the permission resolver.
 
 A number of Symfony [service container](php_api.md#service-container) parameters [have been dropped](https://github.com/ezsystems/ezplatform-kernel/blob/v1.0.0/doc/bc/1.0/dropped-container-parameters.md).
 
-Check if your code uses such invalid parameters: search for them by using the `ezpublish\..*\.class` regular expression pattern. 
+Check if your code uses such invalid parameters: search for them by using the `ezpublish\..*\.class` regular expression pattern.
 When found, replace all the occurrences with fully-qualified class names.
 
 ## QueryTypes
@@ -42,7 +42,7 @@ you need to register your QueryTypes as services and tag them with `ezpublish.qu
 
 ## Symfony namespaces
 
-A number of Symfony namespaces have changed, and you must update your code if it uses them. 
+A number of Symfony namespaces have changed, and you must update your code if it uses them.
 For example, the following namespaces are now different:
 
 |Use|Instead of|
@@ -60,7 +60,7 @@ for an example.
 
 ## Deprecations
 
-Due to a number of compatibility breaks and deprecations introduced in eZ Platform v3.0, the changes that result from the above considerations might not be sufficient. 
+Due to a number of compatibility breaks and deprecations introduced in eZ Platform v3.0, the changes that result from the above considerations might not be sufficient.
 Make sure that you review your code and account for all changes listed in [Deprecations and backwards compatibility breaks](ez_platform_v3.0_deprecations.md).
 
 ## Next steps

--- a/docs/update_and_migration/from_3.3/to_4.0.md
+++ b/docs/update_and_migration/from_3.3/to_4.0.md
@@ -50,10 +50,10 @@ First, run:
 The `flex.ibexa.co` Flex server has been disabled.
 If you're using v4.0.2 or earlier v4.0 version, you need to update your Flex server.
 
-To do it, in your `composer.json` check whether the `https://flex.ibexa.co` endpoint is still listed in `extra.symfony.endpoint`. 
+To do it, in your `composer.json` check whether the `https://flex.ibexa.co` endpoint is still listed in `extra.symfony.endpoint`.
 If so, replace it with the new [`https://api.github.com/repos/ibexa/recipes/contents/index.json?ref=flex/main`](https://github.com/ibexa/website-skeleton/blob/v4.0.7/composer.json#L98) endpoint.
 
-If your `composer.json` still uses the `https://flex.ibexa.co` endpoint in `extra.symfony.endpoint`, 
+If your `composer.json` still uses the `https://flex.ibexa.co` endpoint in `extra.symfony.endpoint`,
 replace it with the new [`https://api.github.com/repos/ibexa/recipes/contents/index.json?ref=flex/main`](https://github.com/ibexa/website-skeleton/blob/v4.0.7/composer.json#L96) endpoint.
 
 You can do it manually, or by running the following command:

--- a/docs/update_and_migration/from_3.3/update_from_3.3.md
+++ b/docs/update_and_migration/from_3.3/update_from_3.3.md
@@ -117,7 +117,7 @@ You do this manually by following this procedure:
 
 1. Update your project to v3.3.2 and run the `php bin/console cache:clear` command to generate the service container.
 
-1. Run the following command to discover the names of the new entity managers. 
+1. Run the following command to discover the names of the new entity managers.
     Take note of the names that you discover:
 
     `php bin/console debug:container --parameter=doctrine.entity_managers --format=json | grep ibexa_`
@@ -178,7 +178,7 @@ mysql -u<username> -p<password> <database_name> < vendor/ibexa/installer/upgrade
 ### v3.3.4
 
 #### Migration Bundle
-    
+
 Remove `Kaliop\eZMigrationBundle\eZMigrationBundle::class => ['all' => true],`
 from `config/bundles.php` before running `composer require`.
 
@@ -448,7 +448,7 @@ No additional steps needed.
 
 This release contains security fixes.
 For more information, see [the published security advisory](https://developers.ibexa.co/security-advisories/ibexa-sa-2024-006-vulnerabilities-in-content-name-pattern-commerce-shop-and-varnish-vhost-templates).
-For each of the following fixes, evaluate the vulnerability to determine whether you might have been affected. 
+For each of the following fixes, evaluate the vulnerability to determine whether you might have been affected.
 If so, take appropriate action, for example by [revoking passwords](https://doc.ibexa.co/en/latest/users/passwords/#revoking-passwords) for all affected users.
 
 ##### <abbr title="Browser Reconnaissance & Exfiltration via Adaptive Compression of Hypertext">BREACH</abbr> vulnerability

--- a/docs/update_and_migration/from_4.0/to_4.1.md
+++ b/docs/update_and_migration/from_4.0/to_4.1.md
@@ -173,18 +173,18 @@ Apply the following database update scripts:
 
     Always back up your data before you perform any actions on the product catalog.
 
-Regardless of whether your application already uses the product catalog or you want 
-to start using this functionality, you can choose to use the old features, 
+Regardless of whether your application already uses the product catalog or you want
+to start using this functionality, you can choose to use the old features,
 present in v4.0.x, or upgrade to the all new product catalog that v4.1.x brings.
 
-To use the legacy solution, in the `config/packages` folder, 
-in YAML files with shop configuration, under the `parameters` key, 
+To use the legacy solution, in the `config/packages` folder,
+in YAML files with shop configuration, under the `parameters` key,
 make sure that the `ibexa.commerce.site_access.config.eshop.default.catalog_data_provider` parameter is set to `ez5`.
   
-To use the new product catalog, since the new solution doesn't support the old 
-price engine out of the box, in your price engine configuration, 
-you must update the following parameters by providing the 
-`Ibexa\\ProductCatalog\\Bridge\\PriceProvider` value in the `ibexa_setting` table, 
+To use the new product catalog, since the new solution doesn't support the old
+price engine out of the box, in your price engine configuration,
+you must update the following parameters by providing the
+`Ibexa\\ProductCatalog\\Bridge\\PriceProvider` value in the `ibexa_setting` table,
 `commerce` group, `config` identifier:
 
 ```yaml

--- a/docs/update_and_migration/from_4.1/update_from_4.1.md
+++ b/docs/update_and_migration/from_4.1/update_from_4.1.md
@@ -75,7 +75,7 @@ First, run:
     composer recipes:install ibexa/commerce --force -v
     ```
 
-The `recipes:install` command installs new YAML configuration files. 
+The `recipes:install` command installs new YAML configuration files.
 Review the old YAML files and move your custom configuration to the relevant new files.
 
 #### Run data migration

--- a/docs/update_and_migration/from_4.5/update_from_4.5.md
+++ b/docs/update_and_migration/from_4.5/update_from_4.5.md
@@ -466,7 +466,7 @@ Configure the `spellcheck` component in `solrconfig.xml`:
   </searchComponent>
 ```
 
-Add this `spellcheck` component to the `/select` request handler: 
+Add this `spellcheck` component to the `/select` request handler:
 
 ```xml
   <requestHandler name="/select" class="solr.SearchHandler">

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -304,7 +304,7 @@ No additional steps needed.
 ### Security
 
 This release fixes a critical vulnerability in the [RichText field type](richtextfield.md).
-By entering a maliciously crafted input into the RichText field type's XML, the attacker could perform an attack using [XML external entity (XXE) injection](https://portswigger.net/web-security/xxe). 
+By entering a maliciously crafted input into the RichText field type's XML, the attacker could perform an attack using [XML external entity (XXE) injection](https://portswigger.net/web-security/xxe).
 To exploit this vulnerability, an attacker would need to have edit permission to content with RichText fields.
 
 For more information, see the [published security advisory IBEXA-SA-2025-002](https://developers.ibexa.co/security-advisories/ibexa-sa-2025-002-xxe-vulnerability-in-richtext).
@@ -702,7 +702,7 @@ For more information, see the following security advisories:
     - [PKSA-1tmc-rt7x-12w6](https://packagist.org/security-advisories/PKSA-1tmc-rt7x-12w6)
     - [PKSA-xx6c-6d96-db2w](https://packagist.org/security-advisories/PKSA-xx6c-6d96-db2w)
 
-To use these packages in versions not affected by security vulnerabilities, PHP 8.1 is the minimum required version. 
+To use these packages in versions not affected by security vulnerabilities, PHP 8.1 is the minimum required version.
 
 For projects meeting this requirement, you can update the packages with Composer.
 

--- a/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish.md
+++ b/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish.md
@@ -27,11 +27,11 @@ The 6th generation is aimed at being fully backwards compatible on the following
 
 The specific incompatibilities
 
-The specific changes that are migrated and are incompatible with legacy are: 
+The specific changes that are migrated and are incompatible with legacy are:
 
 - XmlText fields have been replaced with a new [RichText](richtextfield.md) field
 - Page field (ezflow) has been replaced by the [LandingPage](pagefield.md) field, and is now provided by our commercial product [eZ Platform Enterprise Edition](http://ezstudio.com/)
-- Incremental future improvements to the database schema to improve features and scalability of the content repository 
+- Incremental future improvements to the database schema to improve features and scalability of the content repository
 
 Together these major improvements make it practically impossible to run eZ Platform side by side with eZ Publish legacy, like it was possible in 5.x series.
 *For these reasons we recommend that you use eZ Publish Enterprise 5.4  ([which is supported until end of 2021](https://support.ez.no/Public/Service-Life)) if you don't have the option to remake your web application yet, or want to do it gradually.*

--- a/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
+++ b/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
@@ -256,7 +256,7 @@ When that is done, execute the following to update and install all packages from
 
 Add the following new bundle to your new kernel file, `<new-ez-root>/app/AppKernel.php`:
 
-`new EzSystems\EzPlatformXmlTextFieldTypeBundle\EzSystemsEzPlatformXmlTextFieldTypeBundle(),` 
+`new EzSystems\EzPlatformXmlTextFieldTypeBundle\EzSystemsEzPlatformXmlTextFieldTypeBundle(),`
 
 ## Step 3: Upgrade the database
 

--- a/docs/users/user_authentication.md
+++ b/docs/users/user_authentication.md
@@ -44,7 +44,7 @@ In `config/packages/security.yaml`, add the `memory` and `chain` user providers,
 ```
 
 In the `config/services.yaml` file, declare the subscriber as a service to pass your user map.
-Since it implements the `EventSubscriberInterface`, it's automatically tagged as a `kernel.event_subscriber`. 
+Since it implements the `EventSubscriberInterface`, it's automatically tagged as a `kernel.event_subscriber`.
 The config resolver and user service injections are auto-wired automatically.
 
 ``` yaml


### PR DESCRIPTION
Adding more Markdownlint rules.

It's possible to review the changes commit by commit - each one introduces a new rule.

Some of them are still commented - but I want to keep this PR small to make it easier to review.

Rules:

- `no-trailing-spaces`: https://github.com/DavidAnson/markdownlint/blob/0213a0274dfeaac589af389f6c9bc9e821655810/doc/md009.md
- `no-trailing-punctuation`: https://github.com/DavidAnson/markdownlint/blob/0213a0274dfeaac589af389f6c9bc9e821655810/doc/md026.md
- `blanks-around-lists`: https://github.com/DavidAnson/markdownlint/blob/0213a0274dfeaac589af389f6c9bc9e821655810/doc/md032.md