### PR TITLE
Add MCP Servers to API references

### DIFF
--- a/tools/api_refs/api_refs.sh
+++ b/tools/api_refs/api_refs.sh
@@ -10,7 +10,7 @@ REST_API_OPENAPI_FILE_JSON=${5:-./docs/api/rest_api/rest_api_reference/openapi.j
 
 DXP_EDITION='commerce'; # Edition from and for which the Reference is built
 DXP_VERSION='5.0.*'; # Version from and for which the Reference is built
-DXP_ADD_ONS=(automated-translation rector integrated-help fieldtype-richtext-rte connector-anthropic connector-gemini shopping-list cdp connector-raptor connector-quable); # Packages not included in $DXP_EDITION but added to the Reference, listed without their vendor "ibexa"
+DXP_ADD_ONS=(automated-translation rector integrated-help fieldtype-richtext-rte connector-anthropic connector-gemini shopping-list cdp connector-raptor connector-quable mcp); # Packages not included in $DXP_EDITION but added to the Reference, listed without their vendor "ibexa"
 DXP_EDITIONS=(oss headless experience commerce); # Available editions ordered by ascending capabilities
 SF_VERSION='7.4'; # Symfony version used by Ibexa DXP
 PHPDOC_VERSION='3.9.1'; # Version of phpDocumentor used to build the Reference


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Related to #3106

Add MCP Servers (`ibexa/mcp`) to PHP API and REST API references.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
