### PR TITLE
Update instructions

### DIFF
--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -666,7 +666,56 @@ Run the provided SQL upgrade script to update your database:
 
 ## v4.6.30
 
-No additional steps needed.
+### Update Twig to v3.26.0
+
+It's highly recommenced to update `twig/twig` and `twig/intl-extra` to version v3.26.0 for security issues.
+This packages requires minimal PHP 8.1. They're automatically updated if you use PHP 8.1 or higher.
+
+If you're using PHP 7.4 or 8.0, to do the [[= product_name =]] update, you have to options:
+
+#### Update PHP, the custom code, then the platform (recommended)
+
+Make sure to host on PHP 8.1 or higher.
+Migrate custom code to be compatible with PHP 8.1 or higher.
+You can optionally use [Rector](https://github.com/rectorphp/rector) to help yourself.
+Then, update Ibexa DXP.
+
+#### Implement other countermeasures
+
+If updating the Twig packages isn't possible, for example, because the project is using PHP 7.4 or 8.0 where the fix is not available, and you need time to migrate while urgently needing v5.0.8 features, review the security issues carefully and assess the danger.
+
+If you choose to implement countermeasures without upgrading PHP and updating Twig, you can silence the advisories in `composer.json`:
+
+```json
+"config": {
+    "audit": {
+        "ignore": {
+            "GHSA-68jq-c3rv-pcrr": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "GHSA-fc86-6rv6-2jpm": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "GHSA-r7cg-qjjm-xhqq": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-5k7f-wvjj-jrgw": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-sjvz-tbbr-vwth": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-h8hf-ytnd-5t9q": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-wwb1-81rc-pd65": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-hgmw-wn4d-hpcy": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-kvv6-36cr-fkzb": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-n14z-jjjg-g8vd": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-3mcc-k66d-pydb": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-gw7n-z4yx-7xjt": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-dpx1-78wg-1kqs": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-21g2-dzjv-sky5": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-yhcn-xrg3-68b1": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-2wrf-1xmk-1pky": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-6319-ffpf-gx66": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-n7sg-8f52-pqtf": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-8kk8-h2xr-h5nx": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
+            "PKSA-2rbx-bjdx-4d4d": "Description of the countermeasures you've implemented causing this one to be safe to ignore."
+        }
+    }
+}
+```
+
+In addition, consider upgrading your project to one of [the actively supported PHP versions](/getting_started/requirements.md#php).
 
 ## LTS Updates
 

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -672,7 +672,6 @@ For security reasons, it's highly recommenced to update `twig/twig` and `twig/in
 
 For more information, see the following security advisories:
 
-
 * [PKSA-5k7f-wvjj-jrgw](https://packagist.org/security-advisories/PKSA-5k7f-wvjj-jrgw)
 * [PKSA-sjvz-tbbr-vwth](https://packagist.org/security-advisories/PKSA-sjvz-tbbr-vwth)
 * [PKSA-h8hf-ytnd-5t9q](https://packagist.org/security-advisories/PKSA-h8hf-ytnd-5t9q)

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -668,11 +668,11 @@ Run the provided SQL upgrade script to update your database:
 
 ### Update Twig to v3.26.0
 
-It's highly recommenced to update `twig/twig` and `twig/intl-extra` to version v3.26.0 or higher for security issues.
+For security reasons, it's highly recommenced to update `twig/twig` and `twig/intl-extra` to version v3.26.0 or higher.
 
-* [GHSA-68jq-c3rv-pcrr](https://packagist.org/security-advisories/GHSA-68jq-c3rv-pcrr)
-* [GHSA-fc86-6rv6-2jpm](https://packagist.org/security-advisories/GHSA-fc86-6rv6-2jpm)
-* [GHSA-r7cg-qjjm-xhqq](https://packagist.org/security-advisories/GHSA-r7cg-qjjm-xhqq)
+For more information, see the following security advisories:
+
+
 * [PKSA-5k7f-wvjj-jrgw](https://packagist.org/security-advisories/PKSA-5k7f-wvjj-jrgw)
 * [PKSA-sjvz-tbbr-vwth](https://packagist.org/security-advisories/PKSA-sjvz-tbbr-vwth)
 * [PKSA-h8hf-ytnd-5t9q](https://packagist.org/security-advisories/PKSA-h8hf-ytnd-5t9q)
@@ -691,20 +691,21 @@ It's highly recommenced to update `twig/twig` and `twig/intl-extra` to version v
 * [PKSA-8kk8-h2xr-h5nx](https://packagist.org/security-advisories/PKSA-8kk8-h2xr-h5nx)
 * [PKSA-2rbx-bjdx-4d4d](https://packagist.org/security-advisories/PKSA-2rbx-bjdx-4d4d)
 
-This packages version requires minimal PHP 8.1. They're automatically updated if you use PHP 8.1 or higher.
+To use these packages in versions not affected by security vulnerabilities, PHP 8.1 is the minimum required version. 
+
+For projects meeting this requirement, you can update the packages with Composer.
 
 If you're using PHP 7.4 or 8.0, to do the [[= product_name =]] update, you have two options:
 
 #### Update PHP, the custom code, then the platform (recommended)
 
-Make sure to host on PHP 8.1 or higher.
-Migrate custom code to be compatible with PHP 8.1 or higher.
-You can optionally use [Rector](https://github.com/rectorphp/rector) to help yourself.
+Make sure to use on PHP 8.1 or higher.
+Migrate custom code to be compatible with PHP 8.1 or higher, for example by using [Rector](https://github.com/rectorphp/rector).
 Then, update Ibexa DXP.
 
 #### Implement other countermeasures
 
-If updating the Twig packages isn't possible, for example, because the project is using PHP 7.4 or 8.0 where the fix is not available, and you need time to migrate while urgently needing v5.0.8 features, review the security issues carefully and assess the danger.
+If updating the Twig packages isn't possible, for example, because the project is using PHP 7.4 or 8.0 where the fixes are not available, review the security issues carefully and assess the danger.
 
 If you choose to implement countermeasures without upgrading PHP and updating Twig, you can silence the advisories in `composer.json`:
 
@@ -737,7 +738,7 @@ If you choose to implement countermeasures without upgrading PHP and updating Tw
 }
 ```
 
-In addition, consider upgrading your project to one of [the actively supported PHP versions](/getting_started/requirements.md#php).
+In addition, consider upgrading your project to one of [the actively supported PHP versions](requirements.md#php).
 
 ## LTS Updates
 

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -713,9 +713,6 @@ If you choose to implement countermeasures without upgrading PHP and updating Tw
 "config": {
     "audit": {
         "ignore": {
-            "GHSA-68jq-c3rv-pcrr": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
-            "GHSA-fc86-6rv6-2jpm": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
-            "GHSA-r7cg-qjjm-xhqq": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
             "PKSA-5k7f-wvjj-jrgw": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
             "PKSA-sjvz-tbbr-vwth": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",
             "PKSA-h8hf-ytnd-5t9q": "Description of the countermeasures you've implemented causing this one to be safe to ignore.",

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -668,10 +668,32 @@ Run the provided SQL upgrade script to update your database:
 
 ### Update Twig to v3.26.0
 
-It's highly recommenced to update `twig/twig` and `twig/intl-extra` to version v3.26.0 for security issues.
-This packages requires minimal PHP 8.1. They're automatically updated if you use PHP 8.1 or higher.
+It's highly recommenced to update `twig/twig` and `twig/intl-extra` to version v3.26.0 or higher for security issues.
 
-If you're using PHP 7.4 or 8.0, to do the [[= product_name =]] update, you have to options:
+* [GHSA-68jq-c3rv-pcrr](https://packagist.org/security-advisories/GHSA-68jq-c3rv-pcrr)
+* [GHSA-fc86-6rv6-2jpm](https://packagist.org/security-advisories/GHSA-fc86-6rv6-2jpm)
+* [GHSA-r7cg-qjjm-xhqq](https://packagist.org/security-advisories/GHSA-r7cg-qjjm-xhqq)
+* [PKSA-5k7f-wvjj-jrgw](https://packagist.org/security-advisories/PKSA-5k7f-wvjj-jrgw)
+* [PKSA-sjvz-tbbr-vwth](https://packagist.org/security-advisories/PKSA-sjvz-tbbr-vwth)
+* [PKSA-h8hf-ytnd-5t9q](https://packagist.org/security-advisories/PKSA-h8hf-ytnd-5t9q)
+* [PKSA-wwb1-81rc-pd65](https://packagist.org/security-advisories/PKSA-wwb1-81rc-pd65)
+* [PKSA-hgmw-wn4d-hpcy](https://packagist.org/security-advisories/PKSA-hgmw-wn4d-hpcy)
+* [PKSA-kvv6-36cr-fkzb](https://packagist.org/security-advisories/PKSA-kvv6-36cr-fkzb)
+* [PKSA-n14z-jjjg-g8vd](https://packagist.org/security-advisories/PKSA-n14z-jjjg-g8vd)
+* [PKSA-3mcc-k66d-pydb](https://packagist.org/security-advisories/PKSA-3mcc-k66d-pydb)
+* [PKSA-gw7n-z4yx-7xjt](https://packagist.org/security-advisories/PKSA-gw7n-z4yx-7xjt)
+* [PKSA-dpx1-78wg-1kqs](https://packagist.org/security-advisories/PKSA-dpx1-78wg-1kqs)
+* [PKSA-21g2-dzjv-sky5](https://packagist.org/security-advisories/PKSA-21g2-dzjv-sky5)
+* [PKSA-yhcn-xrg3-68b1](https://packagist.org/security-advisories/PKSA-yhcn-xrg3-68b1)
+* [PKSA-2wrf-1xmk-1pky](https://packagist.org/security-advisories/PKSA-2wrf-1xmk-1pky)
+* [PKSA-6319-ffpf-gx66](https://packagist.org/security-advisories/PKSA-6319-ffpf-gx66)
+* [PKSA-n7sg-8f52-pqtf](https://packagist.org/security-advisories/PKSA-n7sg-8f52-pqtf)
+* [PKSA-8kk8-h2xr-h5nx](https://packagist.org/security-advisories/PKSA-8kk8-h2xr-h5nx)
+* [PKSA-2rbx-bjdx-4d4d](https://packagist.org/security-advisories/PKSA-2rbx-bjdx-4d4d)
+
+This packages version requires minimal PHP 8.1. They're automatically updated if you use PHP 8.1 or higher.
+
+If you're using PHP 7.4 or 8.0, to do the [[= product_name =]] update, you have two options:
 
 #### Update PHP, the custom code, then the platform (recommended)
 

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -664,6 +664,10 @@ Run the provided SQL upgrade script to update your database:
     psql <database_name> < vendor/ibexa/installer/upgrade/db/postgresql/ibexa-4.6.28-to-4.6.29.sql
     ```
 
+## v4.6.30
+
+No additional steps needed.
+
 ## LTS Updates
 
 [LTS Updates](https://doc.ibexa.co/en/4.6/ibexa_products/editions/#lts-updates) are standalone packages with their own update procedures.

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -503,9 +503,3 @@ To use the [latest features](ibexa_dxp_v5.0.md) added to them, update them separ
     ```bash
     composer require ibexa/fieldtype-richtext-rte:[[= latest_tag_5_0 =]] ibexa/ckeditor-premium:[[= latest_tag_5_0 =]]
     ```
-
-=== "Shopping list"
-
-    ### Shopping list [[% include 'snippets/lts-update_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
-
-    To learn more about the [Shopping list](shopping_list_guide.md), see the [installation and configuration instructions](install_shopping_list.md).

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -453,7 +453,7 @@ Run the provided SQL upgrade script to update your database:
 ### VCL configuration
 
 Update your [Varnish VCL file](reverse_proxy.md#vcl-base-files) to align with the one from [`vendor/ibexa/http-cache/docs/varnish/vcl/`](https://github.com/ibexa/http-cache/tree/v5.0.8/docs/varnish/vcl).
-Especially if you plan to use the [Anonymous user segmentation in Ibexa CDP](https://doc.ibexa.co/en/5.0/cdp/cdp_activation/cdp_configuration/#anonymous-user-segmentation).
+Especially if you plan to use the [Anonymous user segmentation in [[= product_name_cdp =]]](https://doc.ibexa.co/en/5.0/cdp/cdp_activation/cdp_configuration/#anonymous-user-segmentation).
 Make sure it contains the highlighted addition:
 
 ``` vcl hl_lines="2 3"

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -452,8 +452,8 @@ Run the provided SQL upgrade script to update your database:
 
 ### VCL configuration
 
-Update your [Varnish VCL file](reverse_proxy.md#vcl-base-files) to align with the one from [`vendor/ibexa/http-cache/docs/varnish/vcl/`](https://github.com/ibexa/http-cache/tree/v5.0.8/docs/varnish/vcl).
-Especially if you plan to use the [Anonymous user segmentation in [[= product_name_cdp =]]](https://doc.ibexa.co/en/5.0/cdp/cdp_activation/cdp_configuration/#anonymous-user-segmentation).
+When using Varnish or Fastly, update your [VCL files](reverse_proxy.md#vcl-base-files) to align with the ones from [`vendor/ibexa/http-cache/docs/varnish/vcl/`](https://github.com/ibexa/http-cache/tree/v5.0.8/docs/varnish/vcl) or `vendor/ibexa/fastly/fastly/`,
+especially if you plan to use the [Anonymous user segmentation in [[= product_name_cdp =]]](https://doc.ibexa.co/en/5.0/cdp/cdp_activation/cdp_configuration/#anonymous-user-segmentation).
 Make sure it contains the highlighted addition:
 
 ``` vcl hl_lines="2 3"

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -448,7 +448,6 @@ Run the provided SQL upgrade script to update your database:
     psql <database_name> < vendor/ibexa/installer/upgrade/db/postgresql/ibexa-5.0.6-to-5.0.7.sql
     ```
 
-
 ## v5.0.8
 
 ### VCL configuration

--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -448,6 +448,22 @@ Run the provided SQL upgrade script to update your database:
     psql <database_name> < vendor/ibexa/installer/upgrade/db/postgresql/ibexa-5.0.6-to-5.0.7.sql
     ```
 
+
+## v5.0.8
+
+### VCL configuration
+
+Update your [Varnish VCL file](reverse_proxy.md#vcl-base-files) to align with the one from [`vendor/ibexa/http-cache/docs/varnish/vcl/`](https://github.com/ibexa/http-cache/tree/v5.0.8/docs/varnish/vcl).
+Especially if you plan to use the [Anonymous user segmentation in Ibexa CDP](https://doc.ibexa.co/en/5.0/cdp/cdp_activation/cdp_configuration/#anonymous-user-segmentation).
+Make sure it contains the highlighted addition:
+
+``` vcl hl_lines="2 3"
+        set req.http.cookie = regsuball(req.http.cookie, ";(ibexa[-_][^=]*)=", "; \1=");
+        // Keep the Raptor anonymous visitor identifier cookie so CDP segmentation can resolve visitor segments.
+        set req.http.cookie = regsuball(req.http.cookie, ";(rsa)=", "; \1=");
+        set req.http.cookie = regsuball(req.http.cookie, ";[^ ][^;]*", "");
+```
+
 ## LTS Updates and additional packages
 
 [LTS Updates](editions.md#lts-updates) are standalone packages with their own update procedures.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1029,8 +1029,8 @@ extra:
   latest_tag_4_3: '4.3.5'
   latest_tag_4_4: '4.4.4'
   latest_tag_4_5: '4.5.7'
-  latest_tag_4_6: '4.6.29'
-  latest_tag_5_0: '5.0.7'
+  latest_tag_4_6: '4.6.30'
+  latest_tag_5_0: '5.0.8'
 
   symfony_doc: 'https://symfony.com/doc/7.4'
   user_doc: 'https://doc.ibexa.co/projects/userguide/en/5.0'


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | N/A
| Versions      | v5.0.8, v4.6.30
| Edition       | All

- Increase `latest_tag_5_0` and `latest_tag_4_6` to update standard instructions
- [Update from v5.0.7 to v5.0.8 instructions](https://ez-systems-developer-documentation--3220.com.readthedocs.build/en/3220/update_and_migration/from_5.0/update_from_5.0/#v508)
    - VCL files ibexa/http-cache#81
    - nothing else found yet
        - nothing in https://github.com/ibexa/installer/tree/5.0/upgrade/db/mysql on May 21st 10:15
- Remove Shopping List from "LTS Updates and additional packages" tabs (no change since first release, wasn't useful there in the 1st place)
- [Update from v4.6.29 to v4.6.30 instructions](https://ez-systems-developer-documentation--3220.com.readthedocs.build/en/3220/update_and_migration/from_4.6/update_from_4.6/#v4630)
    - Twig security advisories and PHP version
    - nothing else found yet
        - nothing in https://github.com/ibexa/installer/tree/4.6/upgrade/db/mysql on May 21st 10:15

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
