### PR TITLE
Added a table of built-in attributes

### DIFF
--- a/docs/product_catalog/products.md
+++ b/docs/product_catalog/products.md
@@ -38,7 +38,7 @@ The following attribute types are available:
 | Name | Identifier | Description |
 |------|------------|-------------|
 | Checkbox | `checkbox` | Boolean attribute with a true/false value. |
-| Color | `color` | Stores a color value as a hex code. |
+| Color | `color` | Color value stored as a hex code. |
 | [Date and time](date_and_time.md) | `datetime` | Date and time value with configurable accuracy levels. |
 | Float | `float` | Decimal number value. |
 | Integer | `integer` | Integer number value. |

--- a/docs/product_catalog/products.md
+++ b/docs/product_catalog/products.md
@@ -35,14 +35,15 @@ Typical product attribute examples are: length, weight, color, format, and more.
 
 The following attribute types are available:
 
-- checkbox
-- color
-- [date and time](date_and_time.md)
-- float
-- integer
-- measurement (`measurement_range` and `measurement_single`)
-- selection
-- [symbol](symbol_attribute_type.md)
+| Name | Identifier | Description |
+|------|------------|-------------|
+| Checkbox | `checkbox` | Boolean attribute with a true/false value. |
+| Color | `color` | Stores a color value as a hex code. |
+| [Date and time](date_and_time.md) | `datetime` | Date and time value with configurable accuracy levels. |
+| Float | `float` | Decimal number value. |
+| Integer | `integer` | Integer number value. |
+| Selection | `selection` | A value selected from a predefined list of labeled options. |
+| [Symbol](symbol_attribute_type.md) | `symbol` | String value with an enforced format, suitable for standardized identifiers such as EAN or ISBN. |
 
 Product attributes are collected in groups.
 An example of an attribute group can be dimensions (length, width, height).


### PR DESCRIPTION
Adding a table for built-in attributes.

I've noted this down when working on the doc for Quable, as the attribute type identifier is needed when overiding the templates:
see https://doc.ibexa.co/en/latest//product_catalog/customize_product_attribute_templates for an example.

And we didn't have these attribute identifiers in the doc yet.

Note: measurement is removed from the list, as it was removed in v5 (https://github.com/ibexa/measurement/pull/93).

