### PR TITLE
[PHP] Migrated include_file to include_code. Added remove_indent for partial includes

### DIFF
--- a/.github/workflows/preview_comment.yaml
+++ b/.github/workflows/preview_comment.yaml
@@ -28,7 +28,7 @@ jobs:
 
             -   name: Create comment for changed files
                 run: |
-                    file_limit=100
+                    file_limit=150
                     build_url="https://ez-systems-developer-documentation--${{ github.event.pull_request.number }}.com.readthedocs.build/${{inputs.project}}en/${{ github.event.pull_request.number }}/"
 
                     md_change_list=$(git diff --name-only HEAD "origin/$GITHUB_BASE_REF" -- docs/ | grep -E "^docs\/.*\.md$" | sed -E "s|^docs/(.*)\.md$|- [docs/\1.md](${build_url}\1/)|")

--- a/docs/administration/back_office/add_user_setting.md
+++ b/docs/administration/back_office/add_user_setting.md
@@ -13,7 +13,7 @@ To do so, create a setting class implementing two interfaces: `ValueDefinitionIn
 In this example the class is located in `src/Setting/Unit.php` and enables the user to select their preference for metric or imperial unit systems.
 
 ``` php
-[[= include_file('code_samples/back_office/settings/src/Setting/Unit.php') =]]
+[[= include_code('code_samples/back_office/settings/src/Setting/Unit.php') =]]
 ```
 
 Register the setting as a service:
@@ -30,7 +30,7 @@ It can be one of the built-in groups, or a custom one.
 To create a custom setting group, create an `App/Setting/Group/MyGroup.php` file:
 
 ``` php
-[[= include_file('code_samples/back_office/settings/src/Setting/Group/MyGroup.php') =]]
+[[= include_code('code_samples/back_office/settings/src/Setting/Group/MyGroup.php') =]]
 ```
 
 Register the setting group as a service:

--- a/docs/administration/back_office/back_office_elements/extending_thumbnails.md
+++ b/docs/administration/back_office/back_office_elements/extending_thumbnails.md
@@ -42,7 +42,7 @@ First, create base strategy for returning custom thumbnails from a static file.
 Create `StaticStrategy.php` in `src/Strategy`.
 
 ```php
-[[= include_file('code_samples/back_office/thumbnails/src/Strategy/StaticThumbnailStrategy.php') =]]
+[[= include_code('code_samples/back_office/thumbnails/src/Strategy/StaticThumbnailStrategy.php') =]]
 ```
 
 Next, add the strategy with the `ibexa.repository.thumbnail.strategy.content` tag and `priority: 100` to `config/services.yaml`:

--- a/docs/administration/back_office/back_office_menus/add_menu_item.md
+++ b/docs/administration/back_office/back_office_menus/add_menu_item.md
@@ -35,7 +35,7 @@ The route indicates a controller that fetches all visible content items and rend
 Create the following controller file in `src/Controller/AllContentListController.php`:
 
 ``` php
-[[= include_file('code_samples/back_office/menu/menu_item/src/Controller/AllContentListController.php') =]]
+[[= include_code('code_samples/back_office/menu/menu_item/src/Controller/AllContentListController.php') =]]
 ```
 
 ## Add template

--- a/docs/administration/back_office/back_office_menus/back_office_menus.md
+++ b/docs/administration/back_office/back_office_menus/back_office_menus.md
@@ -72,7 +72,7 @@ To add an inactive menu section, don't add a route to its parameters.
 The following method adds a new menu section under **Content**, and under it, a new item with custom attributes:
 
 ``` php
-[[= include_file('code_samples/back_office/menu/menu_item/src/EventSubscriber/MyMenuSubscriber.php', 30, 43) =]]
+[[= include_code('code_samples/back_office/menu/menu_item/src/EventSubscriber/MyMenuSubscriber.php', 31, 43, remove_indent=True) =]]
 ```
 
 `label` is used for the new menu item in the interface.
@@ -127,7 +127,7 @@ You can use the `extras.icon` parameter to define an icon for a menu item.
 For example, the following code changes the default icon for the **Create content** button in content view:
 
 ``` php
-[[= include_file('code_samples/back_office/menu/menu_item/src/EventSubscriber/MyMenuSubscriber.php', 46, 48) =]]
+[[= include_code('code_samples/back_office/menu/menu_item/src/EventSubscriber/MyMenuSubscriber.php', 47, 48, remove_indent=True) =]]
 ```
 
 ## Removing menu items
@@ -135,5 +135,5 @@ For example, the following code changes the default icon for the **Create conten
 To remove a menu item, for example, to remove the **Copy subtree** item from the right menu in content view, use the following event listener:
 
 ``` php
-[[= include_file('code_samples/back_office/menu/menu_item/src/EventSubscriber/MyMenuSubscriber.php', 44, 45) =]]
+[[= include_code('code_samples/back_office/menu/menu_item/src/EventSubscriber/MyMenuSubscriber.php', 45, 45, remove_indent=True) =]]
 ```

--- a/docs/administration/back_office/back_office_tabs/back_office_tabs.md
+++ b/docs/administration/back_office/back_office_tabs/back_office_tabs.md
@@ -47,7 +47,7 @@ You can order the tabs by making the tab implement `OrderedTabInterface`.
 The order depends on the numerical value returned by the `getOrder` method:
 
 ``` php
-[[= include_file('code_samples/back_office/dashboard/article_tab/src/Tab/Dashboard/Everyone/EveryoneArticleTab.php', 37, 41) =]]
+[[= include_code('code_samples/back_office/dashboard/article_tab/src/Tab/Dashboard/Everyone/EveryoneArticleTab.php', 38, 41, remove_indent=True) =]]
 ```
 
 Tabs are displayed according to this value in ascending order.

--- a/docs/administration/back_office/back_office_tabs/create_dashboard_tab.md
+++ b/docs/administration/back_office/back_office_tabs/create_dashboard_tab.md
@@ -8,7 +8,7 @@ To create a new tab in the dashboard, create an `EveryoneArticleTab.php` file in
 This adds a tab to the **Common content** dashboard block that displays all articles in the repository.
 
 ``` php hl_lines="17 38 50-53 64-66"
-[[= include_file('code_samples/back_office/dashboard/article_tab/src/Tab/Dashboard/Everyone/EveryoneArticleTab.php') =]]
+[[= include_code('code_samples/back_office/dashboard/article_tab/src/Tab/Dashboard/Everyone/EveryoneArticleTab.php') =]]
 ```
 
 This tab searches for content with content type "Article" (lines 50-53) and uses the built-in `all_content.html.twig` template to render the results, which ensures that the tab looks the same as the existing tabs (lines 64-66).

--- a/docs/administration/back_office/content_tab_switcher.md
+++ b/docs/administration/back_office/content_tab_switcher.md
@@ -74,7 +74,7 @@ The `meta_field_groups_list` configuration can be overridden.
 First, create an event listener in the `src/EventListener/TextAnchorMenuTabListener.php`:
 
 ``` php hl_lines="28 31"
-[[= include_file('code_samples/back_office/content_type/src/EventListener/TextAnchorMenuTabListener.php') =]]
+[[= include_code('code_samples/back_office/content_type/src/EventListener/TextAnchorMenuTabListener.php') =]]
 ```
 
 A new custom tab is defined in the line 28, the line 31 defines items for the second level.

--- a/docs/administration/back_office/customize_calendar.md
+++ b/docs/administration/back_office/customize_calendar.md
@@ -40,7 +40,7 @@ The following example shows how to create custom events which add different holi
 First, create a new event in `src/Calendar/Holidays/Event.php`:
 
 ``` php
