### PR TITLE
Fix REST API Ref links

### DIFF
--- a/docs/ai_actions/ai_actions_guide.md
+++ b/docs/ai_actions/ai_actions_guide.md
@@ -115,7 +115,7 @@ Procedures are straightforward and intuitive, ensuring that users can quickly ac
 
 AI Actions feature exposes a REST API interface that allows for programmatic execution of AI actions.
 With the API, developers can automate tasks and execute actions on batches of content by integrating them into workflows.
-For more information, see the [AI actions section in the REST API Reference](../api/rest_api/rest_api_reference/rest_api_reference.html#ai-actions-execute-ai-action).
+For more information, see the [AI actions section in the REST API Reference](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Connector-AI/operation/api_aiactions_actionConfigurationIdentifierexecute_post).
 
 ## Capabilities
 

--- a/docs/ai_actions/extend_ai_actions.md
+++ b/docs/ai_actions/extend_ai_actions.md
@@ -102,7 +102,7 @@ The `ActionServiceInterface` service extracts the configuration options from the
 
 [[= product_name =]] comes with a built-in connector to OpenAI services, but you're not limited to it and can add support for additional AI services in your application.
 
-The following example adds a new Action Handler connecting to a local AI run using [the llamafile project](https://github.com/Mozilla-Ocho/llamafile) which you can use to execute Text-To-Text Actions, such as the built-in "Refine Text" Action.
+The following example adds a new Action Handler connecting to a local AI run using [the llamafile project](https://github.com/mozilla-ai/llamafile) which you can use to execute Text-To-Text Actions, such as the built-in "Refine Text" Action.
 
 When creating an Action Handler for [[= product_name_connect =]], add the new handler identifier to the [`Ibexa AI handler` custom property](configure_ai_actions.md#initiate-integration) in [[= product_name_connect =]] user interface.
 

--- a/docs/ai_actions/extend_ai_actions.md
+++ b/docs/ai_actions/extend_ai_actions.md
@@ -244,7 +244,7 @@ The Action Type options provided in the Action Context dictate whether the times
 ### Integrate with the REST API
 
 At this point the custom Action Type can already be executed by using the PHP API.
-To integrate it with the [AI Actions execute endpoint](../api/rest_api/rest_api_reference/rest_api_reference.html#ai-actions-execute-ai-action) you need to create additional classes responsible for parsing the request and response data.
+To integrate it with the [AI Actions execute endpoint](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Connector-AI/operation/api_aiactions_actionConfigurationIdentifierexecute_post) you need to create additional classes responsible for parsing the request and response data.
 See [adding custom media type](adding_custom_media_type.md) and [creating new REST resource](creating_new_rest_resource.md) to learn more about extending the REST API.
 
 #### Handle input data

--- a/docs/api/rest_api/rest_api_usage/rest_requests.md
+++ b/docs/api/rest_api/rest_api_usage/rest_requests.md
@@ -132,9 +132,9 @@ It's used for a `COPY`, `MOVE` or `SWAP` operation to indicate where the resourc
 
 Examples of such requests are:
 
-- [copying a Content](../rest_api_reference/rest_api_reference.html#managing-content-copy-content)
-- [moving a Location and its subtree](../rest_api_reference/rest_api_reference.html#managing-content-move-subtree)
-- [swapping a Location with another](../rest_api_reference/rest_api_reference.html#managing-content-swap-location)
+- [copying a Content](https://doc.ibexa.co/en/4.6/api/rest_api/rest_api_reference/rest_api_reference.html#managing-content-copy-content)
+- [moving a Location and its subtree](https://doc.ibexa.co/en/4.6/api/rest_api/rest_api_reference/rest_api_reference.html#managing-content-move-subtree)
+- [swapping a Location with another](https://doc.ibexa.co/en/4.6/api/rest_api/rest_api_reference/rest_api_reference.html#managing-content-swap-location)
 
 ### Expected user
 
@@ -164,7 +164,7 @@ This script:
 - receives an image path and optionally a name as command-line arguments,
 - uses the [HTTP basic authentication](rest_api_authentication.md#http-basic-authentication), if it's enabled,
 - creates a draft in the /Media/Images folder by posting (`POST`) data to [`/content/objects`](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Objects/operation/api_contentobjects_post),
-- and, publishes (`PUBLISH`) the draft through [`/content/objects/{contentId}/versions/{versionNo}`](../rest_api_reference/rest_api_reference.html#managing-content-publish-a-content-version).
+- and, publishes (`PUBLISH`) the draft through [`/content/objects/{contentId}/versions/{versionNo}`](https://doc.ibexa.co/en/4.6/api/rest_api/rest_api_reference/rest_api_reference.html#managing-content-publish-a-content-version).
 
 === "XML"
 

--- a/docs/api/rest_api/rest_api_usage/rest_responses.md
+++ b/docs/api/rest_api/rest_api_usage/rest_responses.md
@@ -92,7 +92,7 @@ Those example `Accept-Path` headers above indicate that the content could be mod
 
 ### Location header
 
-For example, [creating content](../rest_api_reference/rest_api_reference.html#managing-content-create-content-type) and [getting a content item's current version](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Objects/operation/api_contentobjects_contentIdcurrentversion_get)
+For example, [creating content](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Objects/operation/api_contentobjects_post) and [getting a content item's current version](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Objects/operation/api_contentobjects_contentIdcurrentversion_get)
 both send a `Location` header to provide you with the requested resource's ID.
 
 Those particular headers generally match a specific list of HTTP response codes.

--- a/docs/discounts/configure_discounts.md
+++ b/docs/discounts/configure_discounts.md
@@ -61,7 +61,7 @@ php bin/console ibexa:discounts:reindex
 
 ## Rate limiting
 
-To prevent malicious actors from trying all the possible discount code combinations using brute-force attacks, the [`/discounts_codes/{cartIdentifier}/apply` endpoint](/api/rest_api/rest_api_reference/rest_api_reference.html#discount-codes-apply-discount-to-cart) is rate limited using the [Rate Limiter Symfony component]([[= symfony_doc =]]/rate_limiter.html).
+To prevent malicious actors from trying all the possible discount code combinations using brute-force attacks, the [`/discounts_codes/{cartIdentifier}/apply` endpoint](https://doc.ibexa.co/en/4.6/api/rest_api/rest_api_reference/rest_api_reference.html#discount-codes-apply-discount-to-cart) is rate limited using the [Rate Limiter Symfony component]([[= symfony_doc =]]/rate_limiter.html).
 
 You can adjust the default configuration by modifying the `config/packages/ibexa_discounts_codes.yaml` file created during installation process.
 

--- a/docs/discounts/discounts_api.md
+++ b/docs/discounts/discounts_api.md
@@ -13,7 +13,7 @@ By integrating with the [Discount feature](discounts_guide.md) you can automate 
 
 For example, you can automatically create a discount when a customer places their 3rd order, encouraging them to make another purchase and increase their chances of becoming a loyal customer.
 
-You can manage discounts using [data migrations](importing_data.md#discounts), [REST API](/api/rest_api/rest_api_reference/rest_api_reference.html#discounts), or the PHP API by using the [`Ibexa\Contracts\Discounts\DiscountServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-DiscountServiceInterface.html) service.
+You can manage discounts using [data migrations](importing_data.md#discounts), [REST API](/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Discounts), or the PHP API by using the [`Ibexa\Contracts\Discounts\DiscountServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-DiscountServiceInterface.html) service.
 
 The core concepts when working with discounts through the APIs are listed below.
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Fix links to the REST API Reference. Two cases:
- The entry exists in 5.0 REST API Reference
- The entry doesn't exist in 5.0 Reference but does in 4.6 for two reasons:
    - it doesn't exist because OpenAPI 3.1 doesn't support [custom methods like `COPY` or `PUBLISH`](https://doc.ibexa.co/en/5.0/api/rest_api/rest_api_usage/rest_requests/#request-method)
    - it doesn't exist just because OpenAPI documenting was forgotten

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
