### PR TITLE
api_refs.sh: rm images dir

### DIFF
--- a/tools/api_refs/api_refs.sh
+++ b/tools/api_refs/api_refs.sh
@@ -191,7 +191,7 @@ fi;
 $PHP_BINARY $PHPDOC_BIN -t php_api_reference;
 if [ $? -eq 0 ]; then
   echo -n 'Remove unneeded from phpDocumentor output… ';
-  rm -rf ./php_api_reference/files ./php_api_reference/graphs ./php_api_reference/indices ./php_api_reference/packages;
+  rm -rf ./php_api_reference/files ./php_api_reference/graphs ./php_api_reference/images ./php_api_reference/indices ./php_api_reference/packages;
   rm -f ./php_api_reference/classes/Symfony-*.html ./php_api_reference/namespaces/symfony*.html
   echo -n 'Remove Symfony namespace from index… ';
   awk 'NR==FNR{if (/.*"fqsen": "\\\\Symfony.*/) for (i=-1;i<=3;i++) del[NR+i]; next} !(FNR in del)' \


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Remove `php_api_reference/images` directory added in phpDocumentor v3.10.0 which we use since #3213

https://github.com/phpDocumentor/phpDocumentor/tree/v3.10.0/data/templates/default/images

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