-[[= include_file('code_samples/back_office/calendar/src/Calendar/Holidays/Event.php') =]]
+[[= include_code('code_samples/back_office/calendar/src/Calendar/Holidays/Event.php') =]]
 ```
 
 Here, you define a new class for your event based on `Ibexa\Contracts\Calendar\Event`.
@@ -48,7 +48,7 @@ Here, you define a new class for your event based on `Ibexa\Contracts\Calendar\E
 Next, create `src/Calendar/Holidays/EventType.php`:
 
 ```php hl_lines="20-23"
-[[= include_file('code_samples/back_office/calendar/src/Calendar/Holidays/EventType.php') =]]
+[[= include_code('code_samples/back_office/calendar/src/Calendar/Holidays/EventType.php') =]]
 ```
 
 You can use the identifier defined in lines 20-23 to configure [event colors](#customize-colors-and-icons).
@@ -109,7 +109,7 @@ To do this, place the following `holidays.json` file in `src/Calendar/Holidays`:
 Next, import this file in `src/Calendar/Holidays/EventSourceFactory.php`:
 
 ``` php hl_lines="6-9"
-[[= include_file('code_samples/back_office/calendar/src/Calendar/Holidays/EventSourceFactory.php', 16, 30) =]]
+[[= include_code('code_samples/back_office/calendar/src/Calendar/Holidays/EventSourceFactory.php', 17, 30, remove_indent=True) =]]
 ```
 
 The calendar now displays the events listed in the JSON file.

--- a/docs/administration/back_office/customize_integrated_help.md
+++ b/docs/administration/back_office/customize_integrated_help.md
@@ -96,7 +96,7 @@ In this example, it removes a product roadmap entry from the menu and adds a hel
 The tab is displayed in a production environment only.
 
 ``` php
-[[= include_file('code_samples/back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php') =]]
+[[= include_code('code_samples/back_office/menu/menu_item/src/EventSubscriber/HelpMenuSubscriber.php') =]]
 ```
 
 !!! tip

--- a/docs/administration/back_office/customize_product_tour.md
+++ b/docs/administration/back_office/customize_product_tour.md
@@ -41,7 +41,7 @@ ibexa:
 Then, create a subscriber that modifies the scenario.
 
 ```php hl_lines="32-34 36-38 40-42 44-55"
-[[= include_file('code_samples/back_office/product_tour/src/EventSubscriber/NotificationScenarioSubscriber.php') =]]
+[[= include_code('code_samples/back_office/product_tour/src/EventSubscriber/NotificationScenarioSubscriber.php') =]]
 ```
 
 The subscriber executes the following actions:

--- a/docs/administration/back_office/customize_search_sorting.md
+++ b/docs/administration/back_office/customize_search_sorting.md
@@ -15,7 +15,7 @@ It also implements `TranslationContainerInterface::getTranslationMessages` to pr
 Create the `src/Search/SortingDefinition/Provider/SectionNameSortingDefinitionProvider.php` file:
 
 ``` php hl_lines="22"
-[[= include_file('code_samples/back_office/search/src/Search/SortingDefinition/Provider/SectionNameSortingDefinitionProvider.php') =]]
+[[= include_code('code_samples/back_office/search/src/Search/SortingDefinition/Provider/SectionNameSortingDefinitionProvider.php') =]]
 ```
 
 Then add a service definition to `config/services.yaml`:

--- a/docs/administration/back_office/customize_search_suggestion.md
+++ b/docs/administration/back_office/customize_search_suggestion.md
@@ -46,7 +46,7 @@ This example event subscriber is implemented in the `src/EventSubscriber/MySugge
 It uses [`ProductService::findProducts`](product_api.md#products), and returns the received event after having manipulated the `SuggestionCollection`:
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php') =]]
+[[= include_code('code_samples/back_office/search/src/EventSubscriber/MySuggestionEventSubscriber.php') =]]
 ```
 
 To have the logger injected thanks to the `LoggerAwareTrait`, this subscriber must be registered as a service:
@@ -60,7 +60,7 @@ services:
 To represent the product suggestion data, a `ProductSuggestion` class is created in `src/Search/Model/Suggestion/ProductSuggestion.php`:
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Search/Model/Suggestion/ProductSuggestion.php') =]]
+[[= include_code('code_samples/back_office/search/src/Search/Model/Suggestion/ProductSuggestion.php') =]]
 ```
 
 This representation needs a normalizer to be transformed into a JSON.
@@ -70,7 +70,7 @@ Alongside data about the product, this array must have a `type` key, whose value
 In `src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php`:
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php') =]]
+[[= include_code('code_samples/back_office/search/src/Search/Serializer/Normalizer/Suggestion/ProductSuggestionNormalizer.php') =]]
 ```
 
 This normalizer is added to suggestion normalizers by decorating `ibexa.search.suggestion.serializer` and redefining its list of normalizers:

--- a/docs/administration/back_office/notifications.md
+++ b/docs/administration/back_office/notifications.md
@@ -91,7 +91,7 @@ To create a new notification you can use the [`NotificationService::createNotifi
 like in the example below:
 
 ```php
-[[= include_file('code_samples/back_office/notifications/src/EventListener/ContentPublishEventListener.php') =]]
+[[= include_code('code_samples/back_office/notifications/src/EventListener/ContentPublishEventListener.php') =]]
 ```
 
 A new type of user notification is created: `ContentPublished`.
@@ -103,7 +103,7 @@ To display a user notification, write a renderer and tag it as a service.
 The example below presents a renderer that uses Twig to render a view:
 
 ```php
-[[= include_file('code_samples/back_office/notifications/src/Notification/MyRenderer.php') =]]
+[[= include_code('code_samples/back_office/notifications/src/Notification/MyRenderer.php') =]]
 ```
 
 You can add the template that is used in the `MyRenderer::render()` method to the `admin` theme
@@ -127,7 +127,7 @@ To display a list of notifications, expand the above renderer.
 The example below presents a modified renderer that uses Twig to render a list view:
 
 ```php
-[[= include_file('code_samples/back_office/notifications/src/Notification/ListRenderer.php') =]]
+[[= include_code('code_samples/back_office/notifications/src/Notification/ListRenderer.php') =]]
 ```
 
 ### `ibexa` notification channel

--- a/docs/administration/dashboard/php_api_dashboard_service.md
+++ b/docs/administration/dashboard/php_api_dashboard_service.md
@@ -26,7 +26,7 @@ First argument is the `Content ID` of the dashboard to copy.
 Following arguments are the Content IDs of the user groups.
 
 ``` php hl_lines="61"
-[[= include_file('code_samples/back_office/dashboard/src/Command/DashboardCommand.php') =]]
+[[= include_code('code_samples/back_office/dashboard/src/Command/DashboardCommand.php') =]]
 ```
 
 The following line runs the command with `74` as the model dashboard's Content ID, `13` the user group's Content ID, and on the SiteAccess `admin` to have the right `user_content_type_identifier` config:

--- a/docs/ai_actions/extend_ai_actions.md
+++ b/docs/ai_actions/extend_ai_actions.md
@@ -14,7 +14,7 @@ For example, you can create a handler that connects to a translation model and u
 You can execute AI Actions by using the [ActionServiceInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionServiceInterface.html) service, as in the following example:
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/Command/AddMissingAltTextCommand.php', 86, 105, remove_indent=True) =]]
+[[= include_code('code_samples/ai_actions/src/Command/AddMissingAltTextCommand.php', 87, 105, remove_indent=True) =]]
 ```
 
 The `GenerateAltTextAction` is a built-in action that implements the [ActionInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionInterface.html), takes an [Image](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-Action-DataType-Image.html) as an input, and generates the alternative text in the response.
@@ -44,7 +44,7 @@ Below you can find the full example of a Symfony Command, together with a matchi
 The command finds the images modified in the last 24 hours, and adds the alternative text to them if it's missing.
 
 ``` php hl_lines="72 85-110"
-[[= include_file('code_samples/ai_actions/src/Command/AddMissingAltTextCommand.php') =]]
+[[= include_code('code_samples/ai_actions/src/Command/AddMissingAltTextCommand.php') =]]
 ```
 
 ``` yaml
@@ -77,7 +77,7 @@ See [Action Configuration Search Criteria reference](action_configuration_criter
 The following example creates a new Action Configuration:
 
 ``` php hl_lines="3 17"
-[[= include_file('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 46, 63, remove_indent=True) =]]
+[[= include_code('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 47, 63, remove_indent=True) =]]
 ```
 
 Actions Configurations are tied to a specific Action Type and are translatable.
@@ -88,7 +88,7 @@ Reuse existing Action Configurations to simplify the execution of AI Actions.
 You can pass one directly to the `ActionServiceInterface::execute()` method:
 
 ``` php hl_lines="7-8"
-[[= include_file('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 64, 72, remove_indent=True) =]]
+[[= include_code('code_samples/ai_actions/src/Command/ActionConfigurationCreateCommand.php', 65, 72, remove_indent=True) =]]
 ```
 
 The passed Action Configuration is only taken into account if the Action Context was not passed to the Action directly using the [ActionInterface::setActionContext()](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionInterface.html#method_hasActionContext) method.
@@ -117,7 +117,7 @@ Create a class implementing the [ActionHandlerInterface](/api/php_api/php_api_re
 See the code sample below, together with a matching service definition:
 
 ``` php hl_lines="17 25-28 30-65 67-70"
-[[= include_file('code_samples/ai_actions/src/AI/Handler/LLaVaTextToTextActionHandler.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/Handler/LLaVaTextToTextActionHandler.php') =]]
 ```
 
 ``` yaml
@@ -137,7 +137,7 @@ Form configuration makes the Handler configurable by using the back office.
 The example handler uses the `system_prompt` option, which becomes part of the Action Configuration UI thanks to the following code:
 
 ``` php hl_lines="16-20"
-[[= include_file('code_samples/ai_actions/src/Form/Type/TextToTextOptionsType.php') =]]
+[[= include_code('code_samples/ai_actions/src/Form/Type/TextToTextOptionsType.php') =]]
 ```
 
 ``` yaml
@@ -180,7 +180,7 @@ The class needs to define following  parameters of the Action Type:
 - Action object
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/ActionType/TranscribeAudioActionType.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/ActionType/TranscribeAudioActionType.php') =]]
 ```
 
 ``` yaml
@@ -203,13 +203,13 @@ The `TranscribeAudio` Action Type requires adding two data classes that exist in
 - an `Audio` class, implementing the [DataType interface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-DataType.html), to store the input data for the Action
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/DataType/Audio.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/DataType/Audio.php') =]]
 ```
 
 - an `TranscribeAudioAction` class, implementing the [ActionInterface interface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorAi-ActionInterface.html). Pass this object to the `ActionServiceInterface::execute()` method to execute the action.
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/Action/TranscribeAudioAction.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/Action/TranscribeAudioAction.php') =]]
 ```
 
 ### Create custom Action Type options form
@@ -218,7 +218,7 @@ Custom Form Type is needed if the Action Type requires additional options config
 The following example adds a checkbox field that indicates to the Action Handler whether the transcription should include the timestamps.
 
 ``` php hl_lines="16-20"
-[[= include_file('code_samples/ai_actions/src/Form/Type/TranscribeAudioOptionsType.php') =]]
+[[= include_code('code_samples/ai_actions/src/Form/Type/TranscribeAudioOptionsType.php') =]]
 ```
 
 ``` yaml
@@ -234,7 +234,7 @@ The language of the transcribed data is extracted from the Runtime Context for b
 The Action Type options provided in the Action Context dictate whether the timestamps will be removed before returning the result.
 
 ``` php hl_lines="34-37 52-55"
-[[= include_file('code_samples/ai_actions/src/AI/Handler/WhisperAudioToTextActionHandler.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/Handler/WhisperAudioToTextActionHandler.php') =]]
 ```
 
 ``` yaml
@@ -252,7 +252,7 @@ See [adding custom media type](adding_custom_media_type.md) and [creating new RE
 Start by creating an Input Parser able to handle the `application/vnd.ibexa.api.ai.TranscribeAudio` media type.
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/REST/Input/Parser/TranscribeAudio.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/REST/Input/Parser/TranscribeAudio.php') =]]
 ```
 
 ``` yaml
@@ -262,7 +262,7 @@ Start by creating an Input Parser able to handle the `application/vnd.ibexa.api.
 The `TranscribeAudioAction` is a value object holding the parsed request data.
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/REST/Value/TranscribeAudioAction.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/REST/Value/TranscribeAudioAction.php') =]]
 ```
 
 #### Handle output data
@@ -272,14 +272,14 @@ To transform the `TranscribeAudioAction` into a REST response you need to create
 - An `AudioText` value object holding the REST response data
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/REST/Value/AudioText.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/REST/Value/AudioText.php') =]]
 ```
 
 - A resolver converting the Action Response returned from the PHP API layer into the `AudioText` object.
 The resolver is activated when `application/vnd.ibexa.api.ai.AudioText` media type is specified in the `Accept` header:
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/REST/Output/Resolver/AudioTextResolver.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/REST/Output/Resolver/AudioTextResolver.php') =]]
 ```
 
 ``` yaml
@@ -290,7 +290,7 @@ The resolver is activated when `application/vnd.ibexa.api.ai.AudioText` media ty
 
 
 ``` php
-[[= include_file('code_samples/ai_actions/src/AI/REST/Output/ValueObjectVisitor/AudioText.php') =]]
+[[= include_code('code_samples/ai_actions/src/AI/REST/Output/ValueObjectVisitor/AudioText.php') =]]
 ```
 
 ``` yaml

--- a/docs/api/event_reference/event_reference.md
+++ b/docs/api/event_reference/event_reference.md
@@ -13,7 +13,7 @@ In most cases, two events are dispatched for every action, one before the action
 For example, copying a content item is connected with two events: `BeforeCopyContentEvent` and `CopyContentEvent`.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/EventSubscriber/MyEventSubcriber.php') =]]
+[[= include_code('code_samples/api/public_php_api/src/EventSubscriber/MyEventSubcriber.php') =]]
 ```
 
 [[= cards([

--- a/docs/api/graphql/graphql_custom_ft.md
+++ b/docs/api/graphql/graphql_custom_ft.md
@@ -41,7 +41,7 @@ If not specified, it uses `FieldDefinition`.
 Compiler pass example that should be placed in `src/DependencyInjection/Compiler`:
 
 ``` php
-[[= include_file('code_samples/api/graphql/src/DependencyInjection/Compiler/MyCustomTypeGraphQLCompilerPass.php') =]]
+[[= include_code('code_samples/api/graphql/src/DependencyInjection/Compiler/MyCustomTypeGraphQLCompilerPass.php') =]]
 ```
 
 ### Map with a custom `FieldDefinitionMapper`
@@ -75,7 +75,7 @@ When a mapper method is decorated, you need to call the decorated service method
 To do that, you need to replace `mapXXX` by the method it's in:
 
 ```php
-[[= include_file('code_samples/api/graphql/src/GraphQL/Schema/MyFieldDefinitionMapper.php', 19, 22, remove_indent=True) =]]
+[[= include_code('code_samples/api/graphql/src/GraphQL/Schema/MyFieldDefinitionMapper.php', 20, 22, remove_indent=True) =]]
 ```
 
 It's required for every implemented method, so that other mappers are called for the other field types.
@@ -99,7 +99,7 @@ For example, `ibexa_matrix` generates its own input types depending on the confi
 Example of a `MyFieldDefinitionMapper` mapper for a complex field type:
 
 ```php
-[[= include_file('code_samples/api/graphql/src/GraphQL/Schema/MyFieldDefinitionMapper.php') =]]
+[[= include_code('code_samples/api/graphql/src/GraphQL/Schema/MyFieldDefinitionMapper.php') =]]
 ```
 
 ## Resolver expressions

--- a/docs/api/php_api/php_api.md
+++ b/docs/api/php_api/php_api.md
@@ -126,7 +126,7 @@ While [using `sudo()`](#using-sudo) is the recommended option, you can also set 
 To identify as a different user, you need to use the `UserService` together with `PermissionResolver` (in the example `admin` is the login of the administrator user):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateContentCommand.php', 44, 46) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateContentCommand.php', 45, 46, remove_indent=True) =]]
 ```
 
 !!! tip

--- a/docs/api/rest_api/extending_rest_api/adding_custom_media_type.md
+++ b/docs/api/rest_api/extending_rest_api/adding_custom_media_type.md
@@ -32,7 +32,7 @@ In this example, this new `ValueObjectVisitor` extends the built-in `RestLocatio
 This way, the abstract class is implicitly inherited.
 
 ``` php
-[[= include_file('code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php') =]]
+[[= include_code('code_samples/api/rest_api/src/Rest/ValueObjectVisitor/RestLocation.php') =]]
 ```
 
 This new `ValueObjectVisitor` receives a new tag `app.rest.output.value_object.visitor` to be associated to the new `ValueObjectVisitorDispatcher` in the next step.
@@ -56,7 +56,7 @@ services:
 ```
 
 ``` php
-[[= include_file('code_samples/api/rest_api/src/Rest/Output/ValueObjectVisitorDispatcher.php') =]]
+[[= include_code('code_samples/api/rest_api/src/Rest/Output/ValueObjectVisitorDispatcher.php') =]]
 ```
 
 ## New `Output\Visitor` service

--- a/docs/api/rest_api/extending_rest_api/creating_new_rest_resource.md
+++ b/docs/api/rest_api/extending_rest_api/creating_new_rest_resource.md
@@ -61,7 +61,7 @@ A REST controller should:
 - extend `Ibexa\Rest\Server\Controller` to inherit utils methods and properties like `InputDispatcher` or `RequestParser`
 
 ``` php
-[[= include_file('code_samples/api/rest_api/src/Rest/Controller/DefaultController.php') =]]
+[[= include_code('code_samples/api/rest_api/src/Rest/Controller/DefaultController.php') =]]
 ```
 
 If the returned value was depending on a location, it could have been wrapped in a `CachedValue` to be cached by the reverse proxy (like Varnish) for future calls.
@@ -78,7 +78,7 @@ return new CachedValue(
 ## Value and ValueObjectVisitor
 
 ``` php
-[[= include_file('code_samples/api/rest_api/src/Rest/Values/Greeting.php') =]]
+[[= include_code('code_samples/api/rest_api/src/Rest/Values/Greeting.php') =]]
 ```
 
 A `ValueObjectVisitor` must implement the `visit` method.
@@ -90,7 +90,7 @@ A `ValueObjectVisitor` must implement the `visit` method.
 | `$data`      | The visited data. The exact object that you returned from the controller.<br/>It can't have a type declaration because the method signature is shared. |
 
 ``` php
-[[= include_file('code_samples/api/rest_api/src/Rest/ValueObjectVisitor/Greeting.php') =]]
+[[= include_code('code_samples/api/rest_api/src/Rest/ValueObjectVisitor/Greeting.php') =]]
 ```
 
 The `Values/Greeting` class is linked to its `ValueObjectVisitor` through the service tag.
@@ -111,7 +111,7 @@ A REST resource could use route parameters to handle input, but this example ill
 For this example, the structure is a `GreetingInput` root node with two leaf nodes, `Salutation` and `Recipient`.
 
 ``` php
-[[= include_file('code_samples/api/rest_api/src/Rest/InputParser/GreetingInput.php') =]]
+[[= include_code('code_samples/api/rest_api/src/Rest/InputParser/GreetingInput.php') =]]
 ```
 
 Here, this `InputParser` directly returns the right value object.

--- a/docs/api/rest_api/rest_api_usage/testing_rest_api.md
+++ b/docs/api/rest_api/rest_api_usage/testing_rest_api.md
@@ -25,7 +25,7 @@ You can use [Symfony HttpClient]([[= symfony_doc =]]/http_client.html) to test R
 Open a PHP shell in a terminal with <nobr>`php -a`</nobr> and copy-paste this code into it:
 
 ``` php
-[[= include_file('code_samples/api/rest_api/load_content.php', 2, 9) =]]
+[[= include_code('code_samples/api/rest_api/load_content.php', 3, 9, remove_indent=True) =]]
 ```
 
 `$resource` URI should be edited to address the right domain.

--- a/docs/cdp/cdp_data_customization.md
+++ b/docs/cdp/cdp_data_customization.md
@@ -20,7 +20,7 @@ The base class handles user field validation and provides helper methods for wor
 The following example adds a custom date of birth field to the exported data:
 
 ``` php
-[[= include_file('code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php') =]]
+[[= include_code('code_samples/cdp/date_of_birth_export/src/Export/User/DateOfBirthUserItemProcessor.php') =]]
 ```
 
 Register your processor as a Symfony service and tag it with `ibexa.cdp.export.user.item_processor`:

--- a/docs/commerce/cart/cart_api.md
+++ b/docs/commerce/cart/cart_api.md
@@ -23,7 +23,7 @@ From the developer's perspective, carts and entries are referenced with a UUID i
 To access a single cart, use the `CartServiceInterface::getCart` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/CartCommand.php', 63, 66) =]]
+[[= include_code('code_samples/api/commerce/src/Command/CartCommand.php', 64, 66, remove_indent=True) =]]
 ```
 
 ## Get multiple carts
@@ -185,5 +185,5 @@ To combine the contents of multiple shopping carts into a target cart, use the `
 This operation is helpful when you want to consolidate items from a reorder cart and a current cart into a single order.
 
 ```php
-[[= include_file('code_samples/api/commerce/src/Command/CartCommand.php', 126, 139) =]]
+[[= include_code('code_samples/api/commerce/src/Command/CartCommand.php', 127, 139, remove_indent=True) =]]
 ```

--- a/docs/commerce/checkout/checkout_api.md
+++ b/docs/commerce/checkout/checkout_api.md
@@ -22,7 +22,7 @@ From the developer's perspective, checkouts are referenced with an UUID identifi
 To access a single checkout, use the `CheckoutServiceInterface::getCheckout` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 28, 29) =]]
+[[= include_code('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 29, 29, remove_indent=True) =]]
 ```
 
 ## Get single checkout for specific cart
@@ -31,7 +31,7 @@ To fetch checkout for a cart that already exists, use the `CheckoutServiceInterf
 You can use it when you want to initiate the checkout process right after products are successfully added to a cart.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 22, 26) =]]
+[[= include_code('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 23, 26, remove_indent=True) =]]
 ```
 
 ## Create checkout
@@ -39,7 +39,7 @@ You can use it when you want to initiate the checkout process right after produc
 To create a checkout, use the `CheckoutServiceInterface::createCheckout` method and provide it with a `CheckoutCreateStruct` struct that contains a `CartInterface` object.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 31, 37) =]]
+[[= include_code('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 32, 37, remove_indent=True) =]]
 ```
 
 ## Update checkout
@@ -53,7 +53,7 @@ To update the checkout, use the `CheckoutServiceInterface::updateCheckout` metho
 All data is placed in session storage.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 39, 41) =]]
+[[= include_code('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 40, 41, remove_indent=True) =]]
 ```
 
 ## Delete checkout
@@ -61,5 +61,5 @@ All data is placed in session storage.
 To delete a checkout from the session, use the `CheckoutServiceInterface::deleteCheckout` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 43, 44) =]]
+[[= include_code('code_samples/api/commerce/src/Controller/CustomCheckoutController.php', 44, 44, remove_indent=True) =]]
 ```

--- a/docs/commerce/checkout/customize_checkout.md
+++ b/docs/commerce/checkout/customize_checkout.md
@@ -66,7 +66,7 @@ The controller contains a Symfony form that collects user selections.
 It can reuse fields and functions that come from the checkout component, for example, after you check whether the form is valid, use the `AbstractStepController::advance` method to go to the next step of the process.
 
 ``` php hl_lines="23 24"
-[[= include_file('code_samples/front/shop/checkout/src/Controller/Checkout/Step/SelectSeatStepController.php') =]]
+[[= include_code('code_samples/front/shop/checkout/src/Controller/Checkout/Step/SelectSeatStepController.php') =]]
 ```
 
 #### Create a form
@@ -74,7 +74,7 @@ It can reuse fields and functions that come from the checkout component, for exa
 In the `src/Form/Type` folder, create a corresponding form:
 
 ``` php
-[[= include_file('code_samples/front/shop/checkout/src/Form/Type/SelectSeatType.php') =]]
+[[= include_code('code_samples/front/shop/checkout/src/Form/Type/SelectSeatType.php') =]]
 ```
 
 ### Create Twig template
@@ -163,7 +163,7 @@ Within the controller, create a form that contains all the necessary fields, suc
 In the `src/Controller/Checkout` folder, create a file that resembles the following example:
 
 ``` php
-[[= include_file('code_samples/front/shop/checkout/src/Controller/Checkout/OnePageCheckout.php') =]]
+[[= include_code('code_samples/front/shop/checkout/src/Controller/Checkout/OnePageCheckout.php') =]]
 ```
 
 The controller can reuse fields and functions that come from the checkout component, for example, after you check whether the form is valid, use the `AbstractStepController::advance` method to go to the next step of the process.
@@ -173,7 +173,7 @@ The controller can reuse fields and functions that come from the checkout compon
 In the `src/Form/Type` folder, create a corresponding form:
 
 ``` php
-[[= include_file('code_samples/front/shop/checkout/src/Form/Type/OnePageCheckoutType.php') =]]
+[[= include_code('code_samples/front/shop/checkout/src/Form/Type/OnePageCheckoutType.php') =]]
 ```
 
 ### Create Twig template
@@ -212,7 +212,7 @@ Create a PHP definition of the new strategy that allows for workflow manipulatio
 In this example, custom checkout workflow applies when specific currency code ('EUR') is used in the cart.
 
 ``` php
-[[= include_file('code_samples/workflow/strategy/NewWorkflow.php', 0, 25) =]]
+[[= include_code('code_samples/workflow/strategy/NewWorkflow.php', 1, 25, remove_indent=True) =]]
 ```
 
 ### Add conditional step
@@ -224,7 +224,7 @@ By default conditional step is set as null.
 To use conditional step you need to pass second argument to constructor in the strategy definition:
 
 ``` php hl_lines="18"
-[[= include_file('code_samples/workflow/strategy/NewWorkflowConditionalStep.php', 0, 25) =]]
+[[= include_code('code_samples/workflow/strategy/NewWorkflowConditionalStep.php', 1, 25, remove_indent=True) =]]
 ```
 
 ### Register strategy

--- a/docs/commerce/order_management/order_management_api.md
+++ b/docs/commerce/order_management/order_management_api.md
@@ -19,7 +19,7 @@ To get orders and manage them, use the [`Ibexa\Contracts\OrderManagement\OrderSe
 To access a single order by using its string identifier, use the [`OrderServiceInterface::getOrderByIdentifier`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-OrderServiceInterface.html#method_getOrderByIdentifier) method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/OrderCommand.php', 51, 55) =]]
+[[= include_code('code_samples/api/commerce/src/Command/OrderCommand.php', 52, 55, remove_indent=True) =]]
 ```
 
 Use the returned [`OrderInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-Value-Order-OrderInterface.html) value object to access details about the order.
@@ -31,7 +31,7 @@ See the [Discounts API](discounts_api.md#retrieve-applied-discounts) to learn ho
 To access a single order by using its numerical ID, use the [`OrderServiceInterface::getOrder`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-OrderServiceInterface.html#method_getOrder) method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/OrderCommand.php', 57, 61) =]]
+[[= include_code('code_samples/api/commerce/src/Command/OrderCommand.php', 58, 61, remove_indent=True) =]]
 ```
 
 ## Get multiple orders
@@ -51,7 +51,7 @@ It follows the same search query pattern as other APIs:
 To create an order, use the [`OrderServiceInterface::createOrder`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-OrderServiceInterface.html#method_createOrder) method and provide it with the [`Ibexa\Contracts\OrderManagement\Value\Struct\OrderCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-Value-Struct-OrderCreateStruct.html) object that contains a list of products, purchased quantities, product, total prices, and tax amounts.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/OrderCommand.php', 91, 102) =]]
+[[= include_code('code_samples/api/commerce/src/Command/OrderCommand.php', 92, 102, remove_indent=True) =]]
 ```
 
 ## Update order
@@ -61,5 +61,5 @@ You could do it to support a scenario when, for example, the order is processed 
 To update order information, use the [`OrderServiceInterface::updateOrder`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-OrderServiceInterface.html#method_updateOrder) method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/OrderCommand.php', 104, 108) =]]
+[[= include_code('code_samples/api/commerce/src/Command/OrderCommand.php', 105, 108, remove_indent=True) =]]
 ```

--- a/docs/commerce/payment/extend_payment.md
+++ b/docs/commerce/payment/extend_payment.md
@@ -26,7 +26,7 @@ Code samples below show how this could be done if your organization wants to use
 Create a PHP definition of the payment method type.
 
 ``` php
-[[= include_file('code_samples/front/shop/payment/src/PaymentMethodType/PayPal/PayPal.php') =]]
+[[= include_code('code_samples/front/shop/payment/src/PaymentMethodType/PayPal/PayPal.php') =]]
 ```
 
 Make sure that `getName()` returns a human-readable name of the payment method type, the way you want it to appear on the list of available payment method types.
@@ -50,13 +50,13 @@ At this point a custom payment method type should be visible in the user interfa
 Create a corresponding form type:
 
 ``` php
-[[= include_file('code_samples/front/shop/payment/src/Form/Type/PayPalOptionsType.php') =]]
+[[= include_code('code_samples/front/shop/payment/src/Form/Type/PayPalOptionsType.php') =]]
 ```
 
 Next, create a mapper that maps the information that the user inputs in the form into attribute definition.
 
 ``` php
-[[= include_file('code_samples/front/shop/payment/src/PaymentMethodType/PayPal/OptionsFormMapper.php') =]]
+[[= include_code('code_samples/front/shop/payment/src/PaymentMethodType/PayPal/OptionsFormMapper.php') =]]
 ```
 
 Then, register `OptionsFormMapper` as a service:
@@ -71,7 +71,7 @@ You might want to make sure that data provided by the user is validated.
 To do that, create an options validator that checks user input against the constraints and dispatches an error when needed.
 
 ``` php
-[[= include_file('code_samples/front/shop/payment/src/PaymentMethodType/PayPal/UrlOptionValidator.php') =]]
+[[= include_code('code_samples/front/shop/payment/src/PaymentMethodType/PayPal/UrlOptionValidator.php') =]]
 ```
 
 Then, register the validator as a service:
@@ -94,11 +94,11 @@ When you create a payment, you can attach custom data to it, for example, you ca
 You add custom data by using the `setContext` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 81, 93) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 82, 93, remove_indent=True) =]]
 ```
 
 Then, you retrieve it with the `getContext` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 54, 58) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 55, 58, remove_indent=True) =]]
 ```

--- a/docs/commerce/payment/payment_api.md
+++ b/docs/commerce/payment/payment_api.md
@@ -17,7 +17,7 @@ You can change that by providing a custom payment identifier in `Ibexa\Contracts
 To access a single payment by using its numerical ID, use the `PaymentServiceInterface::getPayment` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 48, 52) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 49, 52, remove_indent=True) =]]
 ```
 
 ### Get single payment by identifier
@@ -25,7 +25,7 @@ To access a single payment by using its numerical ID, use the `PaymentServiceInt
 To access a single payment by using its string identifier, use the `PaymentServiceInterface::getPaymentByIdentifier` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 54, 56) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 55, 56, remove_indent=True) =]]
 ```
 
 ## Get multiple payments
@@ -34,7 +34,7 @@ To fetch multiple payments, use the `PaymentServiceInterface::findPayments` meth
 It follows the same search query pattern as other APIs:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 63, 79) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 64, 79, remove_indent=True) =]]
 ```
 
 ## Create payment
@@ -42,7 +42,7 @@ It follows the same search query pattern as other APIs:
 To create a payment, use the `PaymentServiceInterface::createPayment` method and provide it with the `Ibexa\Contracts\Payment\Payment\PaymentCreateStruct` object that takes the following arguments: `method`, `order` and `amount`.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 81, 95) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 82, 95, remove_indent=True) =]]
 ```
 
 ## Update payment
@@ -53,7 +53,7 @@ The `Ibexa\Contracts\Payment\Payment\PaymentUpdateStruct` object takes the follo
 To update payment information, use the `PaymentServiceInterface::updatePayment` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 97, 103) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 98, 103, remove_indent=True) =]]
 ```
 
 ## Delete payment
@@ -61,5 +61,5 @@ To update payment information, use the `PaymentServiceInterface::updatePayment` 
 To delete a payment from the system, use the `PaymentServiceInterface::deletePayment` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentCommand.php', 105, 106) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentCommand.php', 106, 106, remove_indent=True) =]]
 ```

--- a/docs/commerce/payment/payment_method_api.md
+++ b/docs/commerce/payment/payment_method_api.md
@@ -26,7 +26,7 @@ From the developer's perspective, payment methods are referenced with identifier
 To access a single payment method by using its string identifier, use the `PaymentMethodService::getPaymentMethodByIdentifier` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 46, 50) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 47, 50, remove_indent=True) =]]
 ```
 
 ### Get single payment method by ID
@@ -34,7 +34,7 @@ To access a single payment method by using its string identifier, use the `Payme
 To access a single payment method by using its numerical ID, use the `PaymentMethodService::getPaymentMethod` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 40, 44) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 41, 44, remove_indent=True) =]]
 ```
 
 ## Get multiple payment methods
@@ -44,7 +44,7 @@ To fetch multiple payment methods, use the `PaymentMethodService::findPaymentMet
 It follows the same search query pattern as other APIs:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 52, 69) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 53, 69, remove_indent=True) =]]
 ```
 
 ## Create payment method
@@ -70,14 +70,14 @@ An `Ibexa\Contracts\Payment\PaymentMethod\PaymentMethodUpdateStruct` object can 
 To update payment method information, use the `PaymentMethodServiceInterface::updatePaymentMethod` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 83, 93) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 84, 93, remove_indent=True) =]]
 ```
 
 ## Delete payment method
 
 To delete a payment method from the system, use the `PaymentMethodService::deletePayment` method:
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 95, 101) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 96, 101, remove_indent=True) =]]
 ```
 
 ## Check whether payment method is used
@@ -85,5 +85,5 @@ To delete a payment method from the system, use the `PaymentMethodService::delet
 To check whether a payment method is used, for example, before you delete it, use the `PaymentMethodService::isPaymentMethodUsed` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 103, 116) =]]
+[[= include_code('code_samples/api/commerce/src/Command/PaymentMethodCommand.php', 104, 116, remove_indent=True) =]]
 ```

--- a/docs/commerce/payment/payment_method_filtering.md
+++ b/docs/commerce/payment/payment_method_filtering.md
@@ -32,7 +32,7 @@ Now new custom payment method type should be visible in **Commerce** -> **Paymen
 Next, create a `NewPaymentMethodTypeVoter.php` file with the voter definition for your new payment method type:
 
 ``` php
