### PR TITLE
Unified admonitions

### DIFF
--- a/docs/administration/back_office/configure_product_tour.md
+++ b/docs/administration/back_office/configure_product_tour.md
@@ -112,7 +112,7 @@ product_tour:
 When creating new [back office user groups](user_registration.md#user-types), decide whether the existing product tour scenarios should be available for these new user groups.
 If not, add the new group to the exclusion list.
 
-!!! warning
+!!! caution
 
     If a scenario contains information meant only for specific group of users, always use the `user_groups_excluded` setting to exclude other groups.
     Don't rely only on UI access restrictions to control the access to scenarios, as a malicious internal user could trigger and preview them outside of the intended place.

--- a/docs/administration/dashboard/customize_dashboard.md
+++ b/docs/administration/dashboard/customize_dashboard.md
@@ -6,7 +6,7 @@ edition: experience
 
 # Customize dashboard
 
-!!! info
+!!! note
 
      The Dashboard Builder is available only in the Experience and Commerce editions.
      The dashboard from the Headless edition can be customized using [Twig Components](components.md).

--- a/docs/api/rest_api/rest_api_usage/rest_api_usage.md
+++ b/docs/api/rest_api/rest_api_usage/rest_api_usage.md
@@ -29,7 +29,7 @@ php bin/console ibexa:openapi --yaml --output=openapi.yaml # YAML output
 
 Use the specification file with [available OpenAPI tools](https://tools.openapis.org/) to work faster with the API, for example, by generating libraries and clients for the API.
 
-!!! info
+!!! note
 
     In [Symfony's `dev` environment](environments.md), you can access a REST API reference generated for your project by visiting the `/api/ibexa/v2/doc` route in the browser.
 

--- a/docs/commerce/transactional_emails/transactional_emails.md
+++ b/docs/commerce/transactional_emails/transactional_emails.md
@@ -75,7 +75,7 @@ Create campaigns of transactional email type, one for each notification type tha
 When you build a campaign template, make sure that you use the variables supported by [[= product_name =]].
 For a complete list of parameters, see [Transactional email variables reference](transactional_emails_parameters.md).
 
-!!! Tip
+!!! tip
 
     When you invent names for your campaigns, keep them simple, and don't use special characters or spaces.
 

--- a/docs/content_management/taxonomy/taxonomy.md
+++ b/docs/content_management/taxonomy/taxonomy.md
@@ -254,7 +254,7 @@ ibexa:
             default_embedding_model: 'text-embedding-ada-002'
 ```
 
-!!! warning "Change both embedding generation models"
+!!! caution "Change both embedding generation models"
 
     When you change the default suggestions generation model, ensure that you update the `ibexa.system.default.taxonomy.search.default_embedding_model` setting that is used for taxonomy indexing purposes.
     Otherwise the taxonomy suggestions feature fails to find matching entries.

--- a/docs/ibexa_cloud/environment_variables.md
+++ b/docs/ibexa_cloud/environment_variables.md
@@ -12,7 +12,7 @@ Environment variable prefixes are created by converting relationship names to up
 When multiple endpoints are defined for a single relationship, numerical indices are used for all entries except the first one, for example: `SOLR`, `SOLR_1`, `SOLR_2`.
 When multiple services of the same type are present, environment variables are exposed for each service accordingly based on their relationship names.
 
-!!! warning "Environment variables in configuration files"
+!!! caution "Environment variables in configuration files"
 
     To prevent Symfony container initialization failures, you must define placeholder values for [[= product_name_cloud =]] environment variables in your `.env` file when referencing them in configuration files.
 

--- a/docs/infrastructure_and_maintenance/background_tasks.md
+++ b/docs/infrastructure_and_maintenance/background_tasks.md
@@ -67,7 +67,7 @@ php bin/console messenger:consume ibexa.messenger.transport --bus=ibexa.messenge
 
 In [multi-repository setups](repository_configuration.md), the worker process always works for a [SiteAccess](multisite_configuration.md#siteaccess-configuration) that you indicate by using the `--siteaccess` option, therefore you may need to run multiple workers, one for each SiteAccess.
 
-!!! warning "Multi-repository setups"
+!!! caution "Multi-repository setups"
 
     Doctrine transport works across multiple repositories without issues, but other transports may need to be adjusted, so that queues across different repositories are not accidentally shared.
 

--- a/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
@@ -147,7 +147,7 @@ The built-in taggers support the following value types:
 - Any view implementing `Ibexa\Core\MVC\Symfony\View\ContentValueView`
 - Any view implementing `Ibexa\Core\MVC\Symfony\View\LocationValueView`
 
-!!! warning
+!!! caution
 
     If a value of any other type is passed (for example, a [`Content`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-Content.html) object), no tagger matches and the call has no effect.
 

--- a/docs/permissions/limitation_reference.md
+++ b/docs/permissions/limitation_reference.md
@@ -290,7 +290,7 @@ The Personalization limitation specifies the SiteAccesses for which the user can
 
 The Product Type (`ProductType`) limitation specifies whether the user has access to products belonging to a specific product type.
 
-!!! warning
+!!! caution
 
     The `ProductType` limitation can't be used when using [[[= pim_product_name =]]](/product_catalog/quable/quable.md).
 

--- a/docs/permissions/policies.md
+++ b/docs/permissions/policies.md
@@ -309,7 +309,7 @@ The [discount](discounts.md) policies decide which actions can be executed by gi
 |                        | <nobr>`edit`</nobr>   | edit a product                              | [Product Type](limitation_reference.md#product-type-limitation)</br>[Language](limitation_reference.md#language-limitation) |
 |                        | <nobr>`view`</nobr>   | view products listed in the product catalog | [Product Type](limitation_reference.md#product-type-limitation)                                                             |
 
-!!! warning
+!!! caution
 
     The `ProductType` limitation can't be used when using [[[= pim_product_name =]]](/product_catalog/quable/quable.md).
 
@@ -328,7 +328,7 @@ The [discount](discounts.md) policies decide which actions can be executed by gi
 |                             | <nobr>`edit`</nobr>   | edit a product type, attribute, attribute group                                                                  | [Product Type](limitation_reference.md#product-type-limitation) |
 |                             | <nobr>`view`</nobr>   | view product types, attributes and attribute groups                                                              |                      |
 
-!!! warning
+!!! caution
 
     The `ProductType` limitation can't be used when using [[[= pim_product_name =]]](/product_catalog/quable/quable.md).
 

--- a/docs/personalization/legacy_recommendation_api.md
+++ b/docs/personalization/legacy_recommendation_api.md
@@ -72,7 +72,7 @@ It fetches 8 recommendations for user Smith, who is watching the item 123 and th
 The recommendation request returns a list of item IDs that are JSON, JSONP or XML-formatted.
 The result can be integrated into any webpage by using some lines of script code. 
 
-!!! tips
+!!! tip
 
     See the [Quickstart Guide](integrate_recommendation_service.md) for a simple example written in PHP.
 

--- a/docs/product_catalog/quable/install_quable.md
+++ b/docs/product_catalog/quable/install_quable.md
@@ -172,7 +172,7 @@ ibexa_connector_quable:
     webhook_secret: '<webhook authorization header>'
 ```
 
-!!! warning
+!!! caution
 
     [Quable uses dynamic IP addresses](https://faq.quable.com/en/articles/8250056-what-are-the-ip-addresses-of-quable-to-add-to-the-whitelist) to connect to [[= product_name =]].
     If your DXP instance is protected by a firewall, make sure your configuration allows connections from changing IP addresses.

--- a/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
+++ b/docs/update_and_migration/migrate_to_ibexa_dxp/migrating_from_ez_publish_platform.md
@@ -35,7 +35,7 @@ You can then proceed with consecutive upgrades to further versions: v1.13 LTS an
         See [ezpublish-kernel:doc/bc/changes-6.0.md](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.0/doc/bc/changes-6.0.md)
 
 
-!!! warning "Unsupported legacy sorting methods"
+!!! caution "Unsupported legacy sorting methods"
 
     In older eZ Publish versions, sub-items of content items could be sorted by Class identifier (option value 6) or Class name (option value 7).
     These sorting methods are no longer supported in [[= product_name =]].


### PR DESCRIPTION
Target: v5, 4.6

Our admonition usage is not consistent, we have a couple of these which compete with each other - and the `warning` and `info` ones use default MkDocs styling, not our custom one.

In this PR, I'm converting:

- `info` -> `note`
- `warning` -> `caution`

After this change, the usage is:

 - note: 350 total
 - tip: 194 tota
 - caution: 133 total


As a follow up, I'll add a vale rule checking these, to make sure we stay consistent.
