### PR TITLE
Expanded the product availability section

### DIFF
--- a/code_samples/api/product_catalog/src/Command/ProductCommand.php
+++ b/code_samples/api/product_catalog/src/Command/ProductCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use App\ProductCatalog\Availability\PurchasableWithoutStockAvailabilityContext;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Ibexa\Contracts\Core\Repository\UserService;
 use Ibexa\Contracts\ProductCatalog\Local\LocalProductServiceInterface;
@@ -10,7 +11,6 @@ use Ibexa\Contracts\ProductCatalog\ProductServiceInterface;
 use Ibexa\Contracts\ProductCatalog\ProductTypeServiceInterface;
 use Ibexa\Contracts\ProductCatalog\Values\Availability\ProductAvailabilityCreateStruct;
 use Ibexa\Contracts\ProductCatalog\Values\Availability\ProductAvailabilityUpdateStruct;
-use App\ProductCatalog\Availability\PurchasableWithoutStockAvailabilityContext;
 use Ibexa\Contracts\ProductCatalog\Values\Product\ProductQuery;
 use Ibexa\Contracts\ProductCatalog\Values\Product\Query\Criterion;
 use Ibexa\Contracts\ProductCatalog\Values\Product\Query\SortClause;

--- a/code_samples/api/product_catalog/src/Command/ProductCommand.php
+++ b/code_samples/api/product_catalog/src/Command/ProductCommand.php
@@ -10,6 +10,7 @@ use Ibexa\Contracts\ProductCatalog\ProductServiceInterface;
 use Ibexa\Contracts\ProductCatalog\ProductTypeServiceInterface;
 use Ibexa\Contracts\ProductCatalog\Values\Availability\ProductAvailabilityCreateStruct;
 use Ibexa\Contracts\ProductCatalog\Values\Availability\ProductAvailabilityUpdateStruct;
+use App\ProductCatalog\Availability\PurchasableWithoutStockAvailabilityContext;
 use Ibexa\Contracts\ProductCatalog\Values\Product\ProductQuery;
 use Ibexa\Contracts\ProductCatalog\Values\Product\Query\Criterion;
 use Ibexa\Contracts\ProductCatalog\Values\Product\Query\SortClause;
@@ -98,25 +99,33 @@ final class ProductCommand extends Command
 
         $product = $this->productService->getProduct('NEWMODIFIEDPRODUCT');
 
-        $productAvailabilityCreateStruct = new ProductAvailabilityCreateStruct($product, true, true);
+        $productAvailabilityCreateStruct = new ProductAvailabilityCreateStruct($product, false, true);
 
         $this->productAvailabilityService->createProductAvailability($productAvailabilityCreateStruct);
 
         if ($this->productAvailabilityService->hasAvailability($product)) {
             $availability = $this->productAvailabilityService->getAvailability($product);
 
-            $output->write($availability->isAvailable() ? 'Available' : 'Unavailable');
-            $output->writeln(' with stock ' . $availability->getStock());
-
-            $availability = $this->productAvailabilityService->getAvailability($product);
+            $output->writeln($availability->getAvailability() ? 'Available flag: true' : 'Available flag: false');
+            $output->writeln($availability->getComputedAvailability() ? 'Can be ordered: true' : 'Can be ordered: false');
+            $output->writeln('Stock: ' . $availability->getStock());
 
             $productAvailabilityUpdateStruct = new ProductAvailabilityUpdateStruct($product, true, false, 80);
 
             $this->productAvailabilityService->updateProductAvailability($productAvailabilityUpdateStruct);
 
-            $output->write($availability->isAvailable() ? 'Available' : 'Unavailable');
+            $output->writeln($availability->getAvailability() ? 'Available flag: true' : 'Available flag: false');
+            $output->writeln($availability->getComputedAvailability() ? 'Can be ordered: true' : 'Can be ordered: false');
             $output->writeln(' available now with stock ' . $availability->getStock());
         }
+
+        $availability = $this->productAvailabilityService->getAvailability(
+            $product,
+            new PurchasableWithoutStockAvailabilityContext()
+        );
+
+        $canBeOrdered = $availability->getComputedAvailability();
+        $output->writeln('Can be ordered: ' . ($canBeOrdered ? 'true' : 'false') . ', Stock: ' . $availability->getStock());
 
         $this->localProductService->deleteProduct($product);
 