-[[= include_file('code_samples/front/shop/payment/src/lib/PaymentMethod/Voter/NewPaymentMethodTypeVoter.php') =]]
+[[= include_code('code_samples/front/shop/payment/src/lib/PaymentMethod/Voter/NewPaymentMethodTypeVoter.php') =]]
 ```
 
 Created voter decides, if selected payment method type can be used and displayed in checkout process.

--- a/docs/commerce/shipping_management/extend_shipping.md
+++ b/docs/commerce/shipping_management/extend_shipping.md
@@ -41,7 +41,7 @@ Create a `src/ShippingMethodType/Form/Type/CustomShippingMethodOptionsType.php` 
 Next, define a name of the custom shipping method type in the file, by using the `getTranslationMessages` method.
 
 ``` php hl_lines="32"
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/Form/Type/CustomShippingMethodOptionsType.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/Form/Type/CustomShippingMethodOptionsType.php') =]]
 ```
 
 Create a translations file `translations/ibexa_shipping.en.yaml` that stores a name value for the custom shipping method type:
@@ -79,7 +79,7 @@ Use the type factory to define a compound validator class in `config/services.ya
 Then, create a `src/ShippingMethodType/CustomerNotNullValidator.php` file with a validator class:
 
 ``` php
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/CustomerNotNullValidator.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/CustomerNotNullValidator.php') =]]
 ```
 
 Finally, register the validator as a service:
@@ -100,7 +100,7 @@ Here, the storage converter converts the `customer_identifier` string value into
 Create a `src/ShippingMethodType/Storage/StorageConverter.php` file with a storage converter class:
 
 ``` php
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/Storage/StorageConverter.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/Storage/StorageConverter.php') =]]
 ```
 
 Then, register the storage converter as a service:
@@ -123,13 +123,13 @@ The table stores information specific for the custom shipping method type.
 Create a `src/ShippingMethodType/Storage/StorageDefinition.php` file with a storage definition:
 
 ``` php
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/Storage/StorageDefinition.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/Storage/StorageDefinition.php') =]]
 ```
 
 Then, create a `src/ShippingMethodType/Storage/StorageSchema.php` file with a storage schema:
 
 ``` php
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/Storage/StorageSchema.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/Storage/StorageSchema.php') =]]
 ```
 
 Then, register the storage definition as a service:
@@ -145,7 +145,7 @@ Here, you limit shipping method availability to customers who meet a specific co
 Create a `src/ShippingMethodType/Vote/CustomVoter.php` file with a voter class:
 
 ``` php
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/Voter/CustomVoter.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/Voter/CustomVoter.php') =]]
 ```
 
 Register the voter as a service:
@@ -160,7 +160,7 @@ You can extend the default shipping method details view by making shipping metho
 To do this, create a `src/ShippingMethodType/Cost/CustomCostFormatter.php` file with a formatter class:
 
 ``` php
-[[= include_file('code_samples/front/shop/shipping/src/ShippingMethodType/Cost/CustomCostFormatter.php') =]]
+[[= include_code('code_samples/front/shop/shipping/src/ShippingMethodType/Cost/CustomCostFormatter.php') =]]
 ```
 
 Then register the formatter as a service:

--- a/docs/commerce/shipping_management/shipment_api.md
+++ b/docs/commerce/shipping_management/shipment_api.md
@@ -16,7 +16,7 @@ From the developer's perspective, shipments are referenced with a UUID identifie
 To access a single shipment by using its string identifier, use the `ShipmentService::getShipmentByIdentifier` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShipmentCommand.php', 57, 66) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 58, 66, remove_indent=True) =]]
 ```
 
 ### Get single shipment by id
@@ -24,7 +24,7 @@ To access a single shipment by using its string identifier, use the `ShipmentSer
 To access a single shipment by using its numerical id, use the `ShipmentService::getShipment` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShipmentCommand.php', 45, 55) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 46, 55, remove_indent=True) =]]
 ```
 
 ## Get multiple shipments
@@ -33,7 +33,7 @@ To fetch multiple shipments, use the `ShipmentService::findShipments` method.
 It follows the same search query pattern as other APIs:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShipmentCommand.php', 68, 87) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 69, 87, remove_indent=True) =]]
 ```
 
 ## Create shipment
@@ -41,7 +41,7 @@ It follows the same search query pattern as other APIs:
 To create a shipment, use the `ShipmentService::createShipment` method and provide it with an `Ibexa\Contracts\Shipping\Value\ShipmentCreateStruct` object that takes two parameters, a `shippingMethod` string and a `Money` object.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShipmentCommand.php', 89, 103) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 90, 103, remove_indent=True) =]]
 ```
 
 ## Update shipment
@@ -51,7 +51,7 @@ You could do it to support a scenario when, for example, the shipment is process
 To update shipment information, use the `ShipmentService::updateShipment` method:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShipmentCommand.php', 105, 116) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 106, 116, remove_indent=True) =]]
 ```
 ## Delete shipment
 
@@ -59,5 +59,5 @@ To delete a shipment from the system, use the `ShipmentService::deleteShipment` 
 
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShipmentCommand.php', 118, 119) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShipmentCommand.php', 119, 119, remove_indent=True) =]]
 ```

--- a/docs/commerce/shipping_management/shipping_method_api.md
+++ b/docs/commerce/shipping_management/shipping_method_api.md
@@ -17,7 +17,7 @@ To access a shipping method by using its identifier, use the `ShippingMethodServ
 The method takes a string as `$identifier` parameter and uses a prioritized language from SiteAccess settings unless you pass another language as `forcedLanguage`.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 52, 62) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 53, 62, remove_indent=True) =]]
 ```
 
 ### Get shipping method by ID
@@ -26,7 +26,7 @@ To access a shipping method by using its ID, use the `ShippingMethodServiceInter
 The method takes a string as `$id` parameter and uses a prioritized language from SiteAccess settings unless you pass another language as `forcedLanguage`.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 40, 50) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 41, 50, remove_indent=True) =]]
 ```
 
 ## Get multiple shipping methods
@@ -35,7 +35,7 @@ To fetch multiple shipping methods, use the `ShippingMethodServiceInterface::get
 It follows the same search query pattern as other APIs:
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 64, 82) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 65, 82, remove_indent=True) =]]
 ```
 
 ## Create shipping method
@@ -43,7 +43,7 @@ It follows the same search query pattern as other APIs:
 To create a shipping method, use the `ShippingMethodServiceInterface::createShippingMethod` method and provide it with the `Ibexa\Contracts\Shipping\Value\ShippingMethodCreateStruct` object that you created by using the  `newShippingMethodCreateStruct` method.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 84, 107) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 85, 107, remove_indent=True) =]]
 ```
 
 ## Update shipping method
@@ -51,7 +51,7 @@ To create a shipping method, use the `ShippingMethodServiceInterface::createShip
 To update a shipping method, use the `ShippingMethodServiceInterface::updateShippingMethod` method and provide it with the `Ibexa\Contracts\Shipping\Value\ShippingMethodUpdateStruct`  object that you created by using the  `newShippingMethodUpdateStruct` method.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 109, 123) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 110, 123, remove_indent=True) =]]
 ```
 
 ## Delete shipping method
@@ -59,7 +59,7 @@ To update a shipping method, use the `ShippingMethodServiceInterface::updateShip
 To update a shipping method, use the `ShippingMethodServiceInterface::deleteShippingMethod` method.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 125, 131) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 126, 131, remove_indent=True) =]]
 ```
 
 ## Delete shipping method translation
@@ -67,5 +67,5 @@ To update a shipping method, use the `ShippingMethodServiceInterface::deleteShip
 To delete shipping method translation, use the `ShippingMethodServiceInterface::deleteShippingMethodTranslation` method.
 
 ``` php
-[[= include_file('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 133, 142) =]]
+[[= include_code('code_samples/api/commerce/src/Command/ShippingMethodCommand.php', 134, 142, remove_indent=True) =]]
 ```

--- a/docs/commerce/shopping_list/shopping_list_api.md
+++ b/docs/commerce/shopping_list/shopping_list_api.md
@@ -71,13 +71,13 @@ The following example adds products to a shopping list while avoiding error on d
 In this example the duplicates are ignored, but you could extend it to, for example, notify the user about each found duplicate.
 
 ```php
-[[= include_file('code_samples/shopping_list/php_api/src/Command/ShoppingListFilterCommand.php', 39, 50) =]]
+[[= include_code('code_samples/shopping_list/php_api/src/Command/ShoppingListFilterCommand.php', 40, 50, remove_indent=True) =]]
 ```
 
 The following example moves products from a source shopping list to a target shopping list after filtering out products already in the target list:
 
 ```php
-[[= include_file('code_samples/shopping_list/php_api/src/Command/ShoppingListMoveCommand.php', 42, 54) =]]
+[[= include_code('code_samples/shopping_list/php_api/src/Command/ShoppingListMoveCommand.php', 43, 54, remove_indent=True) =]]
 ```
 
 ### Transfer between shopping list and cart
@@ -90,7 +90,7 @@ then adds a product to the shopping list and copies it twice to the cart.
 It continues with moving the whole cart to an empty list.
 
 ```php
-[[= include_file('code_samples/shopping_list/php_api/src/Controller/CartShoppingListTransferController.php', 69, 92) =]]
+[[= include_code('code_samples/shopping_list/php_api/src/Controller/CartShoppingListTransferController.php', 70, 92, remove_indent=True) =]]
 ```
 
 ### Events

--- a/docs/commerce/shopping_list/shopping_list_design.md
+++ b/docs/commerce/shopping_list/shopping_list_design.md
@@ -65,7 +65,7 @@ To have a more complete example, let's continue with a product full view templat
 
 In `src/Controller/ProductViewController.php`, create a new controller to add the variants to the product view:
 ``` php hl_lines="24-30"
-[[= include_file('code_samples/shopping_list/add_to_shopping_list/src/Controller/ProductViewController.php') =]]
+[[= include_code('code_samples/shopping_list/add_to_shopping_list/src/Controller/ProductViewController.php') =]]
 ```
 
 In `templates/themes/standard/full/product.html.twig`, create a template to render the product in full view:

--- a/docs/commerce/storefront/extend_storefront.md
+++ b/docs/commerce/storefront/extend_storefront.md
@@ -33,7 +33,7 @@ This subscriber replaces the URI under the `Home` link.
 Create an event subscriber in `src/EventSubscriber/BreadcrumbsMenuSubscriber.php`:
 
 ``` php
-[[= include_file('code_samples/front/shop/storefront/src/EventSubscriber/BreadcrumbsMenuSubscriber.php') =]]
+[[= include_code('code_samples/front/shop/storefront/src/EventSubscriber/BreadcrumbsMenuSubscriber.php') =]]
 ```
 
 Next, create the `templates/themes/storefront/storefront/knp_menu/breadcrumbs.html.twig` template:

--- a/docs/content_management/collaborative_editing/collaborative_editing_api.md
+++ b/docs/content_management/collaborative_editing/collaborative_editing_api.md
@@ -17,7 +17,7 @@ month_change: false
 You can create new collaboration session with [`SessionService::createSession()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_createSession):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 47, 58) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 48, 58, remove_indent=True) =]]
 ```
 
 ### Get session
@@ -27,13 +27,13 @@ You can get an existing collaboration session with [`SessionService::getSession(
 - using given id - with [`SessionService::getSession()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_getSession)
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 60, 61) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 61, 61, remove_indent=True) =]]
 ```
 
 - using given token - with [`SessionService::getSessionByToken()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_getSessionByToken)
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 61, 62) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 62, 62, remove_indent=True) =]]
 ```
 
 ### Find sessions
@@ -41,7 +41,7 @@ You can get an existing collaboration session with [`SessionService::getSession(
 You can find an existing session with [`SessionService::findSessions()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_findSessions) by passing a SessionQuery object:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 64, 66) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 65, 66, remove_indent=True) =]]
 ```
 
 To learn more about the available search options, see [Search Criteria](collaboration_criteria.md) and [Sort Clauses](collaboration_sort_clauses.md) for Collaborative editing.
@@ -51,7 +51,7 @@ To learn more about the available search options, see [Search Criteria](collabor
 You can update existing invitation with [`SessionService::updateSession()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_updateSession):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 68, 72) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 69, 72, remove_indent=True) =]]
 ```
 
 ### Delete session
@@ -59,7 +59,7 @@ You can update existing invitation with [`SessionService::updateSession()`](/api
 You can delete session with [`SessionService::deleteSession()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_deleteSession):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 147, 148) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 148, 148, remove_indent=True) =]]
 ```
 
 ## Managing participants
@@ -69,7 +69,7 @@ You can delete session with [`SessionService::deleteSession()`](/api/php_api/php
 You can add participant to the collaboration session with [`SessionService::addParticipant()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_addParticipant):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 80, 93) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 81, 93, remove_indent=True) =]]
 ```
 
 ### Get and update participant
@@ -77,7 +77,7 @@ You can add participant to the collaboration session with [`SessionService::addP
 You can update participant added to the collaboration session with [`SessionService::updateParticipant()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_updateParticipant):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 95, 102) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 96, 102, remove_indent=True) =]]
 ```
 
 The example below updates participant's permissions to allow for editing of shared content, not only previewing.
@@ -87,7 +87,7 @@ The example below updates participant's permissions to allow for editing of shar
 You can remove participant from the collaboration session with [`SessionService::removeParticipant()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_removeParticipant):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 104, 105) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 105, 105, remove_indent=True) =]]
 ```
 
 ### Check session owner
@@ -95,7 +95,7 @@ You can remove participant from the collaboration session with [`SessionService:
 You can check whether a user belongs to a collaboration session with [`SessionService::isSessionOwner()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceDecorator.html#method_isSessionOwner):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 107, 111) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 108, 111, remove_indent=True) =]]
 ```
 
 If no user is provided, current user is used.
@@ -105,7 +105,7 @@ If no user is provided, current user is used.
 You can check the participant of the collaboration session with [`SessionService::isSessionParticipant()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-SessionServiceInterface.html#method_isSessionParticipant):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 113, 117) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 114, 117, remove_indent=True) =]]
 ```
 
 ## Managing invitations
@@ -115,7 +115,7 @@ You can check the participant of the collaboration session with [`SessionService
 You can get an invitation with [`InvitationService::getInvitation()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-InvitationServiceInterface.html#method_getInvitation):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 126, 127) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 127, 127, remove_indent=True) =]]
 ```
 
 ### Create invitation
@@ -123,7 +123,7 @@ You can get an invitation with [`InvitationService::getInvitation()`](/api/php_a
 You can create new invitation for the collaborative session using the [`InvitationService::createInvitation()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-InvitationServiceInterface.html#method_createInvitation) method:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 129, 135) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 130, 135, remove_indent=True) =]]
 ```
 
 You can use it when auto-inviting participants is not enabled.
@@ -133,7 +133,7 @@ You can use it when auto-inviting participants is not enabled.
 You can update existing invitation with [`InvitationService::updateInvitation()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-InvitationServiceInterface.html#method_updateInvitation):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 137, 141) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 138, 141, remove_indent=True) =]]
 ```
 
 ### Delete invitation
@@ -141,7 +141,7 @@ You can update existing invitation with [`InvitationService::updateInvitation()`
 You can delete an invitation with [`InvitationService::deleteInvitation()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-InvitationServiceInterface.html#method_deleteInvitation):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 143, 145) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 144, 145, remove_indent=True) =]]
 ```
 
 ### Find invitations
@@ -149,7 +149,7 @@ You can delete an invitation with [`InvitationService::deleteInvitation()`](/api
 You can find an invitation with [`InvitationService::findInvitations()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Collaboration-InvitationServiceInterface.html#method_findInvitations):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 119, 125) =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php', 120, 125, remove_indent=True) =]]
 ```
 
 To learn more about the available search options, see [Search Criteria](collaboration_criteria.md) and [Sort Clauses](collaboration_sort_clauses.md) for Collaborative editing.
@@ -159,5 +159,5 @@ To learn more about the available search options, see [Search Criteria](collabor
 Below you can see an example of API usage for Collaborative editing:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Command/ManageSessionsCommand.php') =]]
+[[= include_code('code_samples/collaboration/src/Command/ManageSessionsCommand.php') =]]
 ```

--- a/docs/content_management/collaborative_editing/extend_collaborative_editing.md
+++ b/docs/content_management/collaborative_editing/extend_collaborative_editing.md
@@ -84,13 +84,13 @@ In the `src/Collaboration/Cart/Persistence/Gateway/` directory, create the follo
 - `DatabaseSchema` - defines the database tables needed to store shared Cart collaboration session data:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Persistence/Gateway/DatabaseSchema.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Persistence/Gateway/DatabaseSchema.php') =]]
 ```
 
 - `DatabaseGateway` - implements the gateway logic for getting and retrieving shared Cart collaboration data from the database. It uses a Discriminator to identify the type of session (in this case, a Cart session):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Persistence/Gateway/DatabaseGateway.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Persistence/Gateway/DatabaseGateway.php') =]]
 ```
 
 ### Define persistence Value objects
@@ -107,19 +107,19 @@ In the `src/Collaboration/Cart/Persistence/Values/` directory, create the follow
 - `CartSession` - represents the Cart collaboration session data:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Persistence/Values/CartSession.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Persistence/Values/CartSession.php') =]]
 ```
 
 - `CartSessionCreateStruct` - defines the data needed to create a new Cart collaboration session:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Persistence/Values/CartSessionCreateStruct.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Persistence/Values/CartSessionCreateStruct.php') =]]
 ```
 
 - `CartSessionUpdateStruct` - defines the data used to update an existing Cart collaboration session:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Persistence/Values/CartSessionUpdateStruct.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Persistence/Values/CartSessionUpdateStruct.php') =]]
 ```
 
 ### Create Cart session Struct objects
@@ -133,25 +133,25 @@ In the `src/Collaboration/Cart/` directory, create the following Session Structs
 - `CartSessionCreateStruct` - holds all necessary properties (like session token, participants, scopes, and the Cart reference) needed by the `SessionService` to create the shared Cart session:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/CartSessionCreateStruct.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/CartSessionCreateStruct.php') =]]
 ```
 
 - `CartSessionUpdateStruct` - defines the properties used to update an existing Cart collaboration session, including participants, scopes, and metadata:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/CartSessionUpdateStruct.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/CartSessionUpdateStruct.php') =]]
 ```
 
 - `CartSession` - represents a Cart collaboration session, storing its ID, token, associated Cart, participants, and scope:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/CartSession.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/CartSession.php') =]]
 ```
 
 - `CartSessionType` - defines the type of the collaboration session (in this case it indicates it’s a Cart session):
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/CartSessionType.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/CartSessionType.php') =]]
 ```
 
 ## Create mappers
@@ -163,25 +163,25 @@ In the `src/Collaboration/Cart/Mapper/` directory, create following mappers:
 - `CartProxyMapper` - creates a simplified version of the Cart with only the necessary data to reduce memory usage in collaboration sessions:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartProxyMapper.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartProxyMapper.php') =]]
 ```
 
 - `CartProxyMapperInterface` - defines how a Cart should be converted into a simplified object that is used in collaboration session and specifies what methods the mapper must implement:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartProxyMapperInterface.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartProxyMapperInterface.php') =]]
 ```
 
 - `CartSessionDomainMapper` - builds the session object from persistence object:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartSessionDomainMapper.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartSessionDomainMapper.php') =]]
 ```
 
 - `CartSessionPersistenceMapper` - prepares session data to be saved or updated in the database:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartSessionPersistenceMapper.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Mapper/CartSessionPersistenceMapper.php') =]]
 ```
 
 Then, in the `src/Collaboration/Cart/Persistence/` directory, create the following mapper:
@@ -189,7 +189,7 @@ Then, in the `src/Collaboration/Cart/Persistence/` directory, create the followi
 - `Persistence/Mapper` - builds the session object from persistence row:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/Persistence/Mapper.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/Persistence/Mapper.php') =]]
 ```
 
 In `services.yaml`, declare and tags the gateway and the mappers:
@@ -217,13 +217,13 @@ In the `src/Collaboration/Cart/` directory, create the following files:
 - `PermissionResolverDecorator` – customizes the permission resolver to handle access rules for Cart collaboration sessions. It allows participants to view or edit shared Carts while preserving default permission checks for all other cases. Here you can decide what scope is available for this collaboration session by choosing between `view` or `edit`:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/PermissionResolverDecorator.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/PermissionResolverDecorator.php') =]]
 ```
 
 - `CartResolverDecorator` – resolves the shared Carts in collaboration sessions by checking if a Cart belongs to a collaboration session:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Collaboration/Cart/CartResolverDecorator.php') =]]
+[[= include_code('code_samples/collaboration/src/Collaboration/Cart/CartResolverDecorator.php') =]]
 ```
 
 In `services.yaml`, declare those decorator services associated with what they decorate:
@@ -254,7 +254,7 @@ If a shared Cart exists, the Cart is retrieved and a session is created (`$cart`
 In the `addParticipant` step, the user whose email address was provided is added to the session and assigned a scope (either `view` or `edit`).
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Controller/ShareCartCreateController.php') =]]
+[[= include_code('code_samples/collaboration/src/Controller/ShareCartCreateController.php') =]]
 ```
 
 ### `ShareCartJoinController`
@@ -266,7 +266,7 @@ If the session exists, the session parameter (`collaboration_session`) is retrie
 Finally, `redirectToRoute` redirects the user to the Cart view and passes the identifier of the shared Cart.
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Controller/ShareCartJoinController.php') =]]
+[[= include_code('code_samples/collaboration/src/Controller/ShareCartJoinController.php') =]]
 ```
 
 !!! caution "Session parameter"
@@ -283,13 +283,13 @@ The form collects the email address of the user that you want to invite, and the
 - `ShareCartType` - a simple form for entering an email address of the user you want to invite to share the Cart. The form contains a single input field where you enter the email address manually:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Form/Type/ShareCartType.php') =]]
+[[= include_code('code_samples/collaboration/src/Form/Type/ShareCartType.php') =]]
 ```
 
 - `ShareCartData` - a class that holds the email address submitted through the form and passes it to the controller:
 
 ``` php
-[[= include_file('code_samples/collaboration/src/Form/Data/ShareCartData.php') =]]
+[[= include_code('code_samples/collaboration/src/Form/Data/ShareCartData.php') =]]
 ```
 
 The last step is to integrate the new session type into your application by adding templates.

--- a/docs/content_management/content_api/browsing_content.md
+++ b/docs/content_management/content_api/browsing_content.md
@@ -46,7 +46,7 @@ It provides you with basic content metadata such as modification and publication
 To get the locations of a content item you need to make use of the [`LocationService`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LocationService.html):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 55, 61) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 56, 61, remove_indent=True) =]]
 ```
 
 [`LocationService::loadLocations`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LocationService.html#method_loadLocations) uses `ContentInfo` to get all the locations of a content item.
@@ -68,7 +68,7 @@ The [`URLAliasService`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-C
 You can retrieve the content type of a content item through the [`getContentType`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-ContentInfo.html#method_getContentType) method of the ContentInfo object:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 69, 71) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 70, 71, remove_indent=True) =]]
 ```
 
 ### Versions
@@ -76,13 +76,13 @@ You can retrieve the content type of a content item through the [`getContentType
 To iterate over the versions of a content item, use the [`ContentService::loadVersions`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html#method_loadVersions) method, which returns an array of `VersionInfo` value objects.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 73, 79) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 74, 79, remove_indent=True) =]]
 ```
 
 You can additionally provide the `loadVersions` method with the version status to get only versions of a specific status, for example:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 80, 81) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 81, 81, remove_indent=True) =]]
 ```
 
 !!! note
@@ -98,7 +98,7 @@ This method loads only the specified subset of relations to improve performance 
 You can get the current version's `VersionInfo` using [`ContentService::loadVersionInfo`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html#method_loadVersionInfo).
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 92, 99) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 93, 99, remove_indent=True) =]]
 ```
 
 You can also specify the version number as the second argument to get Relations for a specific version:
@@ -117,7 +117,7 @@ It also holds the [relation type](content_relations.md), and the optional field 
 You can use the `getOwner` method of the `ContentInfo` object to load the content item's owner as a `User` value object.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 101, 102) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 102, 102, remove_indent=True) =]]
 ```
 
 To get the creator of the current version and not the content item's owner, you need to use the `creatorId` property from the current version's `VersionInfo` object.
@@ -127,7 +127,7 @@ To get the creator of the current version and not the content item's owner, you 
 You can find the section to which a content item belongs through the [`getSection`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-ContentInfo.html#method_getSection) method of the ContentInfo object:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 104, 105) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 105, 105, remove_indent=True) =]]
 ```
 
 !!! note
@@ -142,7 +142,7 @@ You need to provide it with the object state group.
 All object state groups can be retrieved through [`loadObjectStateGroups`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ObjectStateService.html#method_loadObjectStateGroups).
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 107, 112) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ViewContentMetaDataCommand.php', 108, 112, remove_indent=True) =]]
 ```
 
 ## Viewing content with fields
@@ -184,7 +184,7 @@ $contentService->loadContent($content->id, Language::ALL);
 To go through all the content items contained in a subtree, you need to use the [`LocationService`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LocationService.html).
 
 ``` php hl_lines="5 15"
-[[= include_file('code_samples/api/public_php_api/src/Command/BrowseLocationsCommand.php', 31, 50) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/BrowseLocationsCommand.php', 32, 50, remove_indent=True) =]]
 ```
 
 `loadLocation` (line 15) returns a value object, here a `Location`.

--- a/docs/content_management/content_api/creating_content.md
+++ b/docs/content_management/content_api/creating_content.md
@@ -21,7 +21,7 @@ Value objects such as content items are read-only, so to create or modify them y
 returns a new [`ContentCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-ContentCreateStruct.html) object.
 
 ``` php hl_lines="2-3 7"
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateContentCommand.php', 51, 60) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateContentCommand.php', 52, 60, remove_indent=True) =]]
 ```
 
 This command creates a draft using [`ContentService::createContent`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html#method_createContent) (line 6).
@@ -42,7 +42,7 @@ Therefore, when creating a content item of the Image type (or any other content 
 the `ContentCreateStruct` is slightly more complex than in the previous example:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateImageCommand.php', 51, 63) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateImageCommand.php', 52, 63, remove_indent=True) =]]
 ```
 
 Value of the Image field type contains the path to the image file and other basic information based on the input file.
@@ -66,7 +66,7 @@ To publish it, use [`ContentService::publishVersion`](/api/php_api/php_api_refer
 This method must get the [`VersionInfo`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-VersionInfo.html) object of a draft version.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateContentCommand.php', 62, 63) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateContentCommand.php', 63, 63, remove_indent=True) =]]
 ```
 
 ## Updating content
@@ -76,7 +76,7 @@ and pass it to [`ContentService::updateContent`](/api/php_api/php_api_reference/
 This method works on a draft, so to publish your changes you need to use [`ContentService::publishVersion`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html#method_publishVersion) as well:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/UpdateContentCommand.php', 44, 53) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/UpdateContentCommand.php', 45, 53, remove_indent=True) =]]
 ```
 
 ## Translating content
@@ -95,7 +95,7 @@ You can also update content in multiple languages at once using the `setField` m
 Only one language can still be set as a version's initial language:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TranslateContentCommand.php', 57, 58) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TranslateContentCommand.php', 58, 58, remove_indent=True) =]]
 ```
 
 ### Deleting a translation

--- a/docs/content_management/content_api/managing_content.md
+++ b/docs/content_management/content_api/managing_content.md
@@ -33,7 +33,7 @@ It sets the `parentLocationId` property of the new location.
 You can also provide other properties for the location, otherwise they're set to their defaults:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/AddLocationToContentCommand.php', 48, 50) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/AddLocationToContentCommand.php', 49, 50, remove_indent=True) =]]
 ```
 
 ### Changing the main location
@@ -42,7 +42,7 @@ When a content item has more that one location, one location is always considere
 You can change the main location using [`ContentService`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentService.html), by updating the `ContentInfo` with a [`ContentUpdateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-ContentUpdateStruct.html) that sets the new main location:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SetMainLocationCommand.php', 46, 51) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SetMainLocationCommand.php', 47, 51, remove_indent=True) =]]
 ```
 
 ### Hiding and revealing locations
@@ -68,14 +68,14 @@ Content which has more locations is still available in its other locations.
 If you delete the [main location](#changing-the-main-location) of a content item that has more locations, another location becomes the main one.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/DeleteContentCommand.php', 40, 43) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/DeleteContentCommand.php', 41, 43, remove_indent=True) =]]
 ```
 
 To send the location and its subtree to Trash, use [`TrashService::trash`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-TrashService.html#method_trash).
 Items in Trash can be later [restored, or deleted permanently](#trash).
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TrashContentCommand.php', 50, 51) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TrashContentCommand.php', 51, 51, remove_indent=True) =]]
 ```
 
 ### Moving and copying a subtree
@@ -83,7 +83,7 @@ Items in Trash can be later [restored, or deleted permanently](#trash).
 You can move a location with its whole subtree using [`LocationService::moveSubtree`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LocationService.html#method_moveSubtree):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/MoveContentCommand.php', 44, 47) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/MoveContentCommand.php', 45, 47, remove_indent=True) =]]
 ```
 
 [`LocationService::copySubtree`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LocationService.html#method_copySubtree) is used in the same way, but it copies the location and its subtree instead of moving it.
@@ -110,7 +110,7 @@ You must provide the method with the ID of the object in Trash.
 Trash location is identical to the origin location of the object.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TrashContentCommand.php', 60, 61) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TrashContentCommand.php', 61, 61, remove_indent=True) =]]
 ```
 
 The content item is restored under its previous location.
@@ -147,7 +147,7 @@ A content type must have at least one name, in the main language, and at least o
 You can specify more details of the field definition in the create struct, for example:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateContentTypeCommand.php', 64, 74) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateContentTypeCommand.php', 65, 74, remove_indent=True) =]]
 ```
 
 ### Copying content types
