### PR TITLE
Fixed elasticsearch8 composer command for 4.6

### DIFF
--- a/docs/update_and_migration/from_4.6/update_from_4.6.md
+++ b/docs/update_and_migration/from_4.6/update_from_4.6.md
@@ -466,7 +466,7 @@ To use Elasticsearch 8, follow these steps:
 Replace the existing Elasticsearch package and install Elasticsearch 8:
 
 ```bash
-composer require ibexa/elasticsearch8:[[= latest_tag_4_6 =]]
+composer require ibexa/elasticsearch8:[[= latest_tag_4_6 =]] --with-all-dependencies
 ```
 
 #### Update Elasticsearch server


### PR DESCRIPTION
`composer require ibexa/elasticsearch8:4.6.30` will respond with:

```
- ibexa/elasticsearch8[v4.0.0, ..., v4.6.26, v5.0.0, ..., v5.0.5]
cannot be installed as that would require removing ibexa/elasticsearch[v4.6.30].
They all replace ezsystems/ezplatform-elastic-search-engine and thus cannot coexist
```
