### PR TITLE
IBX-11755 Added `list_non_translated_content_ids` MCP tool

### DIFF
--- a/docs/ai/mcp/mcp_config.md
+++ b/docs/ai/mcp/mcp_config.md
@@ -110,7 +110,8 @@ MCP Servers LTS Update comes with the following built-in tools:
 
 - `Ibexa\Mcp\Tool\TranslationTools`
     - `list_languages` - lists all languages in the current SiteAccess
-    - `list_content_translations` - lists languages in which given content item has translations
+    - `list_content_languages` - lists languages in which given content item has translations
+    - `list_non_translated_content_ids` - lists IDs of content with missing translations for a given language code
 - `Ibexa\Mcp\Tool\SeoTools`
     - `get_non_seo_content_ids` - returns IDs of content items that are missing SEO optimization (no meta title tag)
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | IBX-11755
| Versions      | 5.0
| Edition       | All

ibexa/mcp#8

- Add `list_non_translated_content_ids`
- Rename from `list_content_translations` to `list_content_languages`

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
