### PR TITLE
Update Raptor links

### DIFF
--- a/docs/release_notes/ibexa_dxp_v5.0.md
+++ b/docs/release_notes/ibexa_dxp_v5.0.md
@@ -63,8 +63,10 @@ For more information, see [Raptor connector](https://doc.ibexa.co/en/5.0/recomme
 
 This add-on includes two Twig functions to ease tracking setting:
 
-- `ibexa_tracking_script` to load the JavaScript tracking code, for more information, see [Tracking script](https://doc.ibexa.co/en/5.0/recommendations/raptor_integration/tracking_functions/)
-- `ibexa_tracking_track_event` to send tracking events from your pages, for more information, see [Tracking event function](https://doc.ibexa.co/en/5.0/recommendations/raptor_integration/tracking_functions/)
+- `ibexa_tracking_script` to load the JavaScript tracking code
+- `ibexa_tracking_track_event` to send tracking events from your pages
+
+For more information, see [Raptor tracking functions](https://doc.ibexa.co/en/5.0/recommendations/raptor_integration/tracking_functions/).
 
 #### Recommendations blocks [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Looking at db5ae1390190bb44198bfcf2039bacf63039758f `#### Tracking`:
Links have the same target with different texts.

`https://doc.ibexa.co/en/5.0/cdp/raptor_integration/tracking_script/` was from #3105.
Its closer equivalent is https://doc.ibexa.co/en/5.0/templating/twig_function_reference/recommendations_twig_functions/#ibexa_tracking_script-function

`https://doc.ibexa.co/en/5.0/cdp/raptor_integration/tracking_event_function/` was from #3110.
It's splitted in a bit of https://doc.ibexa.co/en/5.0/recommendations/raptor_integration/tracking_functions/ and mostly https://doc.ibexa.co/en/5.0/templating/twig_function_reference/recommendations_twig_functions/#ibexa_tracking_track_event-function

But I wouldn't go to the "Recommendations Twig functions" page directly. https://doc.ibexa.co/en/5.0/recommendations/raptor_integration/tracking_functions/ is a good introduction.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
