### PR TITLE
Update 4.6 & 3.3 PHP requirements

### DIFF
--- a/docs/getting_started/install_ibexa_dxp.md
+++ b/docs/getting_started/install_ibexa_dxp.md
@@ -114,7 +114,7 @@ This operation is performed only once, when you install [[= product_name =]] for
 
 To use Composer to instantly create a project in the current folder with all the dependencies, run the following command:
 
-!!! note "Using PHP 8.4 or 8.3"
+!!! note "Using PHP 8.3"
 
     === "[[= product_name_headless =]]"
 
@@ -134,9 +134,9 @@ To use Composer to instantly create a project in the current folder with all the
         composer create-project ibexa/commerce-skeleton .
         ```
 
-??? note "Using PHP versions 8.2 or 8.1"
+??? note "Using PHP versions other than 8.3"
 
-    If you are using PHP 8.4 (recommended), 8.2, or 8.1 (not recommended as has reached End of Life), use a different set of commands:
+    If you aren't using PHP 8.3 but are using PHP 8.4, PHP 8.2, or any older version, use a different set of commands:
 
     === "[[= product_name_headless =]]"
 
@@ -156,97 +156,6 @@ To use Composer to instantly create a project in the current folder with all the
 
         ``` bash
         composer create-project ibexa/commerce-skeleton --no-install .
-        composer update
-        ```
-
-??? note "Using PHP versions 8.0 or older"
-
-    If you aren't using PHP 8.1 or higher, but are using PHP 8.0 or 7.4 (disrecommended as both have reached End of Life), use a different set of commands to ignore security advisories:
-
-    === "[[= product_name_headless =]]"
-
-        ``` bash
-        composer create-project ibexa/headless-skeleton --no-install .
-        composer config audit.ignore --json '{
-            "GHSA-68jq-c3rv-pcrr": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "GHSA-fc86-6rv6-2jpm": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "GHSA-r7cg-qjjm-xhqq": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-5k7f-wvjj-jrgw": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-sjvz-tbbr-vwth": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-h8hf-ytnd-5t9q": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-wwb1-81rc-pd65": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-hgmw-wn4d-hpcy": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-kvv6-36cr-fkzb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-n14z-jjjg-g8vd": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-3mcc-k66d-pydb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-gw7n-z4yx-7xjt": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-dpx1-78wg-1kqs": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-21g2-dzjv-sky5": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-yhcn-xrg3-68b1": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-2wrf-1xmk-1pky": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-6319-ffpf-gx66": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-n7sg-8f52-pqtf": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-8kk8-h2xr-h5nx": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-2rbx-bjdx-4d4d": "As this is for code quality tests and not to run a production DXP, this can be ignored."
-        }'
-        composer update
-        ```
-
-    === "[[= product_name_exp =]]"
-
-        ``` bash
-        composer create-project ibexa/experience-skeleton --no-install .
-        composer config audit.ignore --json '{
-            "GHSA-68jq-c3rv-pcrr": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "GHSA-fc86-6rv6-2jpm": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "GHSA-r7cg-qjjm-xhqq": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-5k7f-wvjj-jrgw": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-sjvz-tbbr-vwth": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-h8hf-ytnd-5t9q": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-wwb1-81rc-pd65": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-hgmw-wn4d-hpcy": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-kvv6-36cr-fkzb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-n14z-jjjg-g8vd": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-3mcc-k66d-pydb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-gw7n-z4yx-7xjt": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-dpx1-78wg-1kqs": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-21g2-dzjv-sky5": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-yhcn-xrg3-68b1": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-2wrf-1xmk-1pky": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-6319-ffpf-gx66": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-n7sg-8f52-pqtf": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-8kk8-h2xr-h5nx": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-2rbx-bjdx-4d4d": "As this is for code quality tests and not to run a production DXP, this can be ignored."
-        }'
-        composer update
-        ```
-
-    === "[[= product_name_com =]]"
-
-        ``` bash
-        composer create-project ibexa/commerce-skeleton --no-install .
-        composer config audit.ignore --json '{
-            "GHSA-68jq-c3rv-pcrr": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "GHSA-fc86-6rv6-2jpm": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "GHSA-r7cg-qjjm-xhqq": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-5k7f-wvjj-jrgw": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-sjvz-tbbr-vwth": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-h8hf-ytnd-5t9q": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-wwb1-81rc-pd65": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-hgmw-wn4d-hpcy": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-kvv6-36cr-fkzb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-n14z-jjjg-g8vd": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-3mcc-k66d-pydb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-gw7n-z4yx-7xjt": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-dpx1-78wg-1kqs": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-21g2-dzjv-sky5": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-yhcn-xrg3-68b1": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-2wrf-1xmk-1pky": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-6319-ffpf-gx66": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-n7sg-8f52-pqtf": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-8kk8-h2xr-h5nx": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
-            "PKSA-2rbx-bjdx-4d4d": "As this is for code quality tests and not to run a production DXP, this can be ignored."
-        }'
         composer update
         ```
 

--- a/docs/getting_started/install_ibexa_dxp.md
+++ b/docs/getting_started/install_ibexa_dxp.md
@@ -134,9 +134,9 @@ To use Composer to instantly create a project in the current folder with all the
         composer create-project ibexa/commerce-skeleton .
         ```
 