--- a/code_samples/pim/availability/config/custom_services.yaml
+++ b/code_samples/pim/availability/config/custom_services.yaml
@@ -1,0 +1,4 @@
+services:
+    App\ProductCatalog\Availability\ProductAvailabilityPurchasableWithoutStockStrategy:
+        tags:
+            - { name: ibexa.product_catalog.availability.strategy }

--- a/code_samples/pim/availability/src/ProductAvailabilityPurchasableWithoutStockStrategy.php
+++ b/code_samples/pim/availability/src/ProductAvailabilityPurchasableWithoutStockStrategy.php
@@ -11,9 +11,11 @@ use Ibexa\ProductCatalog\Local\Repository\Values\Availability;
 
 final class ProductAvailabilityPurchasableWithoutStockStrategy implements ProductAvailabilityStrategyInterface
 {
-    public function __construct(
-        private readonly HandlerInterface $handler,
-    ) {
+    private HandlerInterface $handler;
+
+    public function __construct(HandlerInterface $handler)
+    {
+        $this->handler = $handler;
     }
 
     public function accept(AvailabilityContextInterface $context): bool
@@ -23,7 +25,7 @@ final class ProductAvailabilityPurchasableWithoutStockStrategy implements Produc
 
     public function getProductAvailability(
         ProductInterface $product,
-        AvailabilityContextInterface $context,
+        AvailabilityContextInterface $context
     ): AvailabilityInterface {
         $productAvailability = $this->handler->find($product->getCode());
 
@@ -49,7 +51,7 @@ final class ProductAvailabilityPurchasableWithoutStockStrategy implements Produc
     private function calculateAvailability(
         bool $rawAvailable,
         ?int $stock,
-        bool $isInfinite,
+        bool $isInfinite
     ): bool {
         if ($rawAvailable === false) {
             return false;

--- a/code_samples/pim/availability/src/ProductAvailabilityPurchasableWithoutStockStrategy.php
+++ b/code_samples/pim/availability/src/ProductAvailabilityPurchasableWithoutStockStrategy.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace App\ProductCatalog\Availability;
+
+use Ibexa\Contracts\ProductCatalog\ProductAvailabilityStrategyInterface;
+use Ibexa\Contracts\ProductCatalog\Values\Availability\AvailabilityContextInterface;
+use Ibexa\Contracts\ProductCatalog\Values\Availability\AvailabilityInterface;
+use Ibexa\Contracts\ProductCatalog\Values\ProductInterface;
+use Ibexa\ProductCatalog\Local\Persistence\Legacy\ProductAvailability\HandlerInterface;
+use Ibexa\ProductCatalog\Local\Repository\Values\Availability;
+
+final class ProductAvailabilityPurchasableWithoutStockStrategy implements ProductAvailabilityStrategyInterface
+{
+    public function __construct(
+        private readonly HandlerInterface $handler,
+    ) {
+    }
+
+    public function accept(AvailabilityContextInterface $context): bool
+    {
+        return $context instanceof PurchasableWithoutStockAvailabilityContext;
+    }
+
+    public function getProductAvailability(
+        ProductInterface $product,
+        AvailabilityContextInterface $context,
+    ): AvailabilityInterface {
+        $productAvailability = $this->handler->find($product->getCode());
+
+        $rawAvailableFlag = $productAvailability->isAvailable();
+        $stock = $productAvailability->getStock();
+        $isInfinite = $productAvailability->isInfinite();
+
+        $computedAvailable = $this->calculateAvailability(
+            $rawAvailableFlag,
+            $stock,
+            $isInfinite,
+        );
+
+        return new Availability(
+            $product,
+            $rawAvailableFlag,
+            $computedAvailable,
+            $isInfinite,
+            $stock,
+        );
+    }
+
+    private function calculateAvailability(
+        bool $rawAvailable,
+        ?int $stock,
+        bool $isInfinite,
+    ): bool {
+        if ($rawAvailable === false) {
+            return false;
+        }
+
+        if ($isInfinite) {
+            return true;
+        }
+
+        if ($stock === null) {
+            return true;
+        }
+
+        return $stock >= 0;
+    }
+}

--- a/code_samples/pim/availability/src/PurchasableWithoutStockAvailabilityContext.php
+++ b/code_samples/pim/availability/src/PurchasableWithoutStockAvailabilityContext.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace App\ProductCatalog\Availability;
+
+use Ibexa\Contracts\ProductCatalog\Values\Availability\AvailabilityContextInterface;
+
+final class PurchasableWithoutStockAvailabilityContext implements AvailabilityContextInterface
+{
+}

--- a/docs/pim/create_custom_availability_strategy.md
+++ b/docs/pim/create_custom_availability_strategy.md
@@ -1,0 +1,53 @@
+---
+description: 
+---
+
+# Create custom availability strategy
+
+The product catalog uses an availability strategy to calculate [computed availability](products.md#availability-and-computed-availability) for a product.
+The default strategy determines whether a product can be ordered based on its stored availability and stock.
+
+You can replace this logic with a custom strategy to handle specific business scenarios, for example preoders, minimum order quantities, or per-region availability.
+
+The following example implements an availability strategy which allows buying products when they're set as available, without taking their stock into account.
+You could use it for [virtual products](products.md#product-types) or in preorder scenarios.
+
+## Create a custom availability context
+
+An availability context carries the parameters needed by the strategy to evaluate computed availability.
+Create a class implementing [`AvailabilityContextInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityContextInterface.html):
+
+``` php
+[[= include_file('code_samples/pim/availability/src/PurchasableWithoutStockAvailabilityContext.php') =]]
+```
+
+## Create a custom availability strategy
+
+Create a class implementing [`ProductAvailabilityStrategyInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityStrategyInterface.html):
+
+``` php
+[[= include_file('code_samples/pim/availability/src/ProductAvailabilityPurchasableWithoutStockStrategy.php') =]]
+```
+
+The strategy has two methods:
+
+- `accept()` decides if the strategy can handle the provided availability context
+- `getProductAvailability()` returns an [`AvailabilityInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityInterface.html) object
+
+When constructing the `AvailabilityInterface` object, provide the stock amount, the availability flag, and the result of your custom availability logic.
+
+## Register the strategy as a service
+
+Tag the strategy service with `ibexa.product_catalog.availability.strategy`:
+
+``` yaml
+[[= include_file('code_samples/pim/availability/config/custom_services.yaml') =]]
+```
+
+## Use the custom context
+
+Pass the custom context as the second argument to [`ProductAvailabilityServiceInterface::getAvailability()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityServiceInterface.html):
+
+```php
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 122, 127, remove_indent=True) =]]
+```

--- a/docs/pim/create_custom_availability_strategy.md
+++ b/docs/pim/create_custom_availability_strategy.md
@@ -1,16 +1,16 @@
 ---
-description: 
+description: Implement custom availability strategies to handle different business scenarios, for example pre-orders or per-region availability.
 ---
 
 # Create custom availability strategy
 
-The product catalog uses an availability strategy to calculate [computed availability](products.md#availability-and-computed-availability) for a product.
-The default strategy determines whether a product can be ordered based on its stored availability and stock.
+The product catalog uses an availability strategy to calculate [computed availability](products.md#availability-and-computed-availability) for a product, deciding whether the customers can order it.
+The default is based on the product availability and stock amount.
 
-You can replace this logic with a custom strategy to handle specific business scenarios, for example preoders, minimum order quantities, or per-region availability.
+You can replace this logic with a custom strategy to handle specific business scenarios, for example pre-oders, minimum order quantities, or per-region availability.
 
 The following example implements an availability strategy which allows buying products when they're set as available, without taking their stock into account.
-You could use it for [virtual products](products.md#product-types) or in preorder scenarios.
+You could use it for [virtual products](products.md#product-types) or in pre-order scenarios.
 
 ## Create a custom availability context
 

--- a/docs/pim/create_custom_availability_strategy.md
+++ b/docs/pim/create_custom_availability_strategy.md
@@ -4,8 +4,9 @@ description: Implement custom availability strategies to handle different busine
 
 # Create custom availability strategy
 
-The product catalog uses an availability strategy to calculate [computed availability](products.md#availability-and-computed-availability) for a product, deciding whether the customers can order it.
-The default is based on the product availability and stock amount.
+The product catalog uses an availability strategy to calculate [computed availability](products.md#availability-and-computed-availability) for a product.
+Computed availability decides whether the customers can order the product.
+The default availability strategy is based on the product availability and stock amount.
 
 You can replace this logic with a custom strategy to handle specific business scenarios, for example preorders, minimum order quantities, or per-region availability.
 
@@ -15,7 +16,7 @@ You could use it for [virtual products](products.md#product-types) or in preorde
 ## Create custom availability context
 
 Use an availability context to pass the parameters needed by the strategy to evaluate computed availability.
-To do it, create a class implementing the [`AvailabilityContextInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityContextInterface.html) interface:
+To do it, create a class that implements the [`AvailabilityContextInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityContextInterface.html) interface:
 
 ``` php
 [[= include_file('code_samples/pim/availability/src/PurchasableWithoutStockAvailabilityContext.php') =]]
@@ -23,7 +24,7 @@ To do it, create a class implementing the [`AvailabilityContextInterface`](/api/
 
 ## Create custom availability strategy
 
-Create a class implementing [`ProductAvailabilityStrategyInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityStrategyInterface.html):
+Create a class that implements the [`ProductAvailabilityStrategyInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityStrategyInterface.html) interface:
 
 ``` php
 [[= include_file('code_samples/pim/availability/src/ProductAvailabilityPurchasableWithoutStockStrategy.php') =]]

--- a/docs/pim/create_custom_availability_strategy.md
+++ b/docs/pim/create_custom_availability_strategy.md
@@ -12,16 +12,16 @@ You can replace this logic with a custom strategy to handle specific business sc
 The following example implements an availability strategy which allows buying products when they're set as available, without taking their stock into account.
 You could use it for [virtual products](products.md#product-types) or in preorder scenarios.
 
-## Create a custom availability context
+## Create custom availability context
 
-An availability context carries the parameters needed by the strategy to evaluate computed availability.
-Create a class implementing [`AvailabilityContextInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityContextInterface.html):
+Use an availability context to pass the parameters needed by the strategy to evaluate computed availability.
+To do it, create a class implementing the [`AvailabilityContextInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityContextInterface.html) interface:
 
 ``` php
 [[= include_file('code_samples/pim/availability/src/PurchasableWithoutStockAvailabilityContext.php') =]]
 ```
 
-## Create a custom availability strategy
+## Create custom availability strategy
 
 Create a class implementing [`ProductAvailabilityStrategyInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityStrategyInterface.html):
 
@@ -36,17 +36,17 @@ The strategy has two methods:
 
 When constructing the `AvailabilityInterface` object, provide the stock amount, the availability flag, and the result of your custom availability logic.
 
-## Register the strategy as a service
+## Register strategy as a service
 
-Tag the strategy service with `ibexa.product_catalog.availability.strategy`:
+If you're not using [autowiring]([[= symfony_doc =]]/service_container/autowiring.html), tag the strategy service with `ibexa.product_catalog.availability.strategy`:
 
 ``` yaml
 [[= include_file('code_samples/pim/availability/config/custom_services.yaml') =]]
 ```
 
-## Use the custom context
+## Use custom context
 
-Pass the custom context as the second argument to [`ProductAvailabilityServiceInterface::getAvailability()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityServiceInterface.html):
+To evaluate product availability using a custom strategy, pass the custom context as the second argument to [`ProductAvailabilityServiceInterface::getAvailability()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityServiceInterface.html):
 
 ```php
 [[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 122, 127, remove_indent=True) =]]

--- a/docs/pim/create_custom_availability_strategy.md
+++ b/docs/pim/create_custom_availability_strategy.md
@@ -7,10 +7,10 @@ description: Implement custom availability strategies to handle different busine
 The product catalog uses an availability strategy to calculate [computed availability](products.md#availability-and-computed-availability) for a product, deciding whether the customers can order it.
 The default is based on the product availability and stock amount.
 
-You can replace this logic with a custom strategy to handle specific business scenarios, for example pre-oders, minimum order quantities, or per-region availability.
+You can replace this logic with a custom strategy to handle specific business scenarios, for example preorders, minimum order quantities, or per-region availability.
 
 The following example implements an availability strategy which allows buying products when they're set as available, without taking their stock into account.
-You could use it for [virtual products](products.md#product-types) or in pre-order scenarios.
+You could use it for [virtual products](products.md#product-types) or in preorder scenarios.
 
 ## Create a custom availability context
 

--- a/docs/pim/customize_pim.md
+++ b/docs/pim/customize_pim.md
@@ -12,4 +12,5 @@ You can customize various areas of the Product Information Management solution t
     "pim/create_product_code_generator",
     "pim/create_custom_catalog_filter",
     "pim/create_custom_name_schema_strategy",
+    "pim/create_custom_availability_strategy",
 ], columns=4) =]]

--- a/docs/pim/product_api.md
+++ b/docs/pim/product_api.md
@@ -1,5 +1,5 @@
 ---
-description: Use PHP API to manage products in PIM, their attributes, availability and prices.
+description: Use PHP API to manage products in PIM, their attributes, availability, and prices.
 month_change: false
 ---
 
@@ -178,24 +178,40 @@ You can also get a list of product types with `ProductTypeServiceInterface::find
 
 ## Product availability
 
-Product availability is an object which defines whether a product is available, and if so, in what stock.
+Product availability is an object which defines whether a product is set as available, in what stock, and whether it can be ordered.
 To manage it, use [`ProductAvailabilityServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-ProductAvailabilityServiceInterface.html).
 
-To check whether a product is available (with or without stock defined), use `ProductAvailabilityServiceInterface::hasAvailability()`.
+The [`AvailabilityInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityInterface.html) provides two distinct availability values:
 
-Get the availability object with `ProductAvailabilityServiceInterface::getAvailability()`.
-You can then use `ProductAvailabilityServiceInterface::getStock()` to get the stock number for the product:
+- `getAvailability()` returns the value of availability flag as set for the product
+- `getComputedAvailability()` returns whether the product can be ordered
 
-```php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 104, 109) =]]        }
+For more information about the distinction between these two values, see [Availability and computed availability](products.md#availability-and-computed-availability).
+
+To check whether a product is set as available, use `ProductAvailabilityServiceInterface::hasAvailability()`.
+
+You can get the availability object with `ProductAvailabilityServiceInterface::getAvailability()`.
+The returned object contains both the stored and computed availability:
+
+``` php
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 106, 111, remove_indent=True) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 134, 134, remove_indent=True) =]]
+```
+
+To evaluate computed availability for a [specific context](create_custom_availability_strategy.md), for example, a specific requested quantity or customer group, pass an optional [`AvailabilityContextInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-AvailabilityContextInterface.html) object as the second argument:
+
+``` php
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 122, 128, remove_indent=True) =]]
 ```
 
 To change availability for a product, use `ProductAvailabilityServiceInterface::updateProductAvailability()` with a [`ProductAvailabilityUpdateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Availability-ProductAvailabilityUpdateStruct.html) and provide it with the product object.
 The second parameter defines whether product is available, and the third whether its stock is infinite. The fourth parameter is the stock number:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 112, 115) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 113, 115, remove_indent=True) =]]
 ```
+
+
 
 ## Attributes
 

--- a/docs/pim/product_api.md
+++ b/docs/pim/product_api.md
@@ -21,7 +21,7 @@ month_change: false
 Get an individual product by using the `ProductServiceInterface::getProduct()` method:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 68, 71) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 70, 72, remove_indent=True) =]]
 ```
 
 Find multiple products with `ProductServiceInterface::findProducts()`.
@@ -29,7 +29,7 @@ Find multiple products with `ProductServiceInterface::findProducts()`.
 Provide the method with optional filter, query or Sort Clauses.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 72, 82) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 74, 83, remove_indent=True) =]]
 ```
 
 See [Product Search Criteria](product_search_criteria.md) and [Product Sort Clauses](product_sort_clauses.md) references for more information about how to use the [`ProductQuery`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Product-ProductQuery.html) class.
@@ -39,7 +39,7 @@ See [Product Search Criteria](product_search_criteria.md) and [Product Sort Clau
 To create, update and delete products, use the `LocalProductServiceInterface`.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 93, 97) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 95, 98, remove_indent=True) =]]
 ```
 
 To create a product, use `LocalProductServiceInterface::newProductCreateStruct()` to get a [`ProductCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-Values-Product-ProductCreateStruct.html).
@@ -47,13 +47,13 @@ Provide the method with the product type object and the main language code.
 You also need to set (at least) the code for the product and the required Field of the underlying content type, `name`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 83, 90) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 85, 89, remove_indent=True) =]]
 ```
 
 To delete a product, use `LocalProductServiceInterface::deleteProduct()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 120, 121) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 130, 130, remove_indent=True) =]]
 ```
 
 ### Product variants
@@ -65,13 +65,13 @@ A `ProductVariantQuery` lets you define the offset and limit of the variant quer
 The default offset is 0, and limit is 25.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductVariantCommand.php', 57, 60) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductVariantCommand.php', 58, 60, remove_indent=True) =]]
 ```
 
 From a variant ([`ProductVariantInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-ProductVariantInterface.html)), you can access the attributes that are used to generate the variant by using `ProductVariantInterface::getDiscriminatorAttributes()`.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductVariantCommand.php', 61, 68) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductVariantCommand.php', 62, 68, remove_indent=True) =]]
 ```
 
 #### Creating variants
@@ -81,7 +81,7 @@ This method takes the product and an array of [`ProductVariantCreateStruct`](/ap
 `ProductVariantCreateStruct` specifies the attribute values and the code for the new variant.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductVariantCommand.php', 70, 76) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductVariantCommand.php', 71, 76, remove_indent=True) =]]
 ```
 
 ### Product assets
