### PR TITLE
Fixed example for ibexa_format_price

### DIFF
--- a/docs/templating/twig_function_reference/product_twig_functions.md
+++ b/docs/templating/twig_function_reference/product_twig_functions.md
@@ -119,7 +119,6 @@ The `ibexa_format_price` filter formats the price value by placing currency code
 {{ order.getValue().getTotalGross()|ibexa_format_price }}
 
 {{ ibexa_get_original_price(discount_product)|ibexa_format_price ?: '-' }}
-{% endfor %}
 ```
 
 ### `ibexa_is_pim_local`

--- a/docs/templating/twig_function_reference/product_twig_functions.md
+++ b/docs/templating/twig_function_reference/product_twig_functions.md
@@ -116,8 +116,9 @@ The `ibexa_format_price` filter formats the price value by placing currency code
 #### Examples
 
 ``` html+twig
-{% for product.price in product.attributes %}
-    {{ product.price.getMoney()|ibexa_format_price }}
+{{ order.getValue().getTotalGross()|ibexa_format_price }}
+
+{{ ibexa_get_original_price(discount_product)|ibexa_format_price ?: '-' }}
 {% endfor %}
 ```
 


### PR DESCRIPTION
Target: 4.6, 5.0

Fixed Twig example for ibexa_format_price - the current one (`{% for product.price in product.attributes %}`) is not valid Twig syntax.

Replaced with actual usages found in the codebase.