-??? note "Using PHP versions other than 8.3"
+??? note "Using PHP versions 8.4, 8.2, or 8.1"
 
-    If you aren't using PHP 8.3 but are using PHP 8.4, PHP 8.2, or any older version, use a different set of commands:
+    If you are using PHP 8.4 (recommended), 8.2, or 8.1 (not recommended as has reached End of Life), use a different set of commands:
 
     === "[[= product_name_headless =]]"
 
@@ -156,6 +156,97 @@ To use Composer to instantly create a project in the current folder with all the
 
         ``` bash
         composer create-project ibexa/commerce-skeleton --no-install .
+        composer update
+        ```
+
+??? note "Using PHP versions 8.0 or older"
+
+    If you aren't using PHP 8.1 or higher, but are using PHP 8.0 or 7.4 (disrecommended as both have reached End of Life), use a different set of commands to ignore security advisories:
+
+    === "[[= product_name_headless =]]"
+
+        ``` bash
+        composer create-project ibexa/headless-skeleton --no-install .
+        composer config audit.ignore --json '{
+            "GHSA-68jq-c3rv-pcrr": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "GHSA-fc86-6rv6-2jpm": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "GHSA-r7cg-qjjm-xhqq": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-5k7f-wvjj-jrgw": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-sjvz-tbbr-vwth": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-h8hf-ytnd-5t9q": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-wwb1-81rc-pd65": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-hgmw-wn4d-hpcy": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-kvv6-36cr-fkzb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-n14z-jjjg-g8vd": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-3mcc-k66d-pydb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-gw7n-z4yx-7xjt": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-dpx1-78wg-1kqs": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-21g2-dzjv-sky5": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-yhcn-xrg3-68b1": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-2wrf-1xmk-1pky": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-6319-ffpf-gx66": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-n7sg-8f52-pqtf": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-8kk8-h2xr-h5nx": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-2rbx-bjdx-4d4d": "As this is for code quality tests and not to run a production DXP, this can be ignored."
+        }'
+        composer update
+        ```
+
+    === "[[= product_name_exp =]]"
+
+        ``` bash
+        composer create-project ibexa/experience-skeleton --no-install .
+        composer config audit.ignore --json '{
+            "GHSA-68jq-c3rv-pcrr": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "GHSA-fc86-6rv6-2jpm": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "GHSA-r7cg-qjjm-xhqq": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-5k7f-wvjj-jrgw": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-sjvz-tbbr-vwth": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-h8hf-ytnd-5t9q": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-wwb1-81rc-pd65": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-hgmw-wn4d-hpcy": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-kvv6-36cr-fkzb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-n14z-jjjg-g8vd": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-3mcc-k66d-pydb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-gw7n-z4yx-7xjt": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-dpx1-78wg-1kqs": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-21g2-dzjv-sky5": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-yhcn-xrg3-68b1": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-2wrf-1xmk-1pky": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-6319-ffpf-gx66": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-n7sg-8f52-pqtf": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-8kk8-h2xr-h5nx": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-2rbx-bjdx-4d4d": "As this is for code quality tests and not to run a production DXP, this can be ignored."
+        }'
+        composer update
+        ```
+
+    === "[[= product_name_com =]]"
+
+        ``` bash
+        composer create-project ibexa/commerce-skeleton --no-install .
+        composer config audit.ignore --json '{
+            "GHSA-68jq-c3rv-pcrr": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "GHSA-fc86-6rv6-2jpm": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "GHSA-r7cg-qjjm-xhqq": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-5k7f-wvjj-jrgw": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-sjvz-tbbr-vwth": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-h8hf-ytnd-5t9q": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-wwb1-81rc-pd65": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-hgmw-wn4d-hpcy": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-kvv6-36cr-fkzb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-n14z-jjjg-g8vd": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-3mcc-k66d-pydb": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-gw7n-z4yx-7xjt": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-dpx1-78wg-1kqs": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-21g2-dzjv-sky5": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-yhcn-xrg3-68b1": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-2wrf-1xmk-1pky": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-6319-ffpf-gx66": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-n7sg-8f52-pqtf": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-8kk8-h2xr-h5nx": "As this is for code quality tests and not to run a production DXP, this can be ignored.",
+            "PKSA-2rbx-bjdx-4d4d": "As this is for code quality tests and not to run a production DXP, this can be ignored."
+        }'
         composer update
         ```
 