@@ -91,14 +91,14 @@ You can get assets assigned to a product by using [`AssetServiceInterface`](/api
 Use `AssetServiceInterface` to get a single asset by providing the product object and the assets's ID as parameters:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductAssetCommand.php', 54, 56) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductAssetCommand.php', 55, 56, remove_indent=True) =]]
 ```
 
 To get all assets assigned to a product, use `AssetServiceInterface::findAssets()`.
 You can retrieve the tags (corresponding to attribute values) of assets with the `AssetInterface::getTags()` method:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductAssetCommand.php', 57, 66) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductAssetCommand.php', 58, 66, remove_indent=True) =]]
 ```
 
 ## Product types
@@ -112,19 +112,19 @@ To create a product type, use [`LocalProductTypeServiceInterface`](/api/php_api/
 First, create a product type struct with `LocalProductTypeServiceInterface::newProductTypeCreateStruct()`, providing the identifier and main language code:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 62, 66) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 63, 66, remove_indent=True) =]]
 ```
 
 You can set names in multiple languages by using `setNames()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 67, 71) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 68, 71, remove_indent=True) =]]
 ```
 
 To create a virtual product type (for products that don't require shipping), use `setVirtual()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 72, 73) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 73, 73, remove_indent=True) =]]
 ```
 
 #### Adding field definitions
@@ -133,7 +133,7 @@ To add custom field definitions to the product type, use `getContentTypeCreateSt
 For more information about working with content types, see [Adding content types](../content_management/content_api/managing_content.md#adding-content-types).
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 76, 83) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 77, 83, remove_indent=True) =]]
 ```
 
 #### Assigning attributes
@@ -143,13 +143,13 @@ To assign product attributes to the product type, use `setAssignedAttributesDefi
 First, retrieve the attribute definition by using [`AttributeDefinitionServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-AttributeDefinitionServiceInterface.html):
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 84, 85) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 85, 85, remove_indent=True) =]]
 ```
 
 Then create the assignment struct with the attribute definition, and set whether it's required and whether it's a discriminator (used for product variants):
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 86, 93) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 87, 93, remove_indent=True) =]]
 ```
 
 For more information about working with attributes through PHP API, see [Attributes](#attributes).
@@ -159,7 +159,7 @@ For more information about working with attributes through PHP API, see [Attribu
 Finally, create the product type with `LocalProductTypeServiceInterface::createProductType()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 94, 95) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 94, 95, remove_indent=True) =]]
 ```
 
 ### Getting product types
@@ -167,13 +167,13 @@ Finally, create the product type with `LocalProductTypeServiceInterface::createP
 Get a product type object by using `ProductTypeServiceInterface::getProductType()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 96, 97) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 97, 97, remove_indent=True) =]]
 ```
 
 You can also get a list of product types with `ProductTypeServiceInterface::findProductTypes()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 100, 105) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductTypeCommand.php', 101, 105, remove_indent=True) =]]
 ```
 
 ## Product availability