@@ -155,7 +155,7 @@ You can specify more details of the field definition in the create struct, for e
 To copy a content type, use [`ContentTypeService::copyContentType`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ContentTypeService.html#method_copyContentType):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateContentTypeCommand.php', 85, 88) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateContentTypeCommand.php', 86, 88, remove_indent=True) =]]
 ```
 
 The copy is automatically getting an identifier based on the original content type identifier and the copy's ID, for example: `copy_of_folder_21`.
@@ -163,7 +163,7 @@ The copy is automatically getting an identifier based on the original content ty
 To change the identifier of the copy, use a [`ContentTypeUpdateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ContentType-ContentTypeUpdateStruct.html):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CreateContentTypeCommand.php', 87, 93) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CreateContentTypeCommand.php', 88, 93, remove_indent=True) =]]
 ```
 
 ### Finding and filtering content types
@@ -180,7 +180,7 @@ This method accepts a `ContentTypeQuery` object that supports filtering and sort
 The following example shows how you can use the criteria to find content types:
 
 ```php hl_lines="28-38"
-[[= include_file('code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php') =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php') =]]
 ```
 
 #### Query parameters
@@ -210,19 +210,19 @@ To get a list of events for a specified time period, use the `CalendarServiceInt
 You need to provide the method with an EventQuery, which takes a date range and a count as the minimum of parameters:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 37, 48) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 38, 48, remove_indent=True) =]]
 ```
 
 You can also get the first and last event in the list by using the `first()` and `last()` methods of an `EventCollection` (`Ibexa\Contracts\Calendar\EventCollection`):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 49, 51) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 50, 51, remove_indent=True) =]]
 ```
 
 You can process the events in a collection using the `find(Closure $predicate)`, `filter(Closure $predicate)`, `map(Closure $callback)` or `slice(int $offset, ?int $length = null)` methods of `EventCollection`, for example:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 52, 56) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 53, 56, remove_indent=True) =]]
 ```
 
 ### Performing calendar actions
@@ -232,5 +232,5 @@ You must pass an `Ibexa\Contracts\Calendar\EventAction\EventActionContext` insta
 `EventActionContext` defines events on which the action is performed, and action-specific parameters, for example, a new date:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 57, 61) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/CalendarCommand.php', 58, 61, remove_indent=True) =]]
 ```

--- a/docs/content_management/content_management_api/bookmark_api.md
+++ b/docs/content_management/content_management_api/bookmark_api.md
@@ -13,17 +13,17 @@ description: You can use the PHP API to view the bookmark list, and add or remov
 To view a list of all bookmarks, use [`BookmarkService::loadBookmarks`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-BookmarkService.html#method_loadBookmarks):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/BookmarkCommand.php', 43, 50) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/BookmarkCommand.php', 44, 50, remove_indent=True) =]]
 ```
 
 You can add a bookmark to a content item by providing its Location object to the [`BookmarkService::createBookmark`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-BookmarkService.html#method_createBookmark) method:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/BookmarkCommand.php', 37, 40) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/BookmarkCommand.php', 38, 40, remove_indent=True) =]]
 ```
 
 You can remove a bookmark from a location with [`BookmarkService::deleteBookmark`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-BookmarkService.html#method_deleteBookmark):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/BookmarkCommand.php', 52, 53) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/BookmarkCommand.php', 53, 53, remove_indent=True) =]]
 ```

--- a/docs/content_management/content_management_api/object_state_api.md
+++ b/docs/content_management/content_management_api/object_state_api.md
@@ -18,7 +18,7 @@ You can manage Object states by using the PHP API by using `ObjectStateService`.
 You can use the [`ObjectStateService`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ObjectStateService.html) to get information about object state groups or object states.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 44, 49) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 45, 49, remove_indent=True) =]]
 ```
 
 ## Creating object states
@@ -26,7 +26,7 @@ You can use the [`ObjectStateService`](/api/php_api/php_api_reference/classes/Ib
 To create an object state group and add object states to it, you need to make use of the [`ObjectStateService`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ObjectStateService.html):
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 53, 57) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 54, 57, remove_indent=True) =]]
 ```
 
 [`ObjectStateService::createObjectStateGroup`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ObjectStateService.html#method_createObjectStateGroup) takes as argument an [`ObjectStateGroupCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-ObjectState-ObjectStateGroupCreateStruct.html), in which you need to specify the identifier, default language and at least one name for the group.
@@ -34,7 +34,7 @@ To create an object state group and add object states to it, you need to make us
 To create an object state inside a group, use [`ObjectStateService::newObjectStateCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-ObjectStateService.html#method_newObjectStateCreateStruct) and provide it with an `ObjectStateCreateStruct`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 59, 63) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 60, 63, remove_indent=True) =]]
 ```
 
 ## Assigning object state
@@ -43,5 +43,5 @@ To assign an object state to a content item, use [`ObjectStateService::setConten
 Provide it with a `ContentInfo` object of the content item, the object state group and the object state:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 73, 78) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/ObjectStateCommand.php', 74, 78, remove_indent=True) =]]
 ```

--- a/docs/content_management/content_management_api/section_api.md
+++ b/docs/content_management/content_management_api/section_api.md
@@ -17,7 +17,7 @@ You can manage sections by using the PHP API by using `SectionService`.
 To create a new section, you need to make use of the [`SectionCreateStruct`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-SectionCreateStruct.html) and pass it to the [`SectionService::createSection`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-SectionService.html#method_createSection) method:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SectionCommand.php', 52, 56) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SectionCommand.php', 53, 56, remove_indent=True) =]]
 ```
 
 ## Getting section information
@@ -25,7 +25,7 @@ To create a new section, you need to make use of the [`SectionCreateStruct`](/ap
 You can use `SectionService` to retrieve section information such as whether it's in use:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SectionCommand.php', 70, 75) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SectionCommand.php', 71, 75, remove_indent=True) =]]
 ```
 
 ## Listing content in a section
@@ -45,7 +45,7 @@ To assign content to a section, use the [`SectionService::assignSection`](/api/p
 You need to provide it with the `ContentInfo` object of the content item, and the [`Section`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-Values-Content-Section.html) object:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SectionCommand.php', 58, 61) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SectionCommand.php', 59, 61, remove_indent=True) =]]
 ```
 
 Assigning a section to content doesn't automatically assign it to the content item's children.

--- a/docs/content_management/data_migration/add_data_migration_matcher.md
+++ b/docs/content_management/data_migration/add_data_migration_matcher.md
@@ -21,7 +21,7 @@ Matchers are instances of `FilteringCriterion`, so a custom normalizer needs to 
 Create the normalizer in `src/Migrations/Matcher/SectionIdentifierNormalizer.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Matcher/SectionIdentifierNormalizer.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Matcher/SectionIdentifierNormalizer.php') =]]
 ```
 
 Register the normalizer as a service:
@@ -47,7 +47,7 @@ Additionally, if you want to export data using the `ibexa:migrations:generate` c
 Create the generator in `src/Migrations/Matcher/SectionIdentifierGenerator.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Matcher/SectionIdentifierGenerator.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Matcher/SectionIdentifierGenerator.php') =]]
 ```
 
 Register the generator as a service:

--- a/docs/content_management/data_migration/create_data_migration_action.md
+++ b/docs/content_management/data_migration/create_data_migration_action.md
@@ -15,14 +15,14 @@ The following example shows how to create an action that assigns a content item 
 First, create an action class, in `src/Migrations/Action/AssignSection.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Action/AssignSection.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Action/AssignSection.php') =]]
 ```
 
 Then you need a denormalizer to convert data that comes from YAML into an action object,
 in `src/Migrations/Action/AssignSectionDenormalizer.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Action/AssignSectionDenormalizer.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Action/AssignSectionDenormalizer.php') =]]
 ```
 
 Then, tag the action denormalizer so it's recognized by the serializer used for migrations.
@@ -34,7 +34,7 @@ Then, tag the action denormalizer so it's recognized by the serializer used for 
 And finally, add an executor to perform the action, in `src/Migrations/Action/AssignSectionExecutor.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Action/AssignSectionExecutor.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Action/AssignSectionExecutor.php') =]]
 ```
 
 Tag the executor with `ibexa.migrations.executor.action.<type>` tag, where `<type>` is the "type" of the step that executor works with (for example, `content`, `content_type`, or `location`).

--- a/docs/content_management/data_migration/create_data_migration_step.md
+++ b/docs/content_management/data_migration/create_data_migration_step.md
@@ -19,7 +19,7 @@ The following example shows how to create a step that replaces all `ibexa_string
 First, create a step class, in `src/Migrations/Step/ReplaceNameStep.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Step/ReplaceNameStep.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Step/ReplaceNameStep.php') =]]
 ```
 
 ## Create normalizer
@@ -28,7 +28,7 @@ Then you need a normalizer to convert data that comes from YAML into a step obje
 in `src/Migrations/Step/ReplaceNameStepNormalizer.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Step/ReplaceNameStepNormalizer.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Step/ReplaceNameStepNormalizer.php') =]]
 ```
 
 Then, tag the step normalizer, so it's recognized by the serializer used for migrations.
@@ -42,7 +42,7 @@ Then, tag the step normalizer, so it's recognized by the serializer used for mig
 And finally, create an executor to perform the step, in `src/Migrations/Step/ReplaceNameExecutor.php`:
 
 ``` php
-[[= include_file('code_samples/data_migration/src/Migrations/Step/ReplaceNameStepExecutor.php') =]]
+[[= include_code('code_samples/data_migration/src/Migrations/Step/ReplaceNameStepExecutor.php') =]]
 ```
 
 Tag the executor with `ibexa.migrations.step_executor` tag.

--- a/docs/content_management/data_migration/data_migration_api.md
+++ b/docs/content_management/data_migration/data_migration_api.md
@@ -11,13 +11,13 @@ You can use the PHP API to manage and run [data migrations](data_migration.md).
 To list all migration files available in the directory defined in configuration (by default, `src/Migrations/Ibexa`), use the `MigrationService:listMigrations()` method:
 
 ``` php
-[[= include_file('code_samples/api/migration/src/Command/MigrationCommand.php', 31, 34) =]]
+[[= include_code('code_samples/api/migration/src/Command/MigrationCommand.php', 32, 34, remove_indent=True) =]]
 ```
 
 To get a single migration file by its name, use the `MigrationService:findOneByName()` method:
 
 ``` php
-[[= include_file('code_samples/api/migration/src/Command/MigrationCommand.php', 36, 37) =]]
+[[= include_code('code_samples/api/migration/src/Command/MigrationCommand.php', 37, 37, remove_indent=True) =]]
 ```
 
 ## Running migration files
@@ -25,7 +25,7 @@ To get a single migration file by its name, use the `MigrationService:findOneByN
 To run migration file(s), use either `MigrationService:executeOne()` or `MigrationService:executeAll()`:
 
 ``` php
-[[= include_file('code_samples/api/migration/src/Command/MigrationCommand.php', 38, 40) =]]
+[[= include_code('code_samples/api/migration/src/Command/MigrationCommand.php', 39, 40, remove_indent=True) =]]
 ```
 
 Both `executeOne()` and `executeAll()` can take an optional parameter: the login of the User that you want to execute the migrations as.
@@ -35,5 +35,5 @@ Both `executeOne()` and `executeAll()` can take an optional parameter: the login
 To add a new migration file, use the `MigrationService:add()` method:
 
 ``` php
-[[= include_file('code_samples/api/migration/src/Command/MigrationCommand.php', 24, 30) =]]
+[[= include_code('code_samples/api/migration/src/Command/MigrationCommand.php', 25, 30, remove_indent=True) =]]
 ```

--- a/docs/content_management/field_types/create_custom_field_type_comparison.md
+++ b/docs/content_management/field_types/create_custom_field_type_comparison.md
@@ -21,7 +21,7 @@ First, create a `Comparable.php` class in `src/FieldType/HelloWorld/Comparison`.
 This class implements the `Ibexa\Contracts\VersionComparison\FieldType\Comparable` interface with the `getDataToCompare()` method:
 
 ``` php
-[[= include_file('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/Comparable.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/Comparable.php') =]]
 ```
 
 The `getDataToCompare()` fetches the data to compare and determines which [comparison engines](#create-comparison-engine) should be used.
@@ -37,7 +37,7 @@ Register this class as a service:
 Next, create a `src/FieldType/HelloWorld/Comparison/Value.php` file that holds the comparison value:
 
 ``` php
-[[= include_file('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/Value.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/Value.php') =]]
 ```
 
 ## Create comparison engine
@@ -49,7 +49,7 @@ For the "Hello World" field type, create the following comparison engine based o
 Place it in `src/FieldType/HelloWorld/Comparison/HelloWorldComparisonEngine.php`:
 
 ``` php
-[[= include_file('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/HelloWorldComparisonEngine.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/HelloWorldComparisonEngine.php') =]]
 ```
 
 Register the comparison engine as a service:
@@ -63,7 +63,7 @@ Register the comparison engine as a service:
 Next, create a comparison result class in `src/FieldType/HelloWorld/Comparison/HelloWorldComparisonResult.php`.
 
 ``` php
-[[= include_file('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/HelloWorldComparisonResult.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Comparison/HelloWorldComparisonResult.php') =]]
 ```
 
 ## Provide templates

--- a/docs/content_management/field_types/create_custom_generic_field_type.md
+++ b/docs/content_management/field_types/create_custom_generic_field_type.md
@@ -29,7 +29,7 @@ The `HelloWorld` Value class should contain:
 - an implementation of the `__toString()` method
 
 ```php
-[[= include_file('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Value.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Value.php') =]]
 ```
 
 ## Define fields and configuration
@@ -57,7 +57,7 @@ Create a `src/Form/Type/HelloWorldType.php` form.
 It enables you to edit the new field type.
 
 ```php
-[[= include_file('code_samples/field_types/generic_ft/src/Form/Type/HelloWorldType.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/Form/Type/HelloWorldType.php') =]]
 ```
 
 Now you can map field definitions into Symfony forms with FormMapper.
@@ -65,7 +65,7 @@ Add the `mapFieldValueForm()` method required by `FieldValueFormMapperInterface`
 and the required `use` statements to `src/FieldType/HelloWorld/Type.php`:
 
 ```php hl_lines="6-7 18-26"
-[[= include_file('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Type.php') =]]
+[[= include_code('code_samples/field_types/generic_ft/src/FieldType/HelloWorld/Type.php') =]]
 ```
 
 For more information about the FormMappers, see [field type form and template](form_and_template.md).

--- a/docs/content_management/forms/create_custom_form_field.md
+++ b/docs/content_management/forms/create_custom_form_field.md
@@ -63,7 +63,7 @@ New types of fields require a mapper which implements the `Ibexa\Contracts\FormB
 To create a Country field type, implement the `FieldMapperInterface` interface in `src/FormBuilder/Field/Mapper/CountryFieldMapper.php`:
 
 ``` php
-[[= include_file('code_samples/forms/custom_form_field/src/FormBuilder/Field/Mapper/CountryFieldMapper.php') =]]
+[[= include_code('code_samples/forms/custom_form_field/src/FormBuilder/Field/Mapper/CountryFieldMapper.php') =]]
 ```
 
 Then, register the mapper as a service:
@@ -91,7 +91,7 @@ Field or field attribute definition can be modified by subscribing to one of the
 The following example adds a `custom` string attribute to `single_line` field definition.
 
 ``` php
-[[= include_file('code_samples/forms/custom_form_field/src/EventSubscriber/FormFieldDefinitionSubscriber.php') =]]
+[[= include_code('code_samples/forms/custom_form_field/src/EventSubscriber/FormFieldDefinitionSubscriber.php') =]]
 ```
 
 Register this subscriber as a service:

--- a/docs/content_management/forms/create_form_attribute.md
+++ b/docs/content_management/forms/create_form_attribute.md
@@ -34,7 +34,7 @@ The attribute must be editable for the form creator, so it needs to have a Symfo
 Add an `AttributeRichtextDescriptionType.php` file with the form type in the `src/FormBuilder/Form/Type/FieldAttribute` directory:
 
 ``` php
-[[= include_file('code_samples/forms/custom_form_attribute/src/FormBuilder/Form/Type/FieldAttribute/AttributeRichtextDescriptionType.php') =]]
+[[= include_code('code_samples/forms/custom_form_attribute/src/FormBuilder/Form/Type/FieldAttribute/AttributeRichtextDescriptionType.php') =]]
 ```
 
 ## Customize Form templates
@@ -91,7 +91,7 @@ Now you have to implement the field, and make sure the value from the Rich Text 
 Create a `src/FormBuilder/Form/Type/CheckboxWithRichtextDescriptionType.php` file.
 
 ```php
-[[= include_file('code_samples/forms/custom_form_attribute/src/FormBuilder/Form/Type/CheckboxWithRichtextDescriptionType.php') =]]
+[[= include_code('code_samples/forms/custom_form_attribute/src/FormBuilder/Form/Type/CheckboxWithRichtextDescriptionType.php') =]]
 ```
 
 ## Implement field mapper
@@ -99,7 +99,7 @@ Create a `src/FormBuilder/Form/Type/CheckboxWithRichtextDescriptionType.php` fil
 To implement a field mapper, create a `src/FormBuilder/FieldType/Field/Mapper/CheckboxWithRichtextDescriptionFieldMapper.php` file.
 
 ```php
-[[= include_file('code_samples/forms/custom_form_attribute/src/FormBuilder/FieldType/Field/Mapper/CheckboxWithRichtextDescriptionFieldMapper.php') =]]
+[[= include_code('code_samples/forms/custom_form_attribute/src/FormBuilder/FieldType/Field/Mapper/CheckboxWithRichtextDescriptionFieldMapper.php') =]]
 ```
 
 Now, the attribute value can be stored in the new Form.
@@ -111,7 +111,7 @@ The new field is based on a checkbox, so to display the submissions of this fiel
 Create a `src/FormBuilder/FormSubmission/Converter/RichtextDescriptionFieldSubmissionConverter.php` file.
 
 ```php
-[[= include_file('code_samples/forms/custom_form_attribute/src/FormBuilder/FormSubmission/Converter/RichtextDescriptionFieldSubmissionConverter.php') =]]
+[[= include_code('code_samples/forms/custom_form_attribute/src/FormBuilder/FormSubmission/Converter/RichtextDescriptionFieldSubmissionConverter.php') =]]
 ```
 
 Now you can go to back office and build a new form.

--- a/docs/content_management/forms/form_api.md
+++ b/docs/content_management/forms/form_api.md
@@ -20,13 +20,13 @@ To manage form submissions created in the [Form Builder](form_builder_guide.md),
 To get existing form submissions, use `FormSubmissionServiceInterface::loadByContent()` (which takes a `ContentInfo` object as parameter), or `FormSubmissionServiceInterface::loadById()`.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 49, 50) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 50, 50, remove_indent=True) =]]
 ```
 
 Through this object, you can get information about submissions, such as their total number, and submission contents.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 51, 60) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 52, 60, remove_indent=True) =]]
 ```
 
 ### Creating form submissions
