### PR TITLE
Update DDEV doc links

### DIFF
--- a/docs/getting_started/install_with_ddev.md
+++ b/docs/getting_started/install_with_ddev.md
@@ -12,7 +12,7 @@ DDEV is an open-source tool that simplifies the process of setting up local PHP 
 Before you start the installation, ensure that you have the following software installed:
 
 - [Docker](https://docs.docker.com/get-started/get-docker/)
-- [DDEV](https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/)
+- [DDEV](https://docs.ddev.com/en/latest/users/install/ddev-installation/)
 
 ## Installation
 
@@ -53,7 +53,7 @@ ddev config --database=mysql:8.4
 ```
 
 You can also use other versions of MariaDB, MySQL or PostgreSQL.
-See [DDEV database types documentation](https://ddev.readthedocs.io/en/latest/users/extend/database-types/) for available version ranges.
+See [DDEV database types documentation](https://docs.ddev.com/en/latest/users/extend/database-types/) for available version ranges.
 
 #### Configure database connection
 
@@ -90,19 +90,19 @@ Depending on your database of choice (MySQL or PostgreSQL), use the appropriate 
 
 #### Enable Mutagen (optional)
 
-If you're using macOS or Windows, you might want to enable [Mutagen](https://ddev.readthedocs.io/en/latest/users/install/performance/#mutagen) to improve performance.
+If you're using macOS or Windows, you might want to enable [Mutagen](https://docs.ddev.com/en/latest/users/install/performance/#mutagen) to improve performance.
 You can do this by running the following command:
 
 ```bash
 ddev config --performance-mode=mutagen
 ```
 
-See [DDEV performance documentation](https://ddev.readthedocs.io/en/latest/users/install/performance/) for more.
+See [DDEV performance documentation](https://docs.ddev.com/en/latest/users/install/performance/) for more.
 
 #### Change port mapping (optional)
 
 By default, DDEV uses ports 80 and 443.
-You can [set different ports](https://ddev.readthedocs.io/en/latest/users/usage/troubleshooting/#method-2-fix-port-conflicts-by-configuring-your-project-to-use-different-ports) with a command like the following:
+You can [set different ports](https://docs.ddev.com/en/latest/users/usage/troubleshooting/#method-2-fix-port-conflicts-by-configuring-your-project-to-use-different-ports) with a command like the following:
 
 ```bash
 ddev config --router-http-port=8080 --router-https-port=8443
@@ -195,17 +195,17 @@ DDEV offers several ways to get the same result, offering different levels of fl
 
 !!! tip
 
-    Learn more about the [DDEV commands](https://ddev.readthedocs.io/en/latest/users/usage/commands/):
+    Learn more about the [DDEV commands](https://docs.ddev.com/en/latest/users/usage/commands/):
 
-    - run [`ddev --help`](https://ddev.readthedocs.io/en/latest/users/usage/cli/#using-the-ddev-command) to list all commands
-    - run [`ddev help <command>`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#help) to get usage details about a specific command
+    - run [`ddev --help`](https://docs.ddev.com/en/latest/users/usage/cli/#using-the-ddev-command) to list all commands
+    - run [`ddev help <command>`](https://docs.ddev.com/en/latest/users/usage/commands/#help) to get usage details about a specific command
 
-    Learn more about DDEV configuration from [`ddev config` command documentation](https://ddev.readthedocs.io/en/latest/users/usage/commands/#config) and [advanced configuration files documentation](https://ddev.readthedocs.io/en/latest/users/configuration/config/).
+    Learn more about DDEV configuration from [`ddev config` command documentation](https://docs.ddev.com/en/latest/users/usage/commands/#config) and [advanced configuration files documentation](https://docs.ddev.com/en/latest/users/configuration/config/).
 
 
 ### Using `auth.json`
 
-An `auth.json` file can be used for one project, or globally for all projects, with the [DDEV `homeaddition` feature](https://ddev.readthedocs.io/en/latest/users/extend/in-container-configuration/).
+An `auth.json` file can be used for one project, or globally for all projects, with the [DDEV `homeaddition` feature](https://docs.ddev.com/en/latest/users/extend/in-container-configuration/).
 
 For example, you can copy an `auth.json` file to a DDEV project: `cp <path-to-an>/auth.json .ddev/homeadditions/.composer`
 
@@ -376,7 +376,7 @@ To run an existing project, you need to:
 1. Install dependencies packages with Composer.
 1. Populate the contents, which could mean:
     - getting a clean database with `ddev php bin/console ibexa:install` and adding some data with [Ibexa data migration](importing_data.md), or
-    - injecting a dump with [`ddev import-db`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#import-db) and copying related binary files into `public/var`.
+    - injecting a dump with [`ddev import-db`](https://docs.ddev.com/en/latest/users/usage/commands/#import-db) and copying related binary files into `public/var`.
 
 The following examples run an already [version-controlled project](install_ibexa_dxp.md#add-project-to-version-control) and have the right content structure (but no content):
 
@@ -404,17 +404,17 @@ ddev launch
 ```
 
 Notice that the example adds the whole `.ddev/` directory to `.gitignore`, but you can also version parts of it.
-Some DDEV configs can be shared among developers. For example, a common `.ddev/config.yaml` can be committed for everyone and [locally extended or overridden](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).
+Some DDEV configs can be shared among developers. For example, a common `.ddev/config.yaml` can be committed for everyone and [locally extended or overridden](https://docs.ddev.com/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).
 
 Compared to running a clean install like described in [Installation steps](#installation), you can proceed as follows:
 
 - In [1. Create a DDEV project directory](#1-create-a-ddev-project-directory), you can use an existing directory that contains an [[= product_name =]] project instead of creating an empty directory.
 - In [5. Create [[= product_name =]] project](#5-create-project), use only `ddev composer install` instead of `ddev composer create-project`.
-- Populate the database with [Ibexa data migration](importing_data.md) or [`ddev import-db`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#import-db).
+- Populate the database with [Ibexa data migration](importing_data.md) or [`ddev import-db`](https://docs.ddev.com/en/latest/users/usage/commands/#import-db).
 
 ### Hostnames and domains
 
-If the local project needs to answer to real production domains (for example, to use the existing [hostname to SiteAccess](siteaccess_matching.md#maphost) or [hostname element to SiteAccess](../multisite/siteaccess/siteaccess_matching.md#hostelement) mappings), you can use [additional hostnames](https://ddev.readthedocs.io/en/latest/users/extend/additional-hostnames/).
+If the local project needs to answer to real production domains (for example, to use the existing [hostname to SiteAccess](siteaccess_matching.md#maphost) or [hostname element to SiteAccess](../multisite/siteaccess/siteaccess_matching.md#hostelement) mappings), you can use [additional hostnames](https://docs.ddev.com/en/latest/users/extend/additional-hostnames/).
 
 !!! caution
 
@@ -439,4 +439,4 @@ If you want to fully remove the project:
 
 If [additional hostnames](#hostnames-and-domains) have been used, you must clean the hosts file.
 
-To learn more about removing all projects at once or DDEV itself, see [Uninstalling DDEV](https://ddev.readthedocs.io/en/latest/users/usage/uninstall/).
+To learn more about removing all projects at once or DDEV itself, see [Uninstalling DDEV](https://docs.ddev.com/en/latest/users/usage/uninstall/).

--- a/docs/getting_started/install_with_ddev.md
+++ b/docs/getting_started/install_with_ddev.md
@@ -12,7 +12,7 @@ DDEV is an open-source tool that simplifies the process of setting up local PHP 
 Before you start the installation, ensure that you have the following software installed:
 
 - [Docker](https://docs.docker.com/get-started/get-docker/)
-- [DDEV](https://docs.ddev.com/en/latest/users/install/ddev-installation/)
+- [DDEV](https://docs.ddev.com/en/stable/users/install/ddev-installation/)
 
 ## Installation
 
@@ -53,7 +53,7 @@ ddev config --database=mysql:8.4
 ```
 
 You can also use other versions of MariaDB, MySQL or PostgreSQL.
-See [DDEV database types documentation](https://docs.ddev.com/en/latest/users/extend/database-types/) for available version ranges.
+See [DDEV database types documentation](https://docs.ddev.com/en/stable/users/extend/database-types/) for available version ranges.
 
 #### Configure database connection
 
@@ -90,19 +90,19 @@ Depending on your database of choice (MySQL or PostgreSQL), use the appropriate 
 
 #### Enable Mutagen (optional)
 
-If you're using macOS or Windows, you might want to enable [Mutagen](https://docs.ddev.com/en/latest/users/install/performance/#mutagen) to improve performance.
+If you're using macOS or Windows, you might want to enable [Mutagen](https://docs.ddev.com/en/stable/users/install/performance/#mutagen) to improve performance.
 You can do this by running the following command:
 
 ```bash
 ddev config --performance-mode=mutagen
 ```
 
-See [DDEV performance documentation](https://docs.ddev.com/en/latest/users/install/performance/) for more.
+See [DDEV performance documentation](https://docs.ddev.com/en/stable/users/install/performance/) for more.
 
 #### Change port mapping (optional)
 
 By default, DDEV uses ports 80 and 443.
-You can [set different ports](https://docs.ddev.com/en/latest/users/usage/troubleshooting/#method-2-fix-port-conflicts-by-configuring-your-project-to-use-different-ports) with a command like the following:
+You can [set different ports](https://docs.ddev.com/en/stable/users/usage/troubleshooting/#method-2-fix-port-conflicts-by-configuring-your-project-to-use-different-ports) with a command like the following:
 
 ```bash
 ddev config --router-http-port=8080 --router-https-port=8443
@@ -195,17 +195,17 @@ DDEV offers several ways to get the same result, offering different levels of fl
 
 !!! tip
 
-    Learn more about the [DDEV commands](https://docs.ddev.com/en/latest/users/usage/commands/):
+    Learn more about the [DDEV commands](https://docs.ddev.com/en/stable/users/usage/commands/):
 
-    - run [`ddev --help`](https://docs.ddev.com/en/latest/users/usage/cli/#using-the-ddev-command) to list all commands
-    - run [`ddev help <command>`](https://docs.ddev.com/en/latest/users/usage/commands/#help) to get usage details about a specific command
+    - run [`ddev --help`](https://docs.ddev.com/en/stable/users/usage/cli/#using-the-ddev-command) to list all commands
+    - run [`ddev help <command>`](https://docs.ddev.com/en/stable/users/usage/commands/#help) to get usage details about a specific command
 
-    Learn more about DDEV configuration from [`ddev config` command documentation](https://docs.ddev.com/en/latest/users/usage/commands/#config) and [advanced configuration files documentation](https://docs.ddev.com/en/latest/users/configuration/config/).
+    Learn more about DDEV configuration from [`ddev config` command documentation](https://docs.ddev.com/en/stable/users/usage/commands/#config) and [advanced configuration files documentation](https://docs.ddev.com/en/stable/users/configuration/config/).
 
 
 ### Using `auth.json`
 
-An `auth.json` file can be used for one project, or globally for all projects, with the [DDEV `homeaddition` feature](https://docs.ddev.com/en/latest/users/extend/in-container-configuration/).
+An `auth.json` file can be used for one project, or globally for all projects, with the [DDEV `homeaddition` feature](https://docs.ddev.com/en/stable/users/extend/in-container-configuration/).
 
 For example, you can copy an `auth.json` file to a DDEV project: `cp <path-to-an>/auth.json .ddev/homeadditions/.composer`
 
@@ -376,7 +376,7 @@ To run an existing project, you need to:
 1. Install dependencies packages with Composer.
 1. Populate the contents, which could mean:
     - getting a clean database with `ddev php bin/console ibexa:install` and adding some data with [Ibexa data migration](importing_data.md), or
-    - injecting a dump with [`ddev import-db`](https://docs.ddev.com/en/latest/users/usage/commands/#import-db) and copying related binary files into `public/var`.
+    - injecting a dump with [`ddev import-db`](https://docs.ddev.com/en/stable/users/usage/commands/#import-db) and copying related binary files into `public/var`.
 
 The following examples run an already [version-controlled project](install_ibexa_dxp.md#add-project-to-version-control) and have the right content structure (but no content):
 
@@ -404,17 +404,17 @@ ddev launch
 ```
 
 Notice that the example adds the whole `.ddev/` directory to `.gitignore`, but you can also version parts of it.
-Some DDEV configs can be shared among developers. For example, a common `.ddev/config.yaml` can be committed for everyone and [locally extended or overridden](https://docs.ddev.com/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).
+Some DDEV configs can be shared among developers. For example, a common `.ddev/config.yaml` can be committed for everyone and [locally extended or overridden](https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).
 
 Compared to running a clean install like described in [Installation steps](#installation), you can proceed as follows:
 
 - In [1. Create a DDEV project directory](#1-create-a-ddev-project-directory), you can use an existing directory that contains an [[= product_name =]] project instead of creating an empty directory.
 - In [5. Create [[= product_name =]] project](#5-create-project), use only `ddev composer install` instead of `ddev composer create-project`.
-- Populate the database with [Ibexa data migration](importing_data.md) or [`ddev import-db`](https://docs.ddev.com/en/latest/users/usage/commands/#import-db).
+- Populate the database with [Ibexa data migration](importing_data.md) or [`ddev import-db`](https://docs.ddev.com/en/stable/users/usage/commands/#import-db).
 
 ### Hostnames and domains
 
-If the local project needs to answer to real production domains (for example, to use the existing [hostname to SiteAccess](siteaccess_matching.md#maphost) or [hostname element to SiteAccess](../multisite/siteaccess/siteaccess_matching.md#hostelement) mappings), you can use [additional hostnames](https://docs.ddev.com/en/latest/users/extend/additional-hostnames/).
+If the local project needs to answer to real production domains (for example, to use the existing [hostname to SiteAccess](siteaccess_matching.md#maphost) or [hostname element to SiteAccess](../multisite/siteaccess/siteaccess_matching.md#hostelement) mappings), you can use [additional hostnames](https://docs.ddev.com/en/stable/users/extend/additional-hostnames/).
 
 !!! caution
 
@@ -439,4 +439,4 @@ If you want to fully remove the project:
 
 If [additional hostnames](#hostnames-and-domains) have been used, you must clean the hosts file.
 
-To learn more about removing all projects at once or DDEV itself, see [Uninstalling DDEV](https://docs.ddev.com/en/latest/users/usage/uninstall/).
+To learn more about removing all projects at once or DDEV itself, see [Uninstalling DDEV](https://docs.ddev.com/en/stable/users/usage/uninstall/).

--- a/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
+++ b/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
@@ -40,7 +40,7 @@ See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.htm
    and application name (for example, `app` from `name: app` line in `.platform.app.yaml` file).
 1. Configures `ibexa_cloud` command token. See [Create an API token](https://fixed.docs.upsun.com/administration/cli/api-tokens.html#2-create-an-api-token) for more information.
 1. Ignores `.ddev/` directory from Git.
-   (Some DDEV config could be committed like in [this documentation](https://docs.ddev.com/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
+   (Some DDEV config could be committed like in [this documentation](https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
 1. Sets Composer authentication by using an already existing `auth.json` file.
 1. Installs the `ddev/ddev-upsun` add-on which prompts for the Upsun API token, project ID and environment name.
 1. Changes `maxmemory-policy` from default `allkeys-lfu` to a [value accepted by the `RedisTagAwareAdapter`](https://github.com/symfony/cache/blob/5.4/Adapter/RedisTagAwareAdapter.php#L95).
@@ -81,11 +81,11 @@ The following sequence of commands:
 (Replace `<project-ID>` with the hash of your own project. See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.html#3-use) for options like selecting another environment).
 1. Configures a new DDEV project.
 1. Ignores `.ddev/` directory from Git.
-(Some DDEV config could be committed like in [this documentation](https://docs.ddev.com/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
+(Some DDEV config could be committed like in [this documentation](https://docs.ddev.com/en/stable/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
 1. Starts the DDEV project.
 1. Sets Composer authentication.
 1. [Gets the database content from Upsun](https://fixed.docs.upsun.com/add-services/mysql.html#exporting-data).
-1. [Imports this database content into DDEV project's database](https://docs.ddev.com/en/latest/users/usage/database-management/#database-imports).
+1. [Imports this database content into DDEV project's database](https://docs.ddev.com/en/stable/users/usage/database-management/#database-imports).
 1. [Downloads the Upsun public/var locally](https://fixed.docs.upsun.com/development/file-transfer.html#transfer-a-file-from-a-mount) to have the content binary files.
 1. Install the dependencies and run post-install scripts.
 1. Displays information about the project services.

--- a/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
+++ b/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
@@ -40,7 +40,7 @@ See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.htm
    and application name (for example, `app` from `name: app` line in `.platform.app.yaml` file).
 1. Configures `ibexa_cloud` command token. See [Create an API token](https://fixed.docs.upsun.com/administration/cli/api-tokens.html#2-create-an-api-token) for more information.
 1. Ignores `.ddev/` directory from Git.
-   (Some DDEV config could be committed like in [this documentation](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
+   (Some DDEV config could be committed like in [this documentation](https://docs.ddev.com/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
 1. Sets Composer authentication by using an already existing `auth.json` file.
 1. Installs the `ddev/ddev-upsun` add-on which prompts for the Upsun API token, project ID and environment name.
 1. Changes `maxmemory-policy` from default `allkeys-lfu` to a [value accepted by the `RedisTagAwareAdapter`](https://github.com/symfony/cache/blob/5.4/Adapter/RedisTagAwareAdapter.php#L95).
@@ -81,11 +81,11 @@ The following sequence of commands:
 (Replace `<project-ID>` with the hash of your own project. See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.html#3-use) for options like selecting another environment).
 1. Configures a new DDEV project.
 1. Ignores `.ddev/` directory from Git.
-(Some DDEV config could be committed like in [this documentation](https://ddev.readthedocs.io/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
+(Some DDEV config could be committed like in [this documentation](https://docs.ddev.com/en/latest/users/extend/customization-extendibility/#extending-configyaml-with-custom-configyaml-files).)
 1. Starts the DDEV project.
 1. Sets Composer authentication.
 1. [Gets the database content from Upsun](https://fixed.docs.upsun.com/add-services/mysql.html#exporting-data).
-1. [Imports this database content into DDEV project's database](https://ddev.readthedocs.io/en/latest/users/usage/database-management/#database-imports).
+1. [Imports this database content into DDEV project's database](https://docs.ddev.com/en/latest/users/usage/database-management/#database-imports).
 1. [Downloads the Upsun public/var locally](https://fixed.docs.upsun.com/development/file-transfer.html#transfer-a-file-from-a-mount) to have the content binary files.
 1. Install the dependencies and run post-install scripts.
 1. Displays information about the project services.

--- a/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
@@ -20,11 +20,11 @@ The `ddev config --php-version` option should set the same PHP version as the pr
 
 !!! tip
 
-    - [`ddev describe`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#describe) displays a cluster summary that include accesses from inside and outside DDEV services
-    - [`ddev ssh`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#ssh) opens a terminal inside a service
-    - [`ddev exec`](https://ddev.readthedocs.io/en/latest/users/usage/commands/#exec) executes a command inside a service
+    - [`ddev describe`](https://docs.ddev.com/en/latest/users/usage/commands/#describe) displays a cluster summary that include accesses from inside and outside DDEV services
+    - [`ddev ssh`](https://docs.ddev.com/en/latest/users/usage/commands/#ssh) opens a terminal inside a service
+    - [`ddev exec`](https://docs.ddev.com/en/latest/users/usage/commands/#exec) executes a command inside a service
 
-   Discover more commands in [DDEV documentation](https://ddev.readthedocs.io/en/latest/users/usage/commands/).
+   Discover more commands in [DDEV documentation](https://docs.ddev.com/en/latest/users/usage/commands/).
 
 To run an [[= product_name_cloud =]] project locally, you may refer to [DDEV and Ibexa Cloud](ddev_and_ibexa_cloud.md) instead.
 

--- a/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
+++ b/docs/infrastructure_and_maintenance/clustering/clustering_with_ddev.md
@@ -20,11 +20,11 @@ The `ddev config --php-version` option should set the same PHP version as the pr
 
 !!! tip
 
-    - [`ddev describe`](https://docs.ddev.com/en/latest/users/usage/commands/#describe) displays a cluster summary that include accesses from inside and outside DDEV services
-    - [`ddev ssh`](https://docs.ddev.com/en/latest/users/usage/commands/#ssh) opens a terminal inside a service
-    - [`ddev exec`](https://docs.ddev.com/en/latest/users/usage/commands/#exec) executes a command inside a service
+    - [`ddev describe`](https://docs.ddev.com/en/stable/users/usage/commands/#describe) displays a cluster summary that include accesses from inside and outside DDEV services
+    - [`ddev ssh`](https://docs.ddev.com/en/stable/users/usage/commands/#ssh) opens a terminal inside a service
+    - [`ddev exec`](https://docs.ddev.com/en/stable/users/usage/commands/#exec) executes a command inside a service
 
-   Discover more commands in [DDEV documentation](https://docs.ddev.com/en/latest/users/usage/commands/).
+   Discover more commands in [DDEV documentation](https://docs.ddev.com/en/stable/users/usage/commands/).
 
 To run an [[= product_name_cloud =]] project locally, you may refer to [DDEV and Ibexa Cloud](ddev_and_ibexa_cloud.md) instead.
 

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -1668,7 +1668,7 @@ For more information, see [[[= product_name_connect =]] scenario block](https://
 
 #### DDEV
 
-[[[= product_name =]] can officially be run on DDEV](https://ddev.readthedocs.io/en/latest/users/quickstart/#ibexa-dxp).
+[[[= product_name =]] can officially be run on DDEV](https://docs.ddev.com/en/latest/users/quickstart/#ibexa-dxp).
 
 For more information, see the [DDEV guide](https://doc.ibexa.co/en/master/getting_started/install_with_ddev/), which offers a step-by-step walkthrough for installing [[= product_name =]].
 

--- a/docs/release_notes/ibexa_dxp_v4.6.md
+++ b/docs/release_notes/ibexa_dxp_v4.6.md
@@ -1668,7 +1668,7 @@ For more information, see [[[= product_name_connect =]] scenario block](https://
 
 #### DDEV
 
-[[[= product_name =]] can officially be run on DDEV](https://docs.ddev.com/en/latest/users/quickstart/#ibexa-dxp).
+[[[= product_name =]] can officially be run on DDEV](https://docs.ddev.com/en/stable/users/quickstart/#ibexa-dxp).
 
 For more information, see the [DDEV guide](https://doc.ibexa.co/en/master/getting_started/install_with_ddev/), which offers a step-by-step walkthrough for installing [[= product_name =]].
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

* Avoid redirection ddev.readthedocs.io → docs.ddev.com
* Use `stable` instead of `latest` to avoid "You're viewing documentation for an unreleased version of DDEV." warning banner.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
