### PR TITLE
API Ref: Fix computed Git reference 

### DIFF
--- a/tools/api_refs/api_refs.sh
+++ b/tools/api_refs/api_refs.sh
@@ -102,6 +102,8 @@ fi;
 
 if [[ "$DXP_VERSION" == *".x-dev" ]]; then
   GIT_REF=$BASE_DXP_BRANCH;
+elif [[ "$DXP_VERSION" == "v"* ]]; then
+  GIT_REF="$DXP_VERSION";
 else
   GIT_REF="v$DXP_VERSION";
 fi


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

#3173 added a "v" in front of exact version that wasn't supported, see https://github.com/ibexa/documentation-developer/actions/runs/26269554588/job/77319911585#step:8:1038

Fix: To ease usage, allow this "v"

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