@@ -41,7 +41,7 @@ This method takes:
 - the array of form field values
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 35, 48) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 36, 48, remove_indent=True) =]]
 ```
 
 ### Deleting form submissions
@@ -49,5 +49,5 @@ This method takes:
 You can delete a form submission by using the `FormSubmissionServiceInterface::delete()` method.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 61, 63) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FormSubmissionCommand.php', 62, 63, remove_indent=True) =]]
 ```

--- a/docs/content_management/images/add_image_asset_from_dam.md
+++ b/docs/content_management/images/add_image_asset_from_dam.md
@@ -102,7 +102,7 @@ which implements [`search()`](/api/php_api/php_api_reference/classes/Ibexa-Contr
 and [`fetchAsset()`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Connector-Dam-Handler-Handler.html#method_fetchAsset) to return asset objects:
 
 ```php
-[[= include_file('code_samples/back_office/images/src/Connector/Dam/Handler/WikimediaCommonsHandler.php') =]]
+[[= include_code('code_samples/back_office/images/src/Connector/Dam/Handler/WikimediaCommonsHandler.php') =]]
 ```
 
 Then, in `config/services.yaml`, register the handler as a service:
@@ -121,7 +121,7 @@ In `src/Connector/Dam/Transformation` folder, create the `WikimediaCommonsTransf
 which implements the [`TransformationFactory` interface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Connector-Dam-Variation-TransformationFactory.html):
 
 ```php
-[[= include_file('code_samples/back_office/images/src/Connector/Dam/Transformation/WikimediaCommonsTransformationFactory.php') =]]
+[[= include_code('code_samples/back_office/images/src/Connector/Dam/Transformation/WikimediaCommonsTransformationFactory.php') =]]
 ```
 
 Then register the transformation factory as a service:

--- a/docs/content_management/images/images.md
+++ b/docs/content_management/images/images.md
@@ -215,13 +215,13 @@ The controller's definition (that you place in the `config/services.yaml` file u
 ```
 
 ```php
-[[= include_file('code_samples/back_office/images/src/SvgController.php') =]]
+[[= include_code('code_samples/back_office/images/src/SvgController.php') =]]
 ```
 
 To be able to use a proper link in your templates, you also need a dedicated Twig extension:
 
 ```php
-[[= include_file('code_samples/back_office/images/src/SvgExtension.php') =]]
+[[= include_code('code_samples/back_office/images/src/SvgExtension.php') =]]
 ```
 
 Now you can load SVG files in your templates by using generated links and a newly created Twig helper:
@@ -258,7 +258,7 @@ You can listen to this event to customize the list of image optimizers at runtim
 The following example shows how to remove the Pngquant optimizer to prevent grayscale conversion of low-saturation PNG images:
 
 ``` php
-[[= include_file('code_samples/back_office/images/src/Event/RemovePngquantOptimizer.php') =]]
+[[= include_code('code_samples/back_office/images/src/Event/RemovePngquantOptimizer.php') =]]
 ```
 
 ## Embedding images in Rich Text

--- a/docs/content_management/pages/create_custom_page_block.md
+++ b/docs/content_management/pages/create_custom_page_block.md
@@ -137,7 +137,7 @@ If you need to compute variables to pass to the template, you can listen or subs
 For example, the following event subscriber loads the `event` content item and passes it to the template as `event_content`:
 
 ``` php
-[[= include_file('code_samples/page/custom_page_block/src/Event/Subscriber/BlockEmbedEventEventSubscriber.php') =]]
+[[= include_code('code_samples/page/custom_page_block/src/Event/Subscriber/BlockEmbedEventEventSubscriber.php') =]]
 ```
 
 The block view template could now use `ibexa_render(event_content, {'viewType': 'embed'})` instead of `render(controller('ibexa_content::viewAction', {'contentId': event, 'viewType': 'embed'}))`, other [content Twig functions](content_twig_functions.md), or [field Twig functions](field_twig_functions.md).

--- a/docs/content_management/pages/page_block_attributes.md
+++ b/docs/content_management/pages/page_block_attributes.md
@@ -72,7 +72,7 @@ for example `AbstractType` for any custom type or `IntegerType` for numeric type
 To define the type, create a `src/Block/Attribute/MyStringAttributeType.php` file:
 
 ``` php hl_lines="5 6 17"
-[[= include_file('code_samples/page/custom_attribute/src/Block/Attribute/MyStringAttributeType.php') =]]
+[[= include_code('code_samples/page/custom_attribute/src/Block/Attribute/MyStringAttributeType.php') =]]
 ```
 
 The attribute uses `AbstractType` (line 5) and `TextType` (line 6).
@@ -97,7 +97,7 @@ To use a custom mapper, create a class that inherits from `Ibexa\Contracts\Field
 for example in `src/Block/Attribute/MyStringAttributeMapper.php`:
 
 ``` php
-[[= include_file('code_samples/page/custom_attribute/src/Block/Attribute/MyStringAttributeMapper.php') =]]
+[[= include_code('code_samples/page/custom_attribute/src/Block/Attribute/MyStringAttributeMapper.php') =]]
 ```
 
 Then, add a new service definition for your mapper to `config/services.yaml`:

--- a/docs/content_management/pages/page_block_validators.md
+++ b/docs/content_management/pages/page_block_validators.md
@@ -45,13 +45,13 @@ First, create classes that support your intended method of validation.
 For example, in `src/Validator`, create an `AlphaOnly.php` file:
 
 ``` php
-[[= include_file('code_samples/page/custom_block_validator/src/Validator/AlphaOnly.php') =]]
+[[= include_code('code_samples/page/custom_block_validator/src/Validator/AlphaOnly.php') =]]
 ```
 
 In `src/Validator`, create an `AlphaOnlyValidator.php` class that performs the validation.
 
 ``` php
-[[= include_file('code_samples/page/custom_block_validator/src/Validator/AlphaOnlyValidator.php') =]]
+[[= include_code('code_samples/page/custom_block_validator/src/Validator/AlphaOnlyValidator.php') =]]
 ```
 
 Then, under `ibexa_fieldtype_page.block_validators`, enable the new validator in Page Builder:
@@ -73,5 +73,5 @@ By default, only `not_blank` and `not_blank_richtext` validators mark a block at
 If you create a custom validator `custom_not_blank` with attribute-specific logic, you can extend the `AttributeType` class with a Symfony form type extension to make sure that the attribute is also considered required:
 
 ``` php hl_lines="15"
-[[= include_file('code_samples/page/custom_block_validator/src/Form/Extension/AttributeTypeExtension.php') =]]
+[[= include_code('code_samples/page/custom_block_validator/src/Form/Extension/AttributeTypeExtension.php') =]]
 ```

--- a/docs/content_management/pages/page_blocks.md
+++ b/docs/content_management/pages/page_blocks.md
@@ -102,7 +102,7 @@ The following events are available:
 For example, to modify a block by adding a new parameter to it, you can create the following listener:
 
 ``` php
-[[= include_file('code_samples/page/page_listener/src/Block/Listener/MyBlockListener.php') =]]
+[[= include_code('code_samples/page/page_listener/src/Block/Listener/MyBlockListener.php') =]]
 ```
 
 Before the block is rendered, the listener adds `my_parameter` to it with value `parameter_value`.

--- a/docs/content_management/rich_text/create_custom_richtext_block.md
+++ b/docs/content_management/rich_text/create_custom_richtext_block.md
@@ -31,7 +31,7 @@ Lines 41-51 handle the conversion of content into an XML string:
 
 
 ``` php hl_lines="32 41 42 43 44 45 46 47 48 49 50 51"
-[[= include_file('code_samples/back_office/online_editor/src/event/subscriber/RichTextBlockSubscriber.php') =]]
+[[= include_code('code_samples/back_office/online_editor/src/event/subscriber/RichTextBlockSubscriber.php') =]]
 ```
 
 Now you can create [templates](templates.md) that are used for displaying and configuring your block.

--- a/docs/content_management/taxonomy/taxonomy_api.md
+++ b/docs/content_management/taxonomy/taxonomy_api.md
@@ -14,7 +14,7 @@ Or pass entry identifier (with optionally a taxonomy identifier),
 and use `TaxonomyServiceInterface::loadEntryByIdentifier()`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 34, 37) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 35, 37, remove_indent=True) =]]
 ```
 
 !!! note
@@ -37,7 +37,7 @@ The default taxonomy identifier is given by `TaxonomyConfiguration::getDefaultTa
 The default limit is 30.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 32, 33) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 33, 33, remove_indent=True) =]]
 ```
 
 To see how many entries is there, use `TaxonomyServiceInterface::countAllEntries()` with optionally a taxonomy identifier.
@@ -47,7 +47,7 @@ provide it with the entry object, and optionally specify the limit of results an
 The default limit is 30:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 39, 44) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 40, 44, remove_indent=True) =]]
 ```
 
 ## Managing taxonomy entries
@@ -56,7 +56,7 @@ You can move a taxonomy entry to a different parent by using `TaxonomyServiceInt
 Provide the method with two objects: the entry that you want to move and the new parent entry:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 45, 49) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 46, 49, remove_indent=True) =]]
 ```
 
 You can also move a taxonomy entry by passing its target sibling entry to `TaxonomyServiceInterface::moveEntry()`.
@@ -64,7 +64,7 @@ The method takes as parameters the entry you want to move, the future sibling,
 and a `position` parameter, which is either `TaxonomyServiceInterface::MOVE_POSITION_NEXT` or `TaxonomyServiceInterface::MOVE_POSITION_PREV`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 50, 52) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/TaxonomyCommand.php', 51, 52, remove_indent=True) =]]
 ```
 
 !!! note

--- a/docs/content_management/workflow/add_custom_workflow_action.md
+++ b/docs/content_management/workflow/add_custom_workflow_action.md
@@ -28,7 +28,7 @@ The configuration indicates the name of the custom action (`legal_transition_act
 To define what the action does, create an event listener `src/EventListener/LegalTransitionListener.php`:
 
 ``` php hl_lines="27 37"
-[[= include_file('code_samples/workflow/custom_workflow/src/EventListener/LegalTransitionListener.php') =]]
+[[= include_code('code_samples/workflow/custom_workflow/src/EventListener/LegalTransitionListener.php') =]]
 ```
 
 This listener displays a notification bar at the bottom of the page when a content item goes through the `to_legal` transition.
@@ -55,7 +55,7 @@ The action indicated here is performed only if the result from the `legal_transi
 Then, the following `src/EventListener/ApprovedTransitionListener` is called:
 
 ``` php hl_lines="27"
-[[= include_file('code_samples/workflow/custom_workflow/src/EventListener/ApprovedTransitionListener.php') =]]
+[[= include_code('code_samples/workflow/custom_workflow/src/EventListener/ApprovedTransitionListener.php') =]]
 ```
 
 Register this listener as a service:

--- a/docs/content_management/workflow/workflow_api.md
+++ b/docs/content_management/workflow/workflow_api.md
@@ -25,7 +25,7 @@ but the implementation in workflow service extends them, for example by providin
 To get information about a specific workflow for a content item, use `WorkflowServiceInterface::loadWorkflowMetadataForContent`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 51, 56) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 52, 56, remove_indent=True) =]]
 ```
 
 !!! tip
@@ -36,7 +36,7 @@ To get information about a specific workflow for a content item, use `WorkflowSe
 To get a list of all workflows that can be used for a given content item, use `WorkflowRegistry`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 45, 49) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 46, 49, remove_indent=True) =]]
 ```
 
 ## Applying workflow transitions
@@ -44,14 +44,14 @@ To get a list of all workflows that can be used for a given content item, use `W
 To place a content item in a workflow, use `WorkflowService::start`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 50, 51) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 51, 51, remove_indent=True) =]]
 ```
 
 To apply a transition to a content item, use `Workflow::apply`.
 Additionally, you can check if the transition is possible for the given object using `WorkflowService::can`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 57, 62) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/WorkflowCommand.php', 58, 62, remove_indent=True) =]]
 ```
 
 !!! tip

--- a/docs/customer_management/cp_applications.md
+++ b/docs/customer_management/cp_applications.md
@@ -68,7 +68,7 @@ Next, create a new form type in `src/Form/VerifyType.php`.
 It's displayed in the application review stage.
 
 ``` php hl_lines="17-18 25"
-[[= include_file('code_samples/customer_portal/src/Form/VerifyType.php') =]]
+[[= include_code('code_samples/customer_portal/src/Form/VerifyType.php') =]]
 ```
 
 Line 29 defines where the form should be displayed, line 21 adds **Note** field, and line 22 adds the **Verify** button.
@@ -79,7 +79,7 @@ Add an event subscriber that passes a new form type to the frontend.
 Create `src/Corporate/EventSubscriber/ApplicationDetailsViewSubscriber.php` following the example below:
 
 ``` php hl_lines="35"
-[[= include_file('code_samples/customer_portal/src/Corporate/EventSubscriber/ApplicationDetailsViewSubscriber.php') =]]
+[[= include_code('code_samples/customer_portal/src/Corporate/EventSubscriber/ApplicationDetailsViewSubscriber.php') =]]
 ```
 
 In line 39, you can see the `verify_form` parameter that passes the `verify` form to the application review view.
@@ -104,7 +104,7 @@ Now, you need to pass the information that the button has been selected to the l
 Create another event subscriber that passes the information from the created form to the application list `src/Corporate/EventSubscriber/VerifyStateEventSubscriber.php`.
 
 ``` php hl_lines="42 68"
-[[= include_file('code_samples/customer_portal/src/Corporate/EventSubscriber/VerifyStateEventSubscriber.php') =]]
+[[= include_code('code_samples/customer_portal/src/Corporate/EventSubscriber/VerifyStateEventSubscriber.php') =]]
 ```
 
 In line 46, you can see that it handles changes to verify status.