--- a/docs/getting_started/install_ibexa_dxp.md
+++ b/docs/getting_started/install_ibexa_dxp.md
@@ -114,7 +114,7 @@ This operation is performed only once, when you install [[= product_name =]] for
 
 To use Composer to instantly create a project in the current folder with all the dependencies, run the following command:
 
-!!! note "Using PHP 8.3"
+!!! note "Using PHP 8.4 or 8.3"
 
     === "[[= product_name_headless =]]"
 
@@ -134,7 +134,7 @@ To use Composer to instantly create a project in the current folder with all the
         composer create-project ibexa/commerce-skeleton .
         ```
 
-??? note "Using PHP versions 8.4, 8.2, or 8.1"
+??? note "Using PHP versions 8.2 or 8.1"
 
     If you are using PHP 8.4 (recommended), 8.2, or 8.1 (not recommended as has reached End of Life), use a different set of commands:
 

--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -136,8 +136,8 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
     - 8.3
     - 8.2
     - 8.1 (PHP 8.1 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
-    - 8.0 (PHP 8.0 has reached its End of Life. Several Symfony dependencies security fixes are not available. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
-    - 7.4 (PHP 7.4 has reached its End of Life. Several Symfony dependencies security fixes are not available. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 8.0 (PHP 8.0 has reached its End of Life. Security fixes for several Symfony dependencies are not available. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.4 (PHP 7.4 has reached its End of Life. Security fixes for several Symfony dependencies are not available. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
 
 === "[[= product_name =]] v3.3"
 

--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -136,8 +136,8 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
     - 8.3
     - 8.2
     - 8.1 (PHP 8.1 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
-    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
-    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 8.0 (PHP 8.0 has reached its End of Life. Several Symfony dependencies security fixes are not available. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.4 (PHP 7.4 has reached its End of Life. Several Symfony dependencies security fixes are not available. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
 
 === "[[= product_name =]] v3.3"
 

--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -143,10 +143,10 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
 
     - 8.3
     - 8.2
-    - 8.1
-    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
-    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
-    - 7.3 (PHP 7.3 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.1)
+    - 8.1 (PHP 8.1 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 8.0 (PHP 8.0 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.4 (PHP 7.4 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
+    - 7.3 (PHP 7.3 has reached its End of Life. Unless you have extended support from vendors like Debian or Zend, you should use PHP 8.2)
 
 ### PHP extensions
 

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -698,7 +698,7 @@ If you're using PHP 7.4 or 8.0, to do the [[= product_name =]] update, you have 
 
 #### Update PHP, the custom code, then the platform (recommended)
 
-Make sure to use PHP 8.1 minimum. Notice that PHP 8.1 has reached its End of Life so you should consider using PHP 8.2 or higher.
+Make sure to use PHP 8.1 or higher. Since PHP 8.1 has reached its End of Life (EOL), it's recommended that you use PHP 8.2 or higher.
 Migrate custom code to be compatible with PHP 8.1 or higher, for example by using [Rector](https://github.com/rectorphp/rector).
 Then, update Ibexa DXP.
 

--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -698,7 +698,7 @@ If you're using PHP 7.4 or 8.0, to do the [[= product_name =]] update, you have 
 
 #### Update PHP, the custom code, then the platform (recommended)
 
-Make sure to use on PHP 8.1 or higher.
+Make sure to use PHP 8.1 minimum. Notice that PHP 8.1 has reached its End of Life so you should consider using PHP 8.2 or higher.
 Migrate custom code to be compatible with PHP 8.1 or higher, for example by using [Rector](https://github.com/rectorphp/rector).
 Then, update Ibexa DXP.
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

- Disrecommend PHP 8.1 and older because End of Life

Previews:

- "Requirements" > "PHP" > "Ibexa DXP v4.6" tab (note about missing security fixes) and "Ibexa DXP v3.3" tab (update about PHP 8.1 life discontinuation)
    - [old](https://doc.ibexa.co/en/4.6/getting_started/requirements/#php)
    - [new](https://ez-systems-developer-documentation--3234.com.readthedocs.build/en/3234/getting_started/requirements/#php)
- "Update from v4.6.x to v4.6.latest" > "v4.6.30" > "Update PHP, the custom code, then the platform (recommended)" (insist on PHP 8.1 being supported but not recommended)
    - [old](https://doc.ibexa.co/en/4.6/update_and_migration/from_4.6/update_from_4.6/#update-php-the-custom-code-then-the-platform-recommended)
    - [new](https://ez-systems-developer-documentation--3234.com.readthedocs.build/en/3234/update_and_migration/from_4.6/update_from_4.6/#update-php-the-custom-code-then-the-platform-recommended)


#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