@@ -211,8 +211,6 @@ The second parameter defines whether product is available, and the third whether
 [[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 113, 115, remove_indent=True) =]]
 ```
 
-
-
 ## Attributes
 
 To get information about product attribute groups, use the [`AttributeGroupServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-AttributeGroupServiceInterface.html), or [`LocalAttributeGroupServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-LocalAttributeGroupServiceInterface.html) to modify attribute groups.
@@ -221,24 +219,24 @@ To get information about product attribute groups, use the [`AttributeGroupServi
 `AttributeGroupServiceInterface::findAttributeGroups()` gets attribute groups, all of them or filtered with an optional [`AttributeGroupQuery`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-AttributeGroup-AttributeGroupQuery.html) object:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 71, 72) =]]
-[[= include_file('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 92, 97) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 72, 72, remove_indent=True) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 93, 97, remove_indent=True) =]]
 ```
 
 To create an attribute group, use `LocalAttributeGroupServiceinterface::createAttributeGroup()` and provide it with an [`AttributeGroupCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-Values-AttributeGroup-AttributeGroupCreateStruct.html):
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 66, 70) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 67, 70, remove_indent=True) =]]
 ```
 
 To get information about product attributes, use the [`AttributeDefinitionServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-AttributeDefinitionServiceInterface.html), or [`LocalAttributeDefinitionServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-LocalAttributeDefinitionServiceInterface.html) to modify attributes.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 78, 80) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 79, 80, remove_indent=True) =]]
 ```
 
 To create an attribute, use `LocalAttributeGroupServiceinterface::createAttributeDefinition()` and provide it with an [`AttributeDefinitionCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Local-Values-AttributeDefinition-AttributeDefinitionCreateStruct.html):
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 83, 89) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/AttributeCommand.php', 84, 89, remove_indent=True) =]]
 ```

--- a/docs/pim/products.md
+++ b/docs/pim/products.md
@@ -86,12 +86,24 @@ You set product availability per variant or per base product:
 - if a product cannot have variants (has no attributes with the "Used for product variants" flag), you set availability per base product
 - if a product can have variants (even if no variants are configured yet), you set availability per variant.
 
-When a product is available, it can have numerical stock defined.
+When a product is set as available, it can have numerical stock defined.
 The stock can also be set to infinite (for example, in case of digital products).
 
-!!! note
+### Availability and computed availability
 
-    Availability doesn't automatically mean that a product can be ordered.
-    A product can be available, but have zero stock.
+Setting a product as available doesn't automatically mean that a product can be ordered.
+For example, a product can be set as available, but have zero stock.
 
-    A product can only be ordered when it has either positive stock, or stock set to infinite.
+The product catalog distinguishes between two types of availability:
+
+- Availability as a value set per product or variant
+
+Availability represents whether the product was set as **Available**, for example in the [back office **Availability** tab]([[= user_doc =]]/product_catalog/manage_availability_and_stock/#set-product-availability) or [PHP API](product_api.md#product-availability).
+
+- Computed availability
+
+Computed availability represents whether the product can actually be ordered.
+By default, a product can only be ordered when it's set as available and has either positive or infinite stock.
+
+You can implement a custom strategy to handle different selling scenarios, such as minimum order quantity, minimum stock quantity, or region-specific availability.
+For more information, see [Create custom availability strategy](create_custom_availability_strategy.md).

--- a/docs/pim/products.md
+++ b/docs/pim/products.md
@@ -91,19 +91,19 @@ The stock can also be set to infinite (for example, in case of digital products)
 
 ### Availability and computed availability
 
-Setting a product as available doesn't automatically mean that a product can be ordered.
+Setting a product as available doesn't automatically mean that it can be ordered.
 For example, a product can be set as available, but have zero stock.
 
 The product catalog distinguishes between two types of availability:
 
 - Availability as a value set per product or variant
 
-Availability represents whether the product was set as **Available**, for example in the [back office **Availability** tab]([[= user_doc =]]/product_catalog/manage_availability_and_stock/#set-product-availability) or [PHP API](product_api.md#product-availability).
+    Availability represents whether the product was set as **Available**, for example in the [back office **Availability** tab]([[= user_doc =]]/product_catalog/manage_availability_and_stock/#set-product-availability) or [PHP API](product_api.md#product-availability).
 
 - Computed availability
 
-Computed availability represents whether the product can actually be ordered.
-By default, a product can only be ordered when it's set as available and has either positive or infinite stock.
+    Computed availability represents whether the product can actually be ordered.
+    By default, a product can only be ordered when it's set as available and has either positive or infinite stock.
 
 You can implement a custom strategy to handle different selling scenarios, such as minimum order quantity, minimum stock quantity, or region-specific availability.
 For more information, see [Create custom availability strategy](create_custom_availability_strategy.md).

--- a/docs/search/criteria_reference/productavailability_criterion.md
+++ b/docs/search/criteria_reference/productavailability_criterion.md
@@ -7,6 +7,7 @@ description: ProductAvailability Search Criterion
 The `ProductAvailability` Search Criterion searches for products by the availability flag, the boolean value set per product or variant.
 
 To search for products that can be ordered, recreate the availability conditions with [existing product search criteria](product_search_criteria.md), for example [LogicalAnd](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Product-Query-Criterion-LogicalAnd.html), [LogicalOr](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Product-Query-Criterion-LogicalOr.html), and [`ProductStock`](productstock_criterion.md).
+To recreate complex [custom availability strategies](create_custom_availability_strategy.md), you might need to implement [custom search criteria](search_criteria_and_sort_clauses.md#custom-criteria-and-sort-clauses) for the conditions not covered by the built-in ones.
 
 For more information, see [Availability and computed availability](products.md#availability-and-computed-availability).
 

--- a/docs/search/criteria_reference/productavailability_criterion.md
+++ b/docs/search/criteria_reference/productavailability_criterion.md
@@ -4,7 +4,11 @@ description: ProductAvailability Search Criterion
 
 # ProductAvailability Criterion
 
-The `ProductAvailability` Search Criterion searches for products by their availability.
+The `ProductAvailability` Search Criterion searches for products by the availability flag, the boolean value set per product or variant.
+
+To search for products that can be ordered, recreate the availability conditions with [existing product search criteria](product_search_criteria.md), for example [LogicalAnd](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Product-Query-Criterion-LogicalAnd.html), [LogicalOr](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-Values-Product-Query-Criterion-LogicalOr.html), and [`ProductStock`](productstock_criterion.md).
+
+For more information, see [Availability and computed availability](products.md#availability-and-computed-availability).
 
 ## Arguments
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -374,9 +374,10 @@ nav:
         - Customize PIM:
             - Customize PIM: pim/customize_pim.md
             - Create custom attribute type: pim/create_custom_attribute_type.md
-            - Create product code generator: pim/create_product_code_generator.md
+            - Create custom availability strategy: pim/create_custom_availability_strategy.md
             - Create custom catalog filter: pim/create_custom_catalog_filter.md
             - Create custom name schema: pim/create_custom_name_schema_strategy.md
+            - Create product code generator: pim/create_product_code_generator.md
         - Add remote PIM support: pim/add_remote_pim_support.md
     - Commerce:
         - Commerce: commerce/commerce.md


### PR DESCRIPTION
Jira: https://ibexa.atlassian.net/browse/IBX-11478

Doc for https://github.com/ibexa/product-catalog/pull/1488

Target: 4.6, 5.0

This PR expands the availability section to explain the difference between availability and computed availability.

In addition, creating custom availability strategies is added

Code tested locally:
<img width="727" height="99" alt="Screenshot 2026-05-08 at 12 39 24" src="https://github.com/user-attachments/assets/7d0bece0-278f-42dc-976c-d2c8c977db70" />