--- a/docs/discounts/discounts_api.md
+++ b/docs/discounts/discounts_api.md
@@ -156,7 +156,7 @@ The example below contains a Command creating a cart discount. The discount:
     - a `summer10` [discount code](#discount-codes) which can be used only 10 times, but a single customer can use the code multiple times
 
 ``` php hl_lines="46-53 55-81 83"
-[[= include_file('code_samples/discounts/src/Command/ManageDiscountsCommand.php') =]]
+[[= include_code('code_samples/discounts/src/Command/ManageDiscountsCommand.php') =]]
 ```
 
 Similarly, use the `deleteDiscount`, `deleteTranslation`, `disableDiscount`, `enableDiscount`, and `updateDiscount` methods from the [DiscountServiceInterface](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-DiscountServiceInterface.html) to manage the discounts. You can always attach additional logic to the Discounts API by listening to the [available events](discounts_events.md).
@@ -181,5 +181,5 @@ The example below shows how you can use:
 - [`OrderServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-OrderManagement-OrderServiceInterface.html) to display discount details for [orders](order_management.md)
 
 ``` php hl_lines="51-52 58-59 61-74 78-104"
-[[= include_file('code_samples/discounts/src/Command/OrderPriceCommand.php') =]]
+[[= include_code('code_samples/discounts/src/Command/OrderPriceCommand.php') =]]
 ```

--- a/docs/discounts/extend_discounts.md
+++ b/docs/discounts/extend_discounts.md
@@ -55,7 +55,7 @@ It's a [`DateTime`](https://www.php.net/manual/en/class.datetime.php) object wit
 To add it, create a class implementing the [`DiscountVariablesResolverInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-DiscountVariablesResolverInterface.html):
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/ExpressionProvider/CurrentUserRegistrationDateResolver.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/ExpressionProvider/CurrentUserRegistrationDateResolver.php') =]]
 ```
 
 And mark it as a service using the `ibexa.discounts.expression_language.variable_resolver` service tag:
@@ -73,7 +73,7 @@ The function accepts an optional argument, `tolerance`, allowing you to extend t
 This implementation is simplified and does not cover the approach for accounts created on February 29 during leap years.
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/ExpressionProvider/IsAnniversaryResolver.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/ExpressionProvider/IsAnniversaryResolver.php') =]]
 ```
 
 Mark it as a service using the `ibexa.discounts.expression_language.function` service tag and specify the function name in the service definition.
@@ -109,7 +109,7 @@ It allows you to offer a special discount for customers on the date when their a
 Create the condition by creating a class implementing the [`DiscountConditionInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-Value-DiscountConditionInterface.html):
 
 ``` php hl_lines="29-32"
-[[= include_file('code_samples/discounts/src/Discounts/Condition/IsAccountAnniversary.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Condition/IsAccountAnniversary.php') =]]
 ```
 
 This condition can be used in both catalog and cart discounts.
@@ -130,7 +130,7 @@ For each custom condition class, you must create a dedicated condition factory, 
 This allows you to create conditions when working in the context of the Symfony service container.
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/Condition/IsAccountAnniversaryConditionFactory.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Condition/IsAccountAnniversaryConditionFactory.php') =]]
 ```
 
 Mark it as a service using the `ibexa.discounts.condition.factory` service tag and specify the condition's identifier.
@@ -163,7 +163,7 @@ You could use it, for example, in regions sharing the same currency and apply th
 To implement a custom rule, create a class implementing the [`DiscountRuleInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-Value-DiscountRuleInterface.html).
 
 ``` php hl_lines="35-38"
-[[= include_file('code_samples/discounts/src/Discounts/Rule/PurchasingPowerParityRule.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Rule/PurchasingPowerParityRule.php') =]]
 ```
 
 The `getExpression()` method contains the logic of the rule, expressed using the variables and functions available in the expression engine.
@@ -178,7 +178,7 @@ It uses three expressions:
 As with conditions, create a dedicated rule factory:
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/Rule/PurchasingPowerParityRuleFactory.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Rule/PurchasingPowerParityRuleFactory.php') =]]
 ```
 
 Then, mark it as a service using the `ibexa.discounts.rule.factory` service tag and specify the rule's type.
@@ -204,7 +204,7 @@ You must implement a custom formatter for each custom rule.
 To do it, create a class implementing the [`DiscountValueFormatterInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-DiscountValueFormatterInterface.html) and use the `ibexa.discounts.value.formatter` service tag:
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/Rule/PurchaseParityValueFormatter.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Rule/PurchaseParityValueFormatter.php') =]]
 ```
 
 ``` yaml
@@ -222,7 +222,7 @@ The example below decorates the default implementation to prioritize recently up
 It uses one of the existing [discount search criterions](discounts_criteria.md).
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/RecentDiscountPrioritizationStrategy.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/RecentDiscountPrioritizationStrategy.php') =]]
 ```
 
 ``` yaml

--- a/docs/discounts/extend_discounts_wizard.md
+++ b/docs/discounts/extend_discounts_wizard.md
@@ -55,13 +55,13 @@ To add a custom step, create a value object representing the step.
 It contains the step identifier, properties for storing form data, and extends the [`AbstractDiscountStep`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-Admin-Form-Data-AbstractDiscountStep.html):
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/Step/AnniversaryConditionStep.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Step/AnniversaryConditionStep.php') =]]
 ```
 
 Then, create a new event listener listening to the [`CreateFormDataEvent` and `MapDiscountToFormDataEvent` events](discounts_events.md#form):
 
 ``` php hl_lines="18-19 26-50"
-[[= include_file('code_samples/discounts/src/Discounts/Step/Step1/AnniversaryConditionStepEventSubscriber.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Step/Step1/AnniversaryConditionStepEventSubscriber.php') =]]
 ```
 
 Attaching the `addAnniversaryConditionStep()` method to both these events adds the custom step both in discount creation and edit forms.
@@ -88,11 +88,11 @@ The custom step is added between the "Conditions" and "Discount value"  steps.
 To add form fields to it, create an event listener adding your fields and a custom form type:
 
 ``` php
-[[= include_file('code_samples/discounts/src/Discounts/Step/AnniversaryConditionStepFormListener.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Step/AnniversaryConditionStepFormListener.php') =]]
 ```
 
 ``` php
-[[= include_file('code_samples/discounts/src/Form/Type/AnniversaryConditionStepType.php') =]]
+[[= include_code('code_samples/discounts/src/Form/Type/AnniversaryConditionStepType.php') =]]
 ```
 
 The new form step, including its form fields, are now part of the discounts wizard.
@@ -107,7 +107,7 @@ Expand the previously created `AnniversaryConditionStepEventSubscriber` to liste
 and add the `addStepDataToStruct()` method:
 
 ``` php hl_lines="23-24 57-70"
-[[= include_file('code_samples/discounts/src/Discounts/Step/Step2/AnniversaryConditionStepEventSubscriber.php') =]]
+[[= include_code('code_samples/discounts/src/Discounts/Step/Step2/AnniversaryConditionStepEventSubscriber.php') =]]
 ```
 
 When the form is submitted, this method extracts information whether the store manager enabled the anniversary discount in the form and adds the condition to make sure this data is properly saved.
@@ -121,19 +121,19 @@ This example continues the [purchasing power parity rule example](extend_discoun
 First, create a new service implementing the `DiscountValueMapperInterface` interface, responsible for handling the new rule type:
 
 ``` php hl_lines="59-60"
-[[= include_file('code_samples/discounts/src/Form/FormMapper/PurchasingPowerParityValueMapper.php') =]]
+[[= include_code('code_samples/discounts/src/Form/FormMapper/PurchasingPowerParityValueMapper.php') =]]
 ```
 
 It uses an `PurchasingPowerParityValue` object to store the form data:
 
 ``` php
-[[= include_file('code_samples/discounts/src/Form/Data/PurchasingPowerParityValue.php') =]]
+[[= include_code('code_samples/discounts/src/Form/Data/PurchasingPowerParityValue.php') =]]
 ```
 
 This value mapper is used by a new form mapper, dedicated to the new rule type:
 
 ``` php
-[[= include_file('code_samples/discounts/src/Form/FormMapper/PurchasingPowerParityFormMapper.php') =]]
+[[= include_code('code_samples/discounts/src/Form/FormMapper/PurchasingPowerParityFormMapper.php') =]]
 ```
 
 Link them together when defining the services:
@@ -153,13 +153,13 @@ As each rule type might have a different rule calculation logic, each rule must 
 To create it, create a dedicated class implementing the [`DiscountValueFormTypeMapperInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Discounts-Admin-Form-DiscountValueFormTypeMapperInterface.html)
 
 ``` php
-[[= include_file('code_samples/discounts/src/Form/FormMapper/PurchasingPowerParityDiscountValueFormTypeMapper.php') =]]
+[[= include_code('code_samples/discounts/src/Form/FormMapper/PurchasingPowerParityDiscountValueFormTypeMapper.php') =]]
 ```
 
 and add a dedicated value type class:
 
 ``` php hl_lines="26-38 45-59 71"
-[[= include_file('code_samples/discounts/src/Form/Type/DiscountValue/PurchasingPowerParityValueType.php') =]]
+[[= include_code('code_samples/discounts/src/Form/Type/DiscountValue/PurchasingPowerParityValueType.php') =]]
 ```
 
 In the example above, the discount value step is used to display a read-only field with regions the discount is limited to.

--- a/docs/infrastructure_and_maintenance/background_tasks.md
+++ b/docs/infrastructure_and_maintenance/background_tasks.md
@@ -80,7 +80,7 @@ In [multi-repository setups](repository_configuration.md), the worker process al
 Dispatch a message from your code like in the following example:
 
 ``` php
-[[= include_file("code_samples/background_tasks/src/Dispatcher/SomeClassThatSchedulesExecutionInTheBackground.php") =]]
+[[= include_code("code_samples/background_tasks/src/Dispatcher/SomeClassThatSchedulesExecutionInTheBackground.php") =]]
 ```
 
 ### Register handler
@@ -88,7 +88,7 @@ Dispatch a message from your code like in the following example:
 Create the handler class:
 
 ``` php
-[[= include_file("code_samples/background_tasks/src/MessageHandler/SomeHandler.php") =]]
+[[= include_code("code_samples/background_tasks/src/MessageHandler/SomeHandler.php") =]]
 ```
 
 Add a service definition to `config/services.yaml`:

--- a/docs/multisite/languages/automated_translations.md
+++ b/docs/multisite/languages/automated_translations.md
@@ -97,7 +97,7 @@ To learn how to build custom AI actions see [Extending AI actions](extend_ai_act
 1. Create a service that implements the [`\Ibexa\AutomatedTranslation\Client\ClientInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-AutomatedTranslation-Client-ClientInterface.html) interface:
 
 ``` php hl_lines="31-48"
-[[= include_file('code_samples/multisite/automated_translation/src/AutomatedTranslation/AiClient.php') =]]
+[[= include_code('code_samples/multisite/automated_translation/src/AutomatedTranslation/AiClient.php') =]]
 ```
 
 2\. Tag the service as `ibexa.automated_translation.client` in the Symfony container:
@@ -127,7 +127,7 @@ The following example adds support for automatically translating alternative tex
 1. Create a class implementing the [`FieldEncoderInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-AutomatedTranslation-Encoder-Field-FieldEncoderInterface.html) and add the required methods:
 
 ``` php hl_lines="11-14 16-19 21-27 33-38"
-[[= include_file('code_samples/multisite/automated_translation/src/AutomatedTranslation/ImageFieldEncoder.php') =]]
+[[= include_code('code_samples/multisite/automated_translation/src/AutomatedTranslation/ImageFieldEncoder.php') =]]
 ```
 In this example, the methods are responsible for:
 

--- a/docs/multisite/languages/language_api.md
+++ b/docs/multisite/languages/language_api.md
@@ -11,7 +11,7 @@ You can manage languages configured in the system with PHP API by using [`Langua
 To get a list of all languages in the system use [`LanguageService::loadLanguages`:](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LanguageService.html#method_loadLanguage)
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/AddLanguageCommand.php', 31, 37) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/AddLanguageCommand.php', 32, 37, remove_indent=True) =]]
 ```
 
 ## Creating a language
@@ -20,5 +20,5 @@ To create a new language, you need to create a [`LanguageCreateStruct`](/api/php
 Then, use [`LanguageService::createLanguage`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-Repository-LanguageService.html#method_createLanguage) and pass the `LanguageCreateStruct` to it:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/AddLanguageCommand.php', 37, 42) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/AddLanguageCommand.php', 38, 42, remove_indent=True) =]]
 ```

--- a/docs/multisite/siteaccess/siteaccess_aware_configuration.md
+++ b/docs/multisite/siteaccess/siteaccess_aware_configuration.md
@@ -36,7 +36,7 @@ Acme\ExampleBundle\AcmeExampleBundle::class => ['all' => true],
 To parse semantic configuration, create a `Configuration` class which extends `Ibexa\Bundle\Core\DependencyInjection\Configuration\SiteAccessAware\Configuration` and then extend its `generateScopeBaseNode()` method:
 
 ``` php hl_lines="19"
-[[= include_file('code_samples/multisite/siteaccess/Configuration.php') =]]
+[[= include_code('code_samples/multisite/siteaccess/Configuration.php') =]]
 ```
 
 !!! note
@@ -74,7 +74,7 @@ You usually do it in the [service container](php_api.md#service-container) exten
 You can also map simple settings by calling `$processor->mapSetting()`, without having to call `$processor->mapConfig()` with a callable.
 
 ``` php
-[[= include_file('code_samples/multisite/siteaccess/AcmeExampleExtension.php', 44, 46) =]]
+[[= include_code('code_samples/multisite/siteaccess/AcmeExampleExtension.php', 45, 46, remove_indent=True) =]]
 ```
 
 !!! caution "Important"
@@ -99,7 +99,7 @@ but enrich them by appending new entries.
 This is possible by using `$processor->mapConfigArray()`, which you must call outside the closure (before or after), so that it's called only once.
 
 ``` php
-[[= include_file('code_samples/multisite/siteaccess/AcmeExampleExtension.php', 48, 49) =]]
+[[= include_code('code_samples/multisite/siteaccess/AcmeExampleExtension.php', 49, 49, remove_indent=True) =]]
 ```
 
 Consider the following default config in `default_settings.yaml`:
@@ -153,7 +153,7 @@ However, because you defined the `os_types` key for `siteaccess1`, it completely
 You can add another level by passing `ContextualizerInterface::MERGE_FROM_SECOND_LEVEL` as the third argument to `$contextualizer->mapConfigArray()`:
 
 ``` php
-[[= include_file('code_samples/multisite/siteaccess/AcmeExampleExtension.php', 51, 53) =]]
+[[= include_code('code_samples/multisite/siteaccess/AcmeExampleExtension.php', 52, 53, remove_indent=True) =]]
 ```
 
 When you use `ContextualizerInterface::MERGE_FROM_SECOND_LEVEL` with the configuration above, you get the following result:

--- a/docs/permissions/custom_policies.md
+++ b/docs/permissions/custom_policies.md
@@ -74,7 +74,7 @@ It defines an abstract `getFiles()` method.
 Extend `YamlPolicyProvider` and implement `getFiles()` to return absolute paths to your YAML files.
 
 ``` php
-[[= include_file('code_samples/back_office/limitation/src/Security/MyPolicyProvider.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/MyPolicyProvider.php') =]]
 ```
 
 In `src/Resources/config/policies.yaml`:
@@ -150,7 +150,7 @@ The base of a custom limitation is a class to store values for the usage of this
 The value class extends `Ibexa\Contracts\Core\Repository\Values\User\Limitation` and says for which limitation it's used:
 
 ``` php
-[[= include_file('code_samples/back_office/limitation/src/Security/Limitation/CustomLimitationValue.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/Limitation/CustomLimitationValue.php') =]]
 ```
 
 The type class implements `Ibexa\Contracts\Core\Limitation\Type`.
@@ -159,7 +159,7 @@ The type class implements `Ibexa\Contracts\Core\Limitation\Type`.
 - `evaluate` challenges a limitation value against the current user, the subject object and other context objects to return if the limitation is satisfied or not. `evaluate` is, among others, used by `PermissionResolver::canUser` (to check if a user that has access to a function can use it in its limitations) and `PermissionResolver::lookupLimitations`.
 
 ```php
-[[= include_file('code_samples/back_office/limitation/src/Security/Limitation/CustomLimitationType.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/Limitation/CustomLimitationType.php') =]]
 ```
 
 The type class is set as a service tagged `ibexa.permissions.limitation_type` with an alias to identify it, and to link it to the value.
@@ -181,7 +181,7 @@ To provide support for editing custom policies in the back office, you need to i
 - `filterLimitationValues` is triggered when the form is submitted and can manipulate the limitation values, such as normalizing them.
 
 ``` php
-[[= include_file('code_samples/back_office/limitation/src/Security/Limitation/Mapper/CustomLimitationFormMapper.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/Limitation/Mapper/CustomLimitationFormMapper.php') =]]
 ```
 
 Provide a template corresponding to `getFormTemplate`.
@@ -214,7 +214,7 @@ The value mapper implements [`Ibexa\AdminUi\Limitation\LimitationValueMapperInte
 Its `mapLimitationValue` function returns the limitation value transformed for the needs of the template.
 
 ``` php
-[[= include_file('code_samples/back_office/limitation/src/Security/Limitation/Mapper/CustomLimitationValueMapper.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/Limitation/Mapper/CustomLimitationValueMapper.php') =]]
 ```
 
 Then register the service with the `ibexa.admin_ui.limitation.mapper.value` tag and set the `limitationType` attribute to limitation type's identifier:
@@ -251,7 +251,7 @@ For example, `translations/ibexa_content_forms_policies.en.yaml`:
 Check if current user has this custom limitation set to true from a custom controller:
 
 ```php
-[[= include_file('code_samples/back_office/limitation/src/Controller/CustomController.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Controller/CustomController.php') =]]
 ```
 
 ## Restrict access to form submissions
@@ -278,7 +278,7 @@ With this setup, users with `content/read` permission can view the form, but can
 First, create the `FormPolicyProvider.php` policy provider that registers the new `form` module and the `read_submissions` function by injecting the custom permission into the configuration tree:
 
 ```php hl_lines="14-18 26"
-[[= include_file('code_samples/back_office/limitation/src/Security/FormPolicyProvider.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/FormPolicyProvider.php') =]]
 ```
 
 Next, extract the [translations](#translations) to the `translations/forms.en.xlf` file.
@@ -312,7 +312,7 @@ To enforce the policy on the PHP API level, decorate the form submission service
 In `src/Security`, create the `FormSubmissionServiceDecorator.php` file:
 
 ```php hl_lines="19 33 40 41 44"
-[[= include_file('code_samples/back_office/limitation/src/Security/Form/FormSubmissionServiceDecorator.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/Form/FormSubmissionServiceDecorator.php') =]]
 ```
 
 !!! note "Duplicate method calls"
@@ -336,7 +336,7 @@ To enforce the policy in the back office, decorate the **Submissions** tab to hi
 In `src/Security`, create the `FormSubmissionsTabDecorator.php` file:
 
 ```php hl_lines="19 30 60-61"
-[[= include_file('code_samples/back_office/limitation/src/Security/Form/FormSubmissionsTabDecorator.php') =]]
+[[= include_code('code_samples/back_office/limitation/src/Security/Form/FormSubmissionsTabDecorator.php') =]]
 ```
 
 Then, add a service definition to `config/services.yaml`:

--- a/docs/product_catalog/attributes/symbol_attribute_type.md
+++ b/docs/product_catalog/attributes/symbol_attribute_type.md
@@ -66,7 +66,7 @@ To validate checksum of symbol:
 See below the example implementation of checksum validation using Luhn formula:
 
 ``` php
-[[= include_file('code_samples/product_catalog/Symbol/Format/Checksum/LuhnChecksum.php') =]]
+[[= include_code('code_samples/product_catalog/Symbol/Format/Checksum/LuhnChecksum.php') =]]
 ```
 
 Example service definition:

--- a/docs/product_catalog/catalog_api.md
+++ b/docs/product_catalog/catalog_api.md
@@ -11,7 +11,7 @@ To get information about product catalogs and manage them, use `CatalogServiceIn
 To get a single catalog, use `Ibexa\Contracts\ProductCatalog\CatalogServiceInterface::getCatalog()` and provide it with catalog ID, or `CatalogServiceInterface::getCatalogByIdentifier()` and pass the identifier:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 68, 70) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 69, 70, remove_indent=True) =]]
 ```
 
 ## Get products in catalog
@@ -20,7 +20,7 @@ To get products from a catalog, request the product query from the catalog objec
 Then, create a new `ProductQuery` based on it and run a product search with `ProductServiceInterface::findProduct()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 72, 78) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 73, 78, remove_indent=True) =]]
 ```
 
 ## Create catalog
@@ -29,7 +29,7 @@ To create a catalog, you need to prepare a `CatalogCreateStruct` that contains: 
 Then, pass this struct to `CatalogServiceInterface::createCatalog()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 51, 66) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 52, 66, remove_indent=True) =]]
 ```
 
 ## Update catalog
@@ -39,5 +39,5 @@ You must pass the catalog object and a `CatalogUpdateStruct` to the method.
 In the following example, you update the catalog to publish it:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 80, 84) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/CatalogCommand.php', 81, 84, remove_indent=True) =]]
 ```

