### PR TITLE
Added more mentions about clearing persistence cache

### DIFF
--- a/docs/infrastructure_and_maintenance/cache/persistence_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/persistence_cache.md
@@ -280,7 +280,7 @@ For more info on usage, see [Symfony Cache's documentation]([[= symfony_doc =]]/
 
 !!! caution "Always clear the persistence with `cache:pool:clear` command"
 
-    Running `php bin/console cache:clear` doesn't clear the persistence cache, even when using a filesystem-based cache pool.
+    Running `php bin/console cache:clear` doesn't clear the persistence cache, even when you use a filesystem-based cache pool.
     
     You must always clear the persistence cache by running:
 

--- a/docs/infrastructure_and_maintenance/cache/persistence_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/persistence_cache.md
@@ -278,6 +278,20 @@ For more info on usage, see [Symfony Cache's documentation]([[= symfony_doc =]]/
 
 ### Clearing persistence cache
 
+!!! caution "Always clear the persistence with `cache:pool:clear` command"
+
+    Running `php bin/console cache:clear` doesn't clear the persistence cache, even when using a filesystem-based cache pool.
+    
+    You must always clear the persistence cache by running:
+
+    ```bash
+    php bin/console cache:pool:clear [cache-pool]
+    ```
+
+    The default cache-pool is named `cache.tagaware.filesystem`. 
+    The default cache-pool when running Redis or Valkey is named `cache.redis`. 
+    If you have customized the persistence cache configuration, the name of your cache pool might be different.
+
 Persistence cache prefixes it's cache using "ibx-". Clearing persistence cache can thus be done in the following ways:
 
 ``` php

--- a/docs/infrastructure_and_maintenance/cache/persistence_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/persistence_cache.md
@@ -281,15 +281,15 @@ For more info on usage, see [Symfony Cache's documentation]([[= symfony_doc =]]/
 !!! caution "Always clear the persistence with `cache:pool:clear` command"
 
     Running `php bin/console cache:clear` doesn't clear the persistence cache, even when you use a filesystem-based cache pool.
-    
+
     You must always clear the persistence cache by running:
 
     ```bash
-    php bin/console cache:pool:clear [cache-pool]
+    php bin/console cache:pool:clear <cache-pool>
     ```
 
-    The default cache pool is named `cache.tagaware.filesystem`. 
-    The default cache pool when running Redis or Valkey is named `cache.redis`. 
+    The default cache pool is named `cache.tagaware.filesystem`.
+    The default cache pool when running Redis or Valkey is named `cache.redis`.
     If you have customized the persistence cache configuration, the name of your cache pool might be different.
 
 Persistence cache prefixes it's cache using "ibx-". Clearing persistence cache can thus be done in the following ways:

--- a/docs/infrastructure_and_maintenance/cache/persistence_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/persistence_cache.md
@@ -288,8 +288,8 @@ For more info on usage, see [Symfony Cache's documentation]([[= symfony_doc =]]/
     php bin/console cache:pool:clear [cache-pool]
     ```
 
-    The default cache-pool is named `cache.tagaware.filesystem`. 
-    The default cache-pool when running Redis or Valkey is named `cache.redis`. 
+    The default cache pool is named `cache.tagaware.filesystem`. 
+    The default cache pool when running Redis or Valkey is named `cache.redis`. 
     If you have customized the persistence cache configuration, the name of your cache pool might be different.
 
 Persistence cache prefixes it's cache using "ibx-". Clearing persistence cache can thus be done in the following ways:

--- a/docs/snippets/page_block_cache_clear.md
+++ b/docs/snippets/page_block_cache_clear.md
@@ -3,8 +3,8 @@
     Persistence cache must be cleared after any modifications have been made to the block config in Page Builder, such as adding, removing or altering the page blocks, block attributes, validators or views configuration.
 
     To clear the persistence cache run `php bin/console cache:pool:clear [cache-pool]` command.
-    The default cache-pool is named `cache.tagaware.filesystem`.
-    The default cache-pool when running Redis or Valkey is named `cache.redis`.
+    The default cache pool is named `cache.tagaware.filesystem`.
+    The default cache pool when running Redis or Valkey is named `cache.redis`.
     If you have customized the [persistence cache configuration](https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/persistence_cache/#what-is-cached), the name of your cache pool might be different.
 
     In prod mode, you also need to clear the symfony cache by running `./bin/console c:c`.

--- a/docs/snippets/page_block_cache_clear.md
+++ b/docs/snippets/page_block_cache_clear.md
@@ -2,7 +2,7 @@
 
     Persistence cache must be cleared after any modifications have been made to the block config in Page Builder, such as adding, removing or altering the page blocks, block attributes, validators or views configuration.
 
-    To clear the persistence cache, run `php bin/console cache:pool:clear [cache-pool]` command.
+    To clear the persistence cache, run `php bin/console cache:pool:clear <cache-pool>` command.
     The default cache pool is named `cache.tagaware.filesystem`.
     The default cache pool when running Redis or Valkey is named `cache.redis`.
     If you have customized the [persistence cache configuration](https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/persistence_cache/#what-is-cached), the name of your cache pool might be different.

--- a/docs/snippets/page_block_cache_clear.md
+++ b/docs/snippets/page_block_cache_clear.md
@@ -2,7 +2,7 @@
 
     Persistence cache must be cleared after any modifications have been made to the block config in Page Builder, such as adding, removing or altering the page blocks, block attributes, validators or views configuration.
 
-    To clear the persistence cache run `./bin/console cache:pool:clear [cache-pool]` command.
+    To clear the persistence cache run `php bin/console cache:pool:clear [cache-pool]` command.
     The default cache-pool is named `cache.tagaware.filesystem`.
     The default cache-pool when running Redis or Valkey is named `cache.redis`.
     If you have customized the [persistence cache configuration](https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/persistence_cache/#what-is-cached), the name of your cache pool might be different.

--- a/docs/snippets/page_block_cache_clear.md
+++ b/docs/snippets/page_block_cache_clear.md
@@ -2,7 +2,7 @@
 
     Persistence cache must be cleared after any modifications have been made to the block config in Page Builder, such as adding, removing or altering the page blocks, block attributes, validators or views configuration.
 
-    To clear the persistence cache run `php bin/console cache:pool:clear [cache-pool]` command.
+    To clear the persistence cache, run `php bin/console cache:pool:clear [cache-pool]` command.
     The default cache pool is named `cache.tagaware.filesystem`.
     The default cache pool when running Redis or Valkey is named `cache.redis`.
     If you have customized the [persistence cache configuration](https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/persistence_cache/#what-is-cached), the name of your cache pool might be different.

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -388,7 +388,7 @@ Update Symfony constraints in `composer.json` before updating the packages.
     - Array-based PHP configuration format
 
         As part of the new [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), Symfony creates the `config/reference.php` file.
-        You should commit this file to the repository.
+        Consider commiting this file to the repository.
 
 4. Update Ibexa packages by running:
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -363,15 +363,32 @@ Update Symfony constraints in `composer.json` before updating the packages.
     For more details about the new version, see the official Symfony [upgrade instructions](https://github.com/symfony/symfony/blob/7.4/UPGRADE-7.4.md) and [blog posts introducing this release](https://symfony.com/blog/category/living-on-the-edge/8.0-7.4).
     Key changes include:
 
-    - Array-based PHP configuration format
-
-        As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
-        You should commit this file to the repository.
 
     - Independent application cache directory
 
         Symfony 7.4 introduces a new [share directory](https://symfony.com/blog/new-in-symfony-7-4-share-directory), dedicated for storing application cache on the file system.
         If you decide to configure it (for example, by setting the `APP_SHARE_DIR` environment variable), review your existing scripts for explicit `var/cache` usage (for example, `rm -rf var/cache`) and decide whether to include `var/share` in the script.
+
+        !!! caution "Always clear the persistence cache with `cache:pool:clear` command"
+
+            Starting with Symfony 7.4, running `php bin/console cache:clear` doesn't clear the [[= product_name =]] persistence cache, even when using a filesystem-based cache pool.
+
+            To clear the persistence cache, for example after adding a [custom Page Builder block](create_custom_page_block.md), you must always run:
+
+            ```bash
+            php bin/console cache:pool:clear [cache-pool]
+            ```
+
+            The default cache-pool is named `cache.tagaware.filesystem`. 
+            The default cache-pool when running Redis or Valkey is named `cache.redis`. 
+            If you have customized the persistence cache configuration, the name of your cache pool might be different.
+
+            For more information about persistence cache, see [Persistence cache](persistence_cache.md).
+
+    - Array-based PHP configuration format
+
+        As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
+        You should commit this file to the repository.
 
 4. Update Ibexa packages by running:
 

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -376,18 +376,18 @@ Update Symfony constraints in `composer.json` before updating the packages.
             To clear the persistence cache, for example after adding a [custom Page Builder block](create_custom_page_block.md), you must always run:
 
             ```bash
-            php bin/console cache:pool:clear [cache-pool]
+            php bin/console cache:pool:clear <cache-pool>
             ```
 
-            The default cache pool is named `cache.tagaware.filesystem`. 
-            The default cache pool when running Redis or Valkey is named `cache.redis`. 
+            The default cache pool is named `cache.tagaware.filesystem`.
+            The default cache pool when running Redis or Valkey is named `cache.redis`.
             If you have customized the persistence cache configuration, the name of your cache pool might be different.
 
             For more information about persistence cache, see [Persistence cache](persistence_cache.md).
 
     - Array-based PHP configuration format
 
-        As part of the [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), a `config/reference.php` file will be created.
+        As part of the new [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), Symfony creates the `config/reference.php` file.
         You should commit this file to the repository.
 
 4. Update Ibexa packages by running:

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -379,8 +379,8 @@ Update Symfony constraints in `composer.json` before updating the packages.
             php bin/console cache:pool:clear [cache-pool]
             ```
 
-            The default cache-pool is named `cache.tagaware.filesystem`. 
-            The default cache-pool when running Redis or Valkey is named `cache.redis`. 
+            The default cache pool is named `cache.tagaware.filesystem`. 
+            The default cache pool when running Redis or Valkey is named `cache.redis`. 
             If you have customized the persistence cache configuration, the name of your cache pool might be different.
 
             For more information about persistence cache, see [Persistence cache](persistence_cache.md).

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -388,7 +388,7 @@ Update Symfony constraints in `composer.json` before updating the packages.
     - Array-based PHP configuration format
 
         As part of the new [array-based PHP configuration format](https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration), Symfony creates the `config/reference.php` file.
-        Consider commiting this file to the repository.
+        Consider committing this file to the repository.
 
 4. Update Ibexa packages by running:
 


### PR DESCRIPTION
As suggested by @marcin-kondera , the `var/share` change is a huge change that breaks all the habits Symfony developers have (namely, running `rm -rf var/cache` and being sure it clears all the caches).

This PR tries to make the description of the change more visible, hoping we save at least some people from debugging this problem.