### PR TITLE
Added continue-on-error

### DIFF
--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -45,12 +45,15 @@ jobs:
                   dependency-versions: highest
 
             - name: Run PHPStan analysis
+              continue-on-error: true
               run: composer phpstan
 
             - name: Run Deptrac analysis
+              continue-on-error: true
               run: composer deptrac
 
             - name: Run Rector check
+              continue-on-error: true
               run: composer check-rector
 
     code-samples-inclusion-check:


### PR DESCRIPTION
This PR makes all the Code Quality jobs run all time, so Rector and Deptrac are not blocked by PHPStan failures - and we can see all the issues during review.

Right now (without these changes), PHPStan errors block future jobs and we don't see the full picture.

The job will still be marked as failed if PHPStan fails while Deptrac and Rector are green.