--- a/docs/product_catalog/create_custom_attribute_type.md
+++ b/docs/product_catalog/create_custom_attribute_type.md
@@ -28,7 +28,7 @@ The form mapper must implement `Ibexa\Contracts\ProductCatalog\Local\Attribute\V
 In this example, you can use the Symfony's built-in `PercentType` class (line 40).
 
 ``` php hl_lines="40"
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/Form/PercentValueFormMapper.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/Form/PercentValueFormMapper.php') =]]
 ```
 
 The `options` array contains additional options for the form, including options resulting from the selected form type.
@@ -46,7 +46,7 @@ A value formatter prepares the attribute value for rendering in the proper forma
 In this example, you can use the `NumberFormatter` to ensure the number is rendered in the percentage form (line 22).
 
 ``` php hl_lines="22"
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentValueFormatter.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentValueFormatter.php') =]]
 ```
 
 Register the value formatter as a service and tag it with `ibexa.product_catalog.attribute.formatter.value`:
@@ -67,7 +67,7 @@ First, create `PercentAttributeOptionsType` that defines two options, `min` and 
 Both those options need to be of `PercentType`.
 
 ``` php hl_lines="16 22"
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentAttributeOptionsType.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentAttributeOptionsType.php') =]]
 ```
 
 ### Options form mapper
@@ -75,7 +75,7 @@ Both those options need to be of `PercentType`.
 Next, create a `PercentOptionsFormMapper` that maps the information that the user inputs in the form into attribute definition.
 
 ``` php
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentOptionsFormMapper.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentOptionsFormMapper.php') =]]
 ```
 
 Register the options form mapper as a service and tag it with `ibexa.product_catalog.attribute.form_mapper.options`:
@@ -92,7 +92,7 @@ It validates the options that the user sets while creating the attribute definit
 In this example, the validator verifies whether the minimum percentage is lower than the maximum.
 
 ``` php
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentOptionsValidator.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentOptionsValidator.php') =]]
 ```
 
 Register the options validator as a service and tag it with `ibexa.product_catalog.attribute.validator.options`:
@@ -107,7 +107,7 @@ Finally, make sure the data provided by the user is validated.
 To do that, create `PercentValueValidator` that checks the values against `min` and `max` and dispatches an error when needed.
 
 ``` php hl_lines="23-27"
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentValueValidator.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/PercentValueValidator.php') =]]
 ```
 
 Register the validator as a service and tag it with `ibexa.product_catalog.attribute.validator.value`:
@@ -149,7 +149,7 @@ Start by creating a `PercentStorageConverter` class, which implements `Ibexa\Con
 This converter is responsible for converting database results into an attribute type instance:
 
 ``` php
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/Storage/PercentStorageConverter.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/Storage/PercentStorageConverter.php') =]]
 ```
 
 Register the converter as a service and tag it with `ibexa.product_catalog.attribute.storage_converter`:
@@ -165,7 +165,7 @@ You can either create a new storage definition or use an existing one.
 To create a new storage definition, prepare a `PercentStorageDefinition` class, which implements `Ibexa\Contracts\ProductCatalog\Local\Attribute\StorageDefinitionInterface`.
 
 ``` php
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/Storage/PercentStorageDefinition.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Attribute/Percent/Storage/PercentStorageDefinition.php') =]]
 ```
 
 Register the storage definition as a service and tag it with `ibexa.product_catalog.attribute.storage_definition`:
@@ -177,14 +177,14 @@ Register the storage definition as a service and tag it with `ibexa.product_cata
 If you prefer to use an existing storage definition, you need to create a Storage Definition Tag CompilerPass `src/DependencyInjection/AddFloatStorageDefinitionTag.php`:
 
 ``` php
-[[= include_file('code_samples/catalog/custom_attribute_type/src/DependencyInjection/AddFloatStorageDefinitionTag.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/DependencyInjection/AddFloatStorageDefinitionTag.php') =]]
 ```
 
 Add the CompilerPass to the container.
 Do it in a `src/Kernel.php` file or in your Bundle class:
 
 ``` php hl_lines="5 7-8 14-20"
-[[= include_file('code_samples/catalog/custom_attribute_type/src/Kernel.php') =]]
+[[= include_code('code_samples/catalog/custom_attribute_type/src/Kernel.php') =]]
 ```
 
 ## Use new attribute type

--- a/docs/product_catalog/create_custom_catalog_filter.md
+++ b/docs/product_catalog/create_custom_catalog_filter.md
@@ -14,7 +14,7 @@ The following example shows how to create a filter that selects products with th
 To create a custom catalog filter, first you need to create a filter class in `App\CatalogFilter\ProductNameFilter`.
 
 ``` php
-[[= include_file('code_samples/catalog/custom_catalog_filter/src/CatalogFilter/ProductNameFilter.php') =]]
+[[= include_code('code_samples/catalog/custom_catalog_filter/src/CatalogFilter/ProductNameFilter.php') =]]
 ```
 
 The filter must implement `Ibexa\Contracts\ProductCatalog\CatalogFilters\FilterDefinitionInterface`, provide the filter identifier and name, and the group in which it's displayed in the editing menu.
@@ -26,7 +26,7 @@ The example above uses the built-in `ProductName` Search Criterion.
 Next, you need to add a form mapper: `ProductNameFilterFormMapper` that maps the input from the filter form to the data model:
 
 ``` php hl_lines="35"
-[[= include_file('code_samples/catalog/custom_catalog_filter/src/CatalogFilter/ProductNameFilterFormMapper.php') =]]
+[[= include_code('code_samples/catalog/custom_catalog_filter/src/CatalogFilter/ProductNameFilterFormMapper.php') =]]
 ```
 
 The filter can use the built-in `ProductName` Criterion, but you still need a data transformer for the data entered when editing the catalog (line 35).
@@ -48,7 +48,7 @@ and the form mapper with `ibexa.product_catalog.catalog_filter.form_mapper`:
 Now, create `ProductNameCriterionTransformer` in `src/CatalogFilter/DataTransformer`:
 
 ``` php
-[[= include_file('code_samples/catalog/custom_catalog_filter/src/CatalogFilter/DataTransformer/ProductNameCriterionTransformer.php') =]]
+[[= include_code('code_samples/catalog/custom_catalog_filter/src/CatalogFilter/DataTransformer/ProductNameCriterionTransformer.php') =]]
 ```
 
 ## Provide templates

--- a/docs/product_catalog/create_custom_name_schema_strategy.md
+++ b/docs/product_catalog/create_custom_name_schema_strategy.md
@@ -14,7 +14,7 @@ Start by creating a `PercentNameSchemaStrategy` class, which implements `\Ibexa\
 This class is responsible for converting attribute values into a string of URL parameters:
 
 ``` php
-[[= include_file('code_samples/catalog/percent_name_schema_strategy/NameSchema/PercentNameSchemaStrategy.php') =]]
+[[= include_code('code_samples/catalog/percent_name_schema_strategy/NameSchema/PercentNameSchemaStrategy.php') =]]
 ```
 
 ## Register strategy

--- a/docs/product_catalog/create_product_code_generator.md
+++ b/docs/product_catalog/create_product_code_generator.md
@@ -15,7 +15,7 @@ The following example shows how to add a generator strategy that creates code, b
 First, create the generator strategy class:
 
 ``` php
-[[= include_file('code_samples/catalog/custom_code_generator_strategy/src/CodeGenerator/Strategy/CustomIncrementalCodeGenerator.php') =]]
+[[= include_code('code_samples/catalog/custom_code_generator_strategy/src/CodeGenerator/Strategy/CustomIncrementalCodeGenerator.php') =]]
 ```
 
 This generator uses the provided context to get product information (in this case the code of the base product) and the incremental number.

--- a/docs/product_catalog/customize_product_attribute_templates.md
+++ b/docs/product_catalog/customize_product_attribute_templates.md
@@ -89,5 +89,5 @@ You can inject additional templates by listening to the [`ProductAttributeRender
 Use this option when you want to add templates conditionally, for example based on the active catalog engine or region.
 
 ``` php
-[[= include_file('code_samples/product_catalog/src/EventSubscriber/MyAttributeRenderSubscriber.php') =]]
+[[= include_code('code_samples/product_catalog/src/EventSubscriber/MyAttributeRenderSubscriber.php') =]]
 ```

--- a/docs/product_catalog/price_api.md
+++ b/docs/product_catalog/price_api.md
@@ -12,13 +12,13 @@ To access a currency object by its code, use `CurrencyServiceInterface::getCurre
 To access a whole list of currencies, use `CurrencyServiceInterface::findCurrencies`.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/CurrencyCommand.php', 45, 53) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/CurrencyCommand.php', 46, 53, remove_indent=True) =]]
 ```
 
 To create a new currency, use `CurrencyServiceInterface::createCurrency()` and provide it with a `CurrencyCreateStruct` with code, number of fractional digits and a flag indicating if the currency is enabled:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/CurrencyCommand.php', 60, 63) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/CurrencyCommand.php', 61, 63, remove_indent=True) =]]
 ```
 
 ## Prices
@@ -28,19 +28,19 @@ To manage prices, use [`ProductPriceServiceInterface`](/api/php_api/php_api_refe
 To retrieve the price of a product in the currency for the current context, use `Product::getPrice()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 60, 63) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 61, 63, remove_indent=True) =]]
 ```
 
 To retrieve the price of a product in a specific currency, use `ProductPriceService::getPriceByProductAndCurrency`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 64, 67) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 65, 67, remove_indent=True) =]]
 ```
 
 To get all prices (in different currencies) for a given product, use `ProductPriceServiceInterface::findPricesByProductCode`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 78, 84) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 79, 84, remove_indent=True) =]]
 ```
 
 To load price definitions that match given criteria, use `ProductPriceServiceInterface::findPrices`:
@@ -55,7 +55,7 @@ You can also use `ProductPriceServiceInterface` to create or modify existing pri
 For example, to create a new price for a given currency, use `ProductPriceService::createProductPrice` and provide it with a `ProductPriceCreateStruct` object:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 69, 75) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductPriceCommand.php', 70, 75, remove_indent=True) =]]
 ```
 
 !!! note
@@ -90,17 +90,17 @@ To get information about the VAT categories and rates configured in the system, 
 VAT is configured per region, so you also need to use [`RegionServiceInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ProductCatalog-RegionServiceInterface.html) to get the relevant region object.
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/VatCommand.php', 41, 42) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/VatCommand.php', 42, 42, remove_indent=True) =]]
 ```
 
 To get information about all VAT categories configured for the selected region, use `VatServiceInterface::getVatCategories()`:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/VatCommand.php', 43, 48) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/VatCommand.php', 44, 48, remove_indent=True) =]]
 ```
 
 To get a single VAT category, use `VatServiceInterface::getVatCategoryByIdentifier()` and provide it with the region object and the identifier of the VAT category:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/VatCommand.php', 49, 50) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/VatCommand.php', 50, 50, remove_indent=True) =]]
 ```

--- a/docs/product_catalog/quable/quable_api.md
+++ b/docs/product_catalog/quable/quable_api.md
@@ -29,7 +29,7 @@ To retrieve product information coming from [[= pim_product_name =]], use the sa
 The following example shows how you can retrieve a single product:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 54, 57, remove_indent=True) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 55, 57, remove_indent=True) =]]
 ```
 
 ### Search for products
@@ -37,7 +37,7 @@ The following example shows how you can retrieve a single product:
 Use [`ProductQuery`](product_api.md#getting-product-information) to search for mulitple products:
 
 ``` php
-[[= include_file('code_samples/api/product_catalog/src/Command/ProductCommand.php', 58, 68, remove_indent=True) =]]
+[[= include_code('code_samples/api/product_catalog/src/Command/ProductCommand.php', 59, 68, remove_indent=True) =]]
 ```
 
 When working with [[= pim_product_name =]] products, the following search criteria are supported:

--- a/docs/recommendations/raptor_integration/tracking_php_api.md
+++ b/docs/recommendations/raptor_integration/tracking_php_api.md
@@ -64,7 +64,7 @@ If you need to track [events](event_reference.md) automatically based on applica
 It reacts to specific events in the application and triggers tracking logic without the need to add it manually in templates.
 
 ``` php
-[[= include_file('code_samples/recommendations/EventSubscriber.php') =]]
+[[= include_code('code_samples/recommendations/EventSubscriber.php') =]]
 ```
 
 You can also use [[= product_name =]] events, for example `CreateOrderEvent` from [Order management events](order_management_events.md).

--- a/docs/search/ai_actions_search_reference/action_configuration_criteria.md
+++ b/docs/search/ai_actions_search_reference/action_configuration_criteria.md
@@ -18,7 +18,7 @@ Search criteria are found in the `Ibexa\Contracts\ConnectorAi\ActionConfiguratio
 
 The following example shows how to use them to find specific Action Configurations:
 ``` php
-[[= include_file('code_samples/ai_actions/src/Query/Search.php') =]]
+[[= include_code('code_samples/ai_actions/src/Query/Search.php') =]]
 ```
 
 The result set contains Action Configurations that are:

--- a/docs/search/ai_actions_search_reference/action_configuration_sort_clauses.md
+++ b/docs/search/ai_actions_search_reference/action_configuration_sort_clauses.md
@@ -13,7 +13,7 @@ Sort Clauses are found in the `Ibexa\Contracts\ConnectorAi\ActionConfiguration\Q
 
 The following example shows how to use them to sort the searched Action Configurations:
 ``` php
-[[= include_file('code_samples/ai_actions/src/Query/Search.php') =]]
+[[= include_code('code_samples/ai_actions/src/Query/Search.php') =]]
 ```
 
 The search results are sorted by:

--- a/docs/search/collaboration_search_reference/collaboration_criteria.md
+++ b/docs/search/collaboration_search_reference/collaboration_criteria.md
@@ -49,7 +49,7 @@ Session Search Criteria are implementing the [CriterionInterface](/api/php_api/p
 The following example shows how you can use the criteria to find all the currently active sessions:
 
 ```php hl_lines="11-15"
-[[= include_file('code_samples/collaboration/src/Query/Search.php') =]]
+[[= include_code('code_samples/collaboration/src/Query/Search.php') =]]
 ```
 
 The criteria limit the result set to sessions matching all of the conditions listed below:

--- a/docs/search/collaboration_search_reference/collaboration_sort_clauses.md
+++ b/docs/search/collaboration_search_reference/collaboration_sort_clauses.md
@@ -34,7 +34,7 @@ Session Search Sort Clauses are implementing the [SortClauseInterface](/api/php_
 The following example shows how to use them to sort the searched sessions:
 
 ```php hl_lines="17"
-[[= include_file('code_samples/collaboration/src/Query/Search.php') =]]
+[[= include_code('code_samples/collaboration/src/Query/Search.php') =]]
 ```
 
 The returned active sessions are sorted by creation date (descending).

--- a/docs/search/content_type_search_reference/content_type_criteria.md
+++ b/docs/search/content_type_search_reference/content_type_criteria.md
@@ -23,5 +23,5 @@ Content Type Search Criteria are only supported by [Content Type Search (`Conten
 The following example shows how to use them to search for content types:
 
 ```php hl_lines="29-31"
-[[= include_file('code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php') =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php') =]]
 ```

--- a/docs/search/content_type_search_reference/content_type_sort_clauses.md
+++ b/docs/search/content_type_search_reference/content_type_sort_clauses.md
@@ -20,7 +20,7 @@ Sort Clauses are found in the [`Ibexa\Contracts\Core\Repository\Values\ContentTy
 The following example shows how to use them to sort the searched content types:
 
 ```php hl_lines="34-36"
-[[= include_file('code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php') =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindContentTypeCommand.php') =]]
 ```
 
 You can change the default sorting order by using the `SORT_ASC` and `SORT_DESC` constants from [`AbstractSortClause`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-CoreSearch-Values-Query-AbstractSortClause.html#constants).

--- a/docs/search/criteria_reference/customfield_criterion.md
+++ b/docs/search/criteria_reference/customfield_criterion.md
@@ -24,5 +24,5 @@ The `CustomField` Criterion isn't available in [Repository filtering](search_api
 ### PHP
 
 ``` php
-[[= include_file('code_samples/search/content/customfield_criterion.php') =]]
+[[= include_code('code_samples/search/content/customfield_criterion.php') =]]
 ```

--- a/docs/search/criteria_reference/datetimeattribute_criterion.md
+++ b/docs/search/criteria_reference/datetimeattribute_criterion.md
@@ -29,5 +29,5 @@ The following operators are supported:
 The following example lists all products for which the `event_date` attribute has value equal to 2025-07-06.
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Query/DateTimeAttributeQuery.php') =]]
+[[= include_code('code_samples/back_office/search/src/Query/DateTimeAttributeQuery.php') =]]
 ```

--- a/docs/search/criteria_reference/datetimeattributerange_criterion.md
+++ b/docs/search/criteria_reference/datetimeattributerange_criterion.md
@@ -19,5 +19,5 @@ The [`DateTimeAttributeRange Search Criterion`](/api/php_api/php_api_reference/c
 The following example lists all products for which the `event_date` attribute has value greater than 2025-01-01.
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Query/DateTimeAttributeRangeQuery.php') =]]
+[[= include_code('code_samples/back_office/search/src/Query/DateTimeAttributeRangeQuery.php') =]]
 ```

--- a/docs/search/criteria_reference/isbookmarked_criterion.md
+++ b/docs/search/criteria_reference/isbookmarked_criterion.md
@@ -20,7 +20,7 @@ This Criterion is available only for location Search.
 ### PHP
 
 ``` php
-[[= include_file('code_samples/search/location/isbookmarked_criterion.php', 2) =]]
+[[= include_code('code_samples/search/location/isbookmarked_criterion.php', 3, remove_indent=True) =]]
 ```
 
 ### REST API

--- a/docs/search/criteria_reference/notification_datecreated_criterion.md
+++ b/docs/search/criteria_reference/notification_datecreated_criterion.md
@@ -17,5 +17,5 @@ The `DateCreated` Search Criterion searches for notifications based on the date 
 ### PHP
 
 ```php hl_lines="14-15 17"
-[[= include_file('code_samples/notifications/Src/Query/search.php') =]]
+[[= include_code('code_samples/notifications/Src/Query/search.php') =]]
 ```

--- a/docs/search/criteria_reference/notification_status_criterion.md
+++ b/docs/search/criteria_reference/notification_status_criterion.md
@@ -16,5 +16,5 @@ The `Status` Search Criterion searches for notifications based on notification s
 ### PHP
 
 ```php hl_lines="12"
-[[= include_file('code_samples/notifications/Src/Query/search.php') =]]
+[[= include_code('code_samples/notifications/Src/Query/search.php') =]]
 ```

--- a/docs/search/criteria_reference/notification_type_criterion.md
+++ b/docs/search/criteria_reference/notification_type_criterion.md
@@ -16,5 +16,5 @@ The `Type` Search Criterion searches for notifications by their types.
 ### PHP
 
 ```php hl_lines="11"
-[[= include_file('code_samples/notifications/Src/Query/search.php') =]]
+[[= include_code('code_samples/notifications/Src/Query/search.php') =]]
 ```

--- a/docs/search/criteria_reference/productcategorysubtree_criterion.md
+++ b/docs/search/criteria_reference/productcategorysubtree_criterion.md
@@ -18,5 +18,5 @@ Unlike the [`ProductCategory` criterion](productcategory_criterion.md), which ma
 ### PHP
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Query/ProductCategorySubtreeQuery.php') =]]
+[[= include_code('code_samples/back_office/search/src/Query/ProductCategorySubtreeQuery.php') =]]
 ```

--- a/docs/search/criteria_reference/symbolattribute_criterion.md
+++ b/docs/search/criteria_reference/symbolattribute_criterion.md
@@ -16,5 +16,5 @@ The `SymbolAttribute` Search Criterion searches for products by [symbol attribut
 ### PHP
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Query/SymbolAttributeTypeQuery.php') =]]
+[[= include_code('code_samples/back_office/search/src/Query/SymbolAttributeTypeQuery.php') =]]
 ```

--- a/docs/search/criteria_reference/taxonomy_no_entries.md
+++ b/docs/search/criteria_reference/taxonomy_no_entries.md
@@ -20,7 +20,7 @@ It's available for all supported search engines and in [repository filtering](se
 The following example searches for articles that have no entries assigned in the `tags` taxonomy:
 
 ```php hl_lines="11-16"
-[[= include_file('code_samples/search/content/taxonomy_no_entries_criterion.php') =]]
+[[= include_code('code_samples/search/content/taxonomy_no_entries_criterion.php') =]]
 ```
 
 The criteria limit the results to content that matches all of the conditions listed below:

--- a/docs/search/criteria_reference/taxonomy_subtree.md
+++ b/docs/search/criteria_reference/taxonomy_subtree.md
@@ -17,7 +17,7 @@ The [`TaxonomySubtree`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-T
 The following example searches for articles assigned to taxonomy entry with ID `42` or any of its child entries:
 
 ```php hl_lines="11-16"
-[[= include_file('code_samples/search/content/taxonomy_subtree_criterion.php') =]]
+[[= include_code('code_samples/search/content/taxonomy_subtree_criterion.php') =]]
 ```
 
 The criteria limit the results to content that match all of the conditions listed below:

--- a/docs/search/criteria_reference/updated_at_criterion.md
+++ b/docs/search/criteria_reference/updated_at_criterion.md
@@ -27,7 +27,7 @@ The `UpdatedAt` Search Criterion searches for products based on the date when th
 ### PHP
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Query/UpdatedAtQuery.php') =]]
+[[= include_code('code_samples/back_office/search/src/Query/UpdatedAtQuery.php') =]]
 ```
 
 ### REST API

--- a/docs/search/criteria_reference/updated_at_range_criterion.md
+++ b/docs/search/criteria_reference/updated_at_range_criterion.md
@@ -19,7 +19,7 @@ At least one of `min` or `max` must be provided.
 ### PHP
 
 ``` php
-[[= include_file('code_samples/back_office/search/src/Query/UpdatedAtRangeQuery.php') =]]
+[[= include_code('code_samples/back_office/search/src/Query/UpdatedAtRangeQuery.php') =]]
 ```
 
 ### REST API

--- a/docs/search/discounts_search_reference/discounts_criteria.md
+++ b/docs/search/discounts_search_reference/discounts_criteria.md
@@ -32,7 +32,7 @@ Use the `limit` and `offset` properties of [DiscountQuery](/api/php_api/php_api_
 The following example shows how you can use the criteria to find all the currently active discounts:
 
 ```php hl_lines="13-20"
-[[= include_file('code_samples/discounts/src/Query/Search.php') =]]
+[[= include_code('code_samples/discounts/src/Query/Search.php') =]]
 ```
 
 The criteria limit the result set to discounts matching all of the conditions listed below:

--- a/docs/search/discounts_search_reference/discounts_sort_clauses.md
+++ b/docs/search/discounts_search_reference/discounts_sort_clauses.md
@@ -24,7 +24,7 @@ Sort Clauses are found in the [`Ibexa\Contracts\Discounts\Value\Query\SortClause
 The following example shows how to use them to sort the searched discounts:
 
 ```php hl_lines="22-24"
-[[= include_file('code_samples/discounts/src/Query/Search.php') =]]
+[[= include_code('code_samples/discounts/src/Query/Search.php') =]]
 ```
 
 The returned active discounts are sorted by:

--- a/docs/search/embeddings_reference/embeddings_reference.md
+++ b/docs/search/embeddings_reference/embeddings_reference.md
@@ -88,7 +88,7 @@ Embedding vectors are stored in dedicated search fields.
 These fields can be used by the search engine to perform vector similarity comparisons when embedding queries are executed.
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/embedding_fields.php') =]]
+[[= include_code('code_samples/api/public_php_api/src/embedding_fields.php') =]]
 ```
 
 Once you create a field, subscribe to the `ContentIndexCreateEvent` indexing event that [adds the field to the index](index_custom_elasticsearch_data.md).

--- a/docs/search/extensibility/customize_elasticsearch_index_structure.md
+++ b/docs/search/extensibility/customize_elasticsearch_index_structure.md
@@ -44,7 +44,7 @@ This resolver must implement `Ibexa\Contracts\Elasticsearch\ElasticSearch\Index\
 In this example, create a `ContentTypeGroupGroupResolver` based on the content type Group ID of the document:
 
 ``` php
-[[= include_file('code_samples/search/custom/src/GroupResolver/ContentTypeGroupGroupResolver.php') =]]
+[[= include_code('code_samples/search/custom/src/GroupResolver/ContentTypeGroupGroupResolver.php') =]]
 ```
 
 Register the resolver as a service:

--- a/docs/search/extensibility/solr_document_field_mappers.md
+++ b/docs/search/extensibility/solr_document_field_mappers.md
@@ -57,7 +57,7 @@ The example relies on a use case of indexing webinar data on the webinar events,
 The field mapper could then look like this:
 
 ```php
-[[= include_file('code_samples/search/custom/src/Search/FieldMapper/WebinarEventParentNameFieldMapper.php') =]]
+[[= include_code('code_samples/search/custom/src/Search/FieldMapper/WebinarEventParentNameFieldMapper.php') =]]
 ```
 
 You index text data only on the content document, therefore, you would register the service like this:

--- a/docs/search/search_api.md
+++ b/docs/search/search_api.md
@@ -279,7 +279,7 @@ The example below uses the `LogicalNot` operator to search for all content conta
 that doesn't belong to the provided Section:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindComplexCommand.php', 47, 54) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindComplexCommand.php', 47, 54, remove_indent=True) =]]
 ```
 
 ### Combine independent Criteria
@@ -312,7 +312,7 @@ To sort the results of a query, use one of more [Sort Clauses](sort_clause_refer
 For example, to order search results by their publication date, from oldest to newest, and then alphabetically by content name, add the following Sort Clauses to the query:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindComplexCommand.php', 56, 59) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindComplexCommand.php', 56, 59, remove_indent=True) =]]
 ```
 
 !!! tip
@@ -330,7 +330,7 @@ With aggregations you can find the count of search results or other result infor
 To do this, you use of the query's `$aggregations` property:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 31, 35) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 31, 35, remove_indent=True) =]]
 ```
 
 The name of the aggregation must be unique in the given query.
@@ -338,13 +338,13 @@ The name of the aggregation must be unique in the given query.
 Access the results by using the `get()` method of the aggregation:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 40, 40) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 40, 40, remove_indent=True) =]]
 ```
 
 Aggregation results contain the name of the result and the count of found items:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 43, 45) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 43, 45, remove_indent=True) =]]
 ```
 
 With field aggregations you can group search results according to the value of a specific field.
@@ -353,14 +353,14 @@ In this case the aggregation takes the content type identifier and the field ide
 The following example creates an aggregation named `selection` that groups results according to the value of the `topic` field in the `article` content type:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 36, 36) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 36, 36, remove_indent=True) =]]
 ```
 
 With term aggregation you can define additional limits to the results.
 The following example limits the number of terms returned to 5 and only considers terms that have 10 or more results:
 
 ``` php
-[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 31, 33) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/FindWithAggregationCommand.php', 31, 33, remove_indent=True) =]]
 ```
 
 To use a range aggregation, you must provide a `ranges` array containing a set of `Range` objects that define the borders of the specific range sets.

--- a/docs/search/shopping_list_search_reference/shopping_list_criteria.md
+++ b/docs/search/shopping_list_search_reference/shopping_list_criteria.md
@@ -30,7 +30,7 @@ $query = new ShoppingListQuery();
 The following example query returns current user's shopping lists, excluding the default one, and sorts them by name:
 
 ```php hl_lines="7-8"
-[[= include_file('code_samples/shopping_list/search/criteria.php', 2) =]]
+[[= include_code('code_samples/shopping_list/search/criteria.php', 3, remove_indent=True) =]]
 ```
 
 For more information about shopping lists search, see [List and search shopping lists](shopping_list_api.md#list-and-search-shopping-lists).

--- a/docs/search/shopping_list_search_reference/shopping_list_sort_clauses.md
+++ b/docs/search/shopping_list_search_reference/shopping_list_sort_clauses.md
@@ -19,7 +19,7 @@ The following example returns all the shopping lists available to the current us
 The returned shopping list are sorted with the default shopping list on top, followed by the rest sorted by their name.
 
 ```php hl_lines="10-11"
-[[= include_file('code_samples/shopping_list/search/sort_clauses.php', 2) =]]
+[[= include_code('code_samples/shopping_list/search/sort_clauses.php', 3, remove_indent=True) =]]
 ```
 
 For more information about shopping lists search, see [List and search shopping lists](shopping_list_api.md#list-and-search-shopping-lists).

--- a/docs/templating/components.md
+++ b/docs/templating/components.md
@@ -27,7 +27,7 @@ Register it as a service by using the `AsTwigComponent` attribute or the `ibexa.
 === "PHP Attribute"
 
     ``` php hl_lines="8-11"
-    [[= include_file('code_samples/back_office/components/MyComponent.php', glue='    ') =]]
+    [[= include_code('code_samples/back_office/components/MyComponent.php', indent_level=1) =]]
     ```
 
 === "YAML configuration"

--- a/docs/templating/embed_and_list_content/embed_content.md
+++ b/docs/templating/embed_and_list_content/embed_content.md
@@ -37,7 +37,7 @@ You can use a custom controller for any situation where Query types aren't suffi
 This configuration points to a custom `RelationController` that should render all Articles with the `showContentAction()` method.
 
 ``` php hl_lines="23 27 28"
-[[= include_file('code_samples/front/embed_content/src/Controller/RelationController.php') =]]
+[[= include_code('code_samples/front/embed_content/src/Controller/RelationController.php') =]]
 ```
 
 This controller uses the Public PHP API to get [the Relations of a content item](browsing_content.md#relations) (lines 27-28).

--- a/docs/templating/layout/add_breadcrumbs.md
+++ b/docs/templating/layout/add_breadcrumbs.md
@@ -11,7 +11,7 @@ This template can contain things such as header, menu, footer, and [assets](asse
 Then, to render breadcrumbs, create a `BreadcrumbController.php` file in `src/Controller`:
 
 ``` php hl_lines="27 35"
-[[= include_file('code_samples/front/layouts/breadcrumbs/src/Controller/BreadcrumbController.php') =]]
+[[= include_code('code_samples/front/layouts/breadcrumbs/src/Controller/BreadcrumbController.php') =]]
 ```
 
 The controller uses the [Ancestor Search Criterion](ancestor_criterion.md) to find all Ancestors of the current Location (line 27).

--- a/docs/templating/layout/add_navigation_menu.md
+++ b/docs/templating/layout/add_navigation_menu.md
@@ -20,7 +20,7 @@ To create a menu that contains a specific set of content items, for example all 
 First, in `src/QueryType`, create a custom `MenuQueryType.php` file that queries for all items that you want in the menu:
 
 ``` php hl_lines="15 16 28"
-[[= include_file('code_samples/front/layouts/menu/src/QueryType/MenuQueryType.php') =]]
+[[= include_code('code_samples/front/layouts/menu/src/QueryType/MenuQueryType.php') =]]
 ```
 
 In this case, it queries for all visible children of location `2`, the root location, (lines 15-16) and renders them in order according to their location priority.
@@ -46,7 +46,7 @@ To make a more configurable menu, where you select the specific items to render,
 To use it, first create a `MenuBuilder.php` file in `src/Menu`:
 
 ``` php hl_lines="21 22 23 27"
-[[= include_file('code_samples/front/layouts/menu/src/Menu/MenuBuilder.php') =]]
+[[= include_code('code_samples/front/layouts/menu/src/Menu/MenuBuilder.php') =]]
 ```
 
 In the builder, you can define items that you want in the menu.

--- a/docs/templating/queries_and_controllers/create_custom_query_type.md
+++ b/docs/templating/queries_and_controllers/create_custom_query_type.md
@@ -11,7 +11,7 @@ The following example shows how to create a custom Query type that renders the l
 First, add the following `LatestContentQueryType.php` file to `src/QueryType`:
 
 ``` php
-[[= include_file('code_samples/front/custom_query_type/src/QueryType/LatestContentQueryType.php') =]]
+[[= include_code('code_samples/front/custom_query_type/src/QueryType/LatestContentQueryType.php') =]]
 ```
 
 !!! tip
@@ -22,7 +22,7 @@ First, add the following `LatestContentQueryType.php` file to `src/QueryType`:
 The name defined in `getName()` is the one you use to identify the Query type in content view configuration.
 
 ``` php
-[[= include_file('code_samples/front/custom_query_type/src/QueryType/LatestContentQueryType.php', 10, 14) =]]
+[[= include_code('code_samples/front/custom_query_type/src/QueryType/LatestContentQueryType.php', 11, 14, remove_indent=True) =]]
 ```
 
 !!! caution
@@ -36,7 +36,7 @@ For more information, see [Content search](search_api.md) and [Search reference]
 The `getSupportedParameters()` method provides the parameters you can set in content view configuration.
 
 ``` php
-[[= include_file('code_samples/front/custom_query_type/src/QueryType/LatestContentQueryType.php', 31, 35) =]]
+[[= include_code('code_samples/front/custom_query_type/src/QueryType/LatestContentQueryType.php', 32, 35, remove_indent=True) =]]
 ```
 
 !!! note
@@ -57,7 +57,7 @@ This gives you more flexibility when defining parameters.
 In the `configureOptions()` method you can define the allowed parameters, their types and default values.
 
 ``` php hl_lines="34 35 36 37 38 39 40"
-[[= include_file('code_samples/front/custom_query_type/src/QueryType/OptionsBasedLatestContentQueryType.php') =]]
+[[= include_code('code_samples/front/custom_query_type/src/QueryType/OptionsBasedLatestContentQueryType.php') =]]
 ```
 
 !!! note

--- a/docs/templating/render_content/render_content_in_php.md
+++ b/docs/templating/render_content/render_content_in_php.md
@@ -22,7 +22,7 @@ It doesn't work with a `full` view when the [page layout](template_configuration
 Create the command in `src/Command/ViewCommand.php`:
 
 ```php hl_lines="57-61"
-[[= include_file('code_samples/front/render_content_in_php/src/Command/ViewCommand.php') =]]
+[[= include_code('code_samples/front/render_content_in_php/src/Command/ViewCommand.php') =]]
 ```
 
 !!! caution

--- a/docs/templating/templates/create_custom_view_matcher.md
+++ b/docs/templating/templates/create_custom_view_matcher.md
@@ -21,7 +21,7 @@ The following example shows how to implement an `Owner` matcher.
 This matcher identifies content items that have the provided owner or owners.
 
 ``` php hl_lines="65"
-[[= include_file('code_samples/front/view_matcher/src/View/Matcher/Owner.php') =]]
+[[= include_code('code_samples/front/view_matcher/src/View/Matcher/Owner.php') =]]
 ```
 
 The matcher checks whether the owner of the current content (by its ContentInfo or location) matches any of the values passed in configuration.

--- a/docs/tutorials/generic_field_type/1_implement_the_point2d_value_class.md
+++ b/docs/tutorials/generic_field_type/1_implement_the_point2d_value_class.md
@@ -43,7 +43,7 @@ You want to focus on what the field type exposes as an API.
 `src/FieldType/Point2D/Value.php` should have the following properties:
 
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/steps/step_1/Value.php', 9, 14) =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/steps/step_1/Value.php', 10, 14, remove_indent=True) =]]
 ```
 
 A Value class must also implement the `Ibexa\Contracts\Core\FieldType\Value` interface.

--- a/docs/tutorials/generic_field_type/2_define_point2d_field_type.md
+++ b/docs/tutorials/generic_field_type/2_define_point2d_field_type.md
@@ -18,7 +18,7 @@ Add a `getFieldTypeIdentifier()` method to it.
 The new method returns the string that **uniquely** identifies your field type, in this case `point2d`:
 
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/steps/step_2/Type.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/steps/step_2/Type.php') =]]
 ```
 
 ## Add a new service definition

--- a/docs/tutorials/generic_field_type/3_create_form_for_point2d.md
+++ b/docs/tutorials/generic_field_type/3_create_form_for_point2d.md
@@ -32,14 +32,14 @@ Next, implement a `mapFieldValueForm()` method and invoke `FormInterface::add` m
 Final version of the Type class should have the following statements and functions:
 
 ```php hl_lines="7 10 19-26"
-[[= include_file('code_samples/field_types/2dpoint_ft/steps/step_3/Type.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/steps/step_3/Type.php') =]]
 ```
 
 Finally, add a `configureOptions` method and set default value of `data_class` to `Value::class` in `src/Form/Type/Point2DType.php`.
 It allows your form to work on this object.
 
 ```php hl_lines="20-25"
-[[= include_file('code_samples/field_types/2dpoint_ft/src/Form/Type/Point2DType.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/Form/Type/Point2DType.php') =]]
 ```
 
 ## Add a new tag

--- a/docs/tutorials/generic_field_type/6_settings.md
+++ b/docs/tutorials/generic_field_type/6_settings.md
@@ -16,7 +16,7 @@ You also specify coordinates as placeholder values `%x%` and `%y%`.
 Open `src/FieldType/Point2D/Type.php` and add a `getSettingsSchema` method according to the following code block:
 
 ```php hl_lines="18-27"
-[[= include_file('code_samples/field_types/2dpoint_ft/steps/step_6/Type.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/steps/step_6/Type.php') =]]
 ```
 
 ## Add a format field
@@ -26,7 +26,7 @@ In this part you define and implement the edit form for your field type.
 Define a `Point2DSettingsType` class and add a `format` field in `src/Form/Type/Point2DSettingsType.php`:
 
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/src/Form/Type/Point2DSettingsType.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/Form/Type/Point2DSettingsType.php') =]]
 ```
 
 ## FieldDefinitionFormMapper Interface
@@ -46,7 +46,7 @@ In `src/FieldType/Point2D/Type.php` you:
 <details class="tip">
 <summary>Complete Type.php code</summary>
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/src/FieldType/Point2D/Type.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/FieldType/Point2D/Type.php') =]]
 ```
 </details>
 

--- a/docs/tutorials/generic_field_type/7_add_a_validation.md
+++ b/docs/tutorials/generic_field_type/7_add_a_validation.md
@@ -7,7 +7,7 @@ description: Learn how to validate custom field data.
 To provide basic validation that ensures both coordinates are provided, add assertions to the `src/FieldType/Point2D/Value.php`:
 
 ```php hl_lines="12 14"
-[[= include_file('code_samples/field_types/2dpoint_ft/src/FieldType/Point2D/Value.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/FieldType/Point2D/Value.php') =]]
 ```
 
 As a result, if a user tries to publish the Point 2D with one value, they receive an error message.

--- a/docs/tutorials/generic_field_type/8_data_migration.md
+++ b/docs/tutorials/generic_field_type/8_data_migration.md
@@ -16,7 +16,7 @@ For more information on Serializer Component, see [Symfony documentation]([[= sy
 First, you need to add support for normalization in a `src/Serializer/Point2D/ValueNormalizer.php`:
 
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueNormalizer.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueNormalizer.php') =]]
 ```
 
 !!! note
@@ -28,7 +28,7 @@ First, you need to add support for normalization in a `src/Serializer/Point2D/Va
 To accept old versions of the field type you need to add support for denormalization in a `src/Serializer/Point2D/ValueDenormalizer.php`:
 
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueDenormalizer.php') =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/Serializer/Point2D/ValueDenormalizer.php') =]]
 ```
 
 ## Change format on the fly
@@ -36,7 +36,7 @@ To accept old versions of the field type you need to add support for denormaliza
 To change the format on the fly, you need to replace the constructor and class properties in `src/FieldType/Point2D/Value.php`:
 
 ```php
-[[= include_file('code_samples/field_types/2dpoint_ft/src/FieldType/Point2D/ValueFinal.php', 10, 24) =]]
+[[= include_code('code_samples/field_types/2dpoint_ft/src/FieldType/Point2D/ValueFinal.php', 11, 24, remove_indent=True) =]]
 ```
 
 Now you can change the internal representation format of the Point 2D field type.

--- a/docs/tutorials/page_and_form_tutorial/4_create_a_custom_block.md
+++ b/docs/tutorials/page_and_form_tutorial/4_create_a_custom_block.md
@@ -40,7 +40,7 @@ Block listener provides the logic for the block.
 It's contained in `src/Event/RandomBlockListener.php`:
 
 ``` php
-[[= include_file('code_samples/tutorials/page_tutorial/src/Event/RandomBlockListener.php') =]]
+[[= include_code('code_samples/tutorials/page_tutorial/src/Event/RandomBlockListener.php') =]]
 ```
 
 At this point the new custom block is ready to be used.

--- a/docs/users/oauth_client.md
+++ b/docs/users/oauth_client.md
@@ -89,7 +89,7 @@ The mapper loads a user (line 40) or creates a new one (line 49), based on the i
 The new username is set with a `google:` prefix (lines 20, 91), to avoid conflicts with users registered in a regular way.
 
 ``` php hl_lines="20 40 67 91"
-[[= include_file('code_samples/user_management/oauth_google/src/OAuth/GoogleResourceOwnerMapper.php') =]]
+[[= include_code('code_samples/user_management/oauth_google/src/OAuth/GoogleResourceOwnerMapper.php') =]]
 ```
 
 Configure the service by using the `ibexa.oauth2_client.resource_owner_mapper` tag to associate it with the `google` client:

--- a/docs/users/segment_api.md
+++ b/docs/users/segment_api.md
@@ -15,13 +15,13 @@ To load a segment group, use `SegmentationService::loadSegmentGroupByIdentifier(
 Get all segments assigned to the group with `SegmentationService::loadSegmentsAssignedToGroup()`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 48, 55) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 49, 55, remove_indent=True) =]]
 ```
 
 Similarly, you can load a segment by using `SegmentationService::loadSegmentByIdentifier()`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 56, 57) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 57, 57, remove_indent=True) =]]
 ```
 
 ## Checking assignment
@@ -29,7 +29,7 @@ Similarly, you can load a segment by using `SegmentationService::loadSegmentById
 You can check whether a user is assigned to a segment with `SegmentationService::isUserAssignedToSegment()`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 60, 65) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 61, 65, remove_indent=True) =]]
 ```
 
 ## Assigning users
@@ -37,7 +37,7 @@ You can check whether a user is assigned to a segment with `SegmentationService:
 To assign a user to a segment, use `SegmentationService::assignUserToSegment()`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 58, 59) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 59, 59, remove_indent=True) =]]
 ```
 
 ## Creating segments
@@ -47,13 +47,13 @@ Each segment must be assigned to a segment group.
 To create a segment group, use `SegmentationService::createSegmentGroup()` and provide it with a `SegmentGroupCreateStruct`:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 32, 39) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 33, 39, remove_indent=True) =]]
 ```
 
 To add a segment, use `SegmentationService::createSegment()` and provide it with a `SegmentCreateStruct`, which takes an existing group as one of the parameters:
 
 ``` php
-[[= include_file('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 40, 47) =]]
+[[= include_code('code_samples/api/public_php_api/src/Command/SegmentCommand.php', 41, 47, remove_indent=True) =]]
 ```
 
 ## Updating segments


### PR DESCRIPTION
Target: v5

For PHP code samples, In code blocks with only a single include_file call:

- include_code is used instead
- if the include is a partial one, remove_indent=True is added to the call

Multiple include_* calls within a single code blocks are not covered here, as they require more attention and will be done in a follow-up

**To review this, please use HTML report I've attached on Slack - this makes the review much easier.**

It contains the changes before and after, and a diff showing what has changed.
Please use the provided HTML file for reviewing - it's generated locally using the existing code samples usage job, this should make the review easier.

<img width="1677" height="889" alt="Screenshot 2026-05-18 at 11 55 42" src="https://github.com/user-attachments/assets/f2ae00d2-d87b-4964-941b-489be858d332" />

