### PR TITLE
New in the doc: May 2026

### DIFF
--- a/docs/administration/back_office/configure_product_tour.md
+++ b/docs/administration/back_office/configure_product_tour.md
@@ -1,7 +1,7 @@
 ---
 description: Configure custom product tour scenarios with steps, blocks, and interaction modes.
 edition: lts-update
-month_change: true
+month_change: false
 ---
 
 # Configure product tour scenarios

--- a/docs/administration/back_office/customize_product_tour.md
+++ b/docs/administration/back_office/customize_product_tour.md
@@ -1,7 +1,7 @@
 ---
 description: Customize product tour scenarios with custom event listeners
 edition: lts-update
-month_change: true
+month_change: false
 ---
 
 # Customize scenarios with PHP code

--- a/docs/administration/back_office/integrated_help.md
+++ b/docs/administration/back_office/integrated_help.md
@@ -1,7 +1,7 @@
 ---
 description: Integrated help provides quick access to documentation, training, and support resources.
 edition: lts-update
-month_change: true
+month_change: false
 ---
 
 # Integrated help

--- a/docs/administration/back_office/notifications.md
+++ b/docs/administration/back_office/notifications.md
@@ -1,6 +1,6 @@
 ---
 description: You can send notifications to users who work with the back office by using notification bars or notifications in the user menu.
-month_change: false
+month_change: true
 ---
 
 # Notifications

--- a/docs/administration/back_office/product_tour.md
+++ b/docs/administration/back_office/product_tour.md
@@ -1,7 +1,7 @@
 ---
 description: Product tours provide interactive guided walkthroughs to help users learn Ibexa DXP features.
 edition: lts-update
-month_change: true
+month_change: false
 ---
 
 # Product tour

--- a/docs/api/event_reference/integrated_help_events.md
+++ b/docs/api/event_reference/integrated_help_events.md
@@ -2,7 +2,7 @@
 description: Events that are triggered when working with integrated help features like product tours.
 edition: lts-update
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Integrated help events

--- a/docs/api/event_reference/product_catalog_events.md
+++ b/docs/api/event_reference/product_catalog_events.md
@@ -1,7 +1,7 @@
 ---
 description: Events that are triggered when working with products, prices, currencies, and attribute rendering.
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Product catalog events

--- a/docs/getting_started/install_with_ddev.md
+++ b/docs/getting_started/install_with_ddev.md
@@ -1,5 +1,6 @@
 ---
 description: Install Ibexa DXP with Docker and DDEV to use it for development.
+month_change: true
 ---
 
 # Install with DDEV

--- a/docs/permissions/limitation_reference.md
+++ b/docs/permissions/limitation_reference.md
@@ -1,7 +1,7 @@
 ---
 description: Limitations let you fine-tune the permission system by specifying limits to roles granted to users.
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Limitation reference

--- a/docs/permissions/policies.md
+++ b/docs/permissions/policies.md
@@ -1,7 +1,7 @@
 ---
 description: Policies are the main building block of the permissions system which lets you define the accesses for specific user roles.
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Policies

--- a/docs/product_catalog/create_custom_availability_strategy.md
+++ b/docs/product_catalog/create_custom_availability_strategy.md
@@ -1,5 +1,6 @@
 ---
 description: Implement custom availability strategies to handle different business scenarios, for example pre-orders or per-region availability.
+month_change: true
 ---
 
 # Create custom availability strategy

--- a/docs/product_catalog/customize_product_attribute_templates.md
+++ b/docs/product_catalog/customize_product_attribute_templates.md
@@ -1,6 +1,6 @@
 ---
 description: Customize the Twig templates used to render product attribute values.
-month_change: true
+month_change: false
 ---
 
 # Customize product attribute templates

--- a/docs/product_catalog/customize_product_embed_templates.md
+++ b/docs/product_catalog/customize_product_embed_templates.md
@@ -1,6 +1,6 @@
 ---
 description: Customize the templates used to render products embedded in RichText fields.
-month_change: true
+month_change: false
 ---
 
 # Customize product embed templates

--- a/docs/product_catalog/product_api.md
+++ b/docs/product_catalog/product_api.md
@@ -1,6 +1,6 @@
 ---
 description: Use PHP API to manage products in PIM, their attributes, availability, and prices.
-month_change: false
+month_change: true
 ---
 
 # Product API

--- a/docs/product_catalog/product_catalog.md
+++ b/docs/product_catalog/product_catalog.md
@@ -1,7 +1,7 @@
 ---
 description: Ibexa DXP provides product catalog capabilities for managing products, product types, variants, attributes, pricing, and catalogs.
 page_type: landing_page
-month_change: true
+month_change: false
 ---
 
 # Product Catalog

--- a/docs/product_catalog/products.md
+++ b/docs/product_catalog/products.md
@@ -1,6 +1,6 @@
 ---
 description: Products are characterized by attributes describing their characteristics. You can create product variants and add assets to each product and variant.
-month_change: false
+month_change: true
 ---
 
 # Products

--- a/docs/product_catalog/quable/configure_quable_connector.md
+++ b/docs/product_catalog/quable/configure_quable_connector.md
@@ -1,7 +1,7 @@
 ---
 description: Quable PIM connector configuration reference for Ibexa DXP
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Configure Quable connector

--- a/docs/product_catalog/quable/install_quable.md
+++ b/docs/product_catalog/quable/install_quable.md
@@ -1,6 +1,6 @@
 ---
 description: Install and configure Quable PIM connector for Ibexa DXP
-month_change: true
+month_change: false
 ---
 
 # Install Quable connector

--- a/docs/product_catalog/quable/quable.md
+++ b/docs/product_catalog/quable/quable.md
@@ -1,7 +1,7 @@
 ---
 description: Quable PIM integration with Ibexa DXP
 page_type: landing_page
-month_change: true
+month_change: false
 ---
 
 # Quable PIM Integration

--- a/docs/product_catalog/quable/quable_api.md
+++ b/docs/product_catalog/quable/quable_api.md
@@ -1,6 +1,6 @@
 ---
 description: Learn how to use PHP and REST APIs to retrieve product data from Quable
-month_change: true
+month_change: false
 ---
 
 

--- a/docs/product_catalog/quable/quable_guide.md
+++ b/docs/product_catalog/quable/quable_guide.md
@@ -1,6 +1,6 @@
 ---
 description: The Quable product guide describes how you can use the product data from Quable in Ibexa DXP to create marketing campaigns built around your products.
-month_change: true
+month_change: false
 ---
 
 # Quable product guide

--- a/docs/recommendations/raptor_integration/custom_recommendation_rendering.md
+++ b/docs/recommendations/raptor_integration/custom_recommendation_rendering.md
@@ -1,6 +1,6 @@
 ---
 description: Use existing controllers to render recommendations outside the Page Builder.
-month_change: true
+month_change: false
 ---
 
 # Custom recommendation rendering

--- a/docs/recommendations/raptor_integration/raptor_connector.md
+++ b/docs/recommendations/raptor_integration/raptor_connector.md
@@ -1,7 +1,7 @@
 ---
 description: Step-by-step activation procedure of setting up the Raptor connector.
 page_type: landing_page
-month_change: true
+month_change: false
 ---
 
 # Raptor connector

--- a/docs/recommendations/raptor_integration/raptor_connector_guide.md
+++ b/docs/recommendations/raptor_integration/raptor_connector_guide.md
@@ -1,6 +1,6 @@
 ---
 description:  Discover Raptor integration - an add-on focused on recommendations and tracking customer behaviors.
-month_change: true
+month_change: false
 ---
 
 # Raptor integration guide

--- a/docs/recommendations/raptor_integration/tracking_functions.md
+++ b/docs/recommendations/raptor_integration/tracking_functions.md
@@ -1,6 +1,6 @@
 ---
 description: Integrate the tracking script to collect user interactions.
-month_change: true
+month_change: false
 ---
 
 # Raptor tracking functions

--- a/docs/resources/new_in_doc.md
+++ b/docs/resources/new_in_doc.md
@@ -14,10 +14,9 @@ This page contains recent highlights and notable changes in [[= product_name =]]
 - [v5.0.8 release notes](https://doc.ibexa.co/en/5.0/release_notes/ibexa_dxp_v5.0/#ibexa-dxp-v508)
 - [v4.6.30 release notes](https://doc.ibexa.co/en/4.6/release_notes/ibexa_dxp_v4.6/#ibexa-dxp-v4630)
 
-### AI & MCP
+### AI
 
-- Added documentation for [MCP Servers](mcp.md)
-- Grouped [AI Actions](ai_actions.md) and MCP Servers under [AI](ai.md)
+- Grouped [AI Actions](ai_actions.md) and [MCP Servers](mcp.md) under [AI](ai.md)
 
 ### Search
 
@@ -42,6 +41,10 @@ This page contains recent highlights and notable changes in [[= product_name =]]
     - [`Ibexa\Contracts\ConnectorRaptor\Tracking\PageViewTrackerInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-PageViewTrackerInterface.html)
     - [`Ibexa\Contracts\Mcp`](/api/php_api/php_api_reference/namespaces/ibexa-contracts-mcp.html)
 
+### DDEV
+
+- Added how to [configure a mail catcher in DDEV](install_with_ddev.md#configure-mailer-optional) for email testing
+
 ## April 2026
 
 ### Releases
@@ -52,6 +55,11 @@ This page contains recent highlights and notable changes in [[= product_name =]]
 ### Configuration
 
 - Added trailing slashes to all `excluded_uri_prefixes` items to avoid collision with other URIs (for example, `/media` matches on both `/media` and `/mediation` while `/media/` only on `/media/`)
+
+### PHP API
+
+- [`Ibexa\Contracts\ConnectorRaptor`](/api/php_api/php_api_reference/namespaces/ibexa-contracts-connectorraptor.html)
+- [`Ibexa\Contracts\IntegratedHelp`](/api/php_api/php_api_reference/namespaces/ibexa-contracts-integratedhelp.html)
 
 ## March 2026
 

--- a/docs/resources/new_in_doc.md
+++ b/docs/resources/new_in_doc.md
@@ -7,6 +7,31 @@ month_change: true
 
 This page contains recent highlights and notable changes in [[= product_name =]] documentation.
 
+## May 2026
+
+### Releases
+
+- [v5.0.8 release notes](https://doc.ibexa.co/en/5.0/release_notes/ibexa_dxp_v5.0/#ibexa-dxp-v508)
+- [v4.6.30 release notes](https://doc.ibexa.co/en/4.6/release_notes/ibexa_dxp_v4.6/#ibexa-dxp-v4630)
+
+### AI & MCP
+
+- Added documentation for [MCP Servers](mcp.md)
+- Grouped [AI Actions](ai_actions.md) and MCP Servers under [AI](ai.md)
+
+### Search
+
+- Documented how to [disable the total count in search results](search_api.md#disable-result-count)
+
+### Notifications
+
+- Covered the [notification channels](notification_channels.md) feature from `ibexa/notifications` package
+- Revamped the [back office notifications documentation](notifications.md)
+
+### HTTP Cache
+
+- Listed the [value types supported by the response taggers](content_aware_cache.md#delegator-and-value-taggers)
+
 ## April 2026
 
 ### Releases

--- a/docs/resources/new_in_doc.md
+++ b/docs/resources/new_in_doc.md
@@ -32,6 +32,16 @@ This page contains recent highlights and notable changes in [[= product_name =]]
 
 - Listed the [value types supported by the response taggers](content_aware_cache.md#delegator-and-value-taggers)
 
+### PHP API
+
+- Enhanced the PHP API reference with the following new classes and namespaces:
+    - [`Ibexa\Contracts\Cdp\Exception\MembershipApiException`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-Cdp-Exception-MembershipApiException.html)
+    - [`Ibexa\Contracts\Cdp\Membership`](/api/php_api/php_api_reference/namespaces/ibexa-contracts-cdp-membership.html)
+    - [`Ibexa\Contracts\ConnectorRaptor\Message\TrackServerSideEventMessage`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Message-TrackServerSideEventMessage.html)
+    - [`Ibexa\Contracts\ConnectorRaptor\Tracking\Event\PageViewEventData`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-Event-PageViewEventData.html)
+    - [`Ibexa\Contracts\ConnectorRaptor\Tracking\PageViewTrackerInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-ConnectorRaptor-Tracking-PageViewTrackerInterface.html)
+    - [`Ibexa\Contracts\Mcp`](/api/php_api/php_api_reference/namespaces/ibexa-contracts-mcp.html)
+
 ## April 2026
 
 ### Releases

--- a/docs/search/criteria_reference/product_search_criteria.md
+++ b/docs/search/criteria_reference/product_search_criteria.md
@@ -1,7 +1,7 @@
 ---
 description: Product Search Criteria
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Product Search Criteria reference

--- a/docs/search/criteria_reference/productavailability_criterion.md
+++ b/docs/search/criteria_reference/productavailability_criterion.md
@@ -1,5 +1,6 @@
 ---
 description: ProductAvailability Search Criterion
+month_change: true
 ---
 
 # ProductAvailability Criterion

--- a/docs/search/criteria_reference/productcategorysubtree_criterion.md
+++ b/docs/search/criteria_reference/productcategorysubtree_criterion.md
@@ -1,6 +1,6 @@
 ---
 description: ProductCategorySubtree Search Criterion
-month_change: true
+month_change: false
 ---
 
 # ProductCategorySubtree Criterion

--- a/docs/search/criteria_reference/updated_at_criterion.md
+++ b/docs/search/criteria_reference/updated_at_criterion.md
@@ -1,6 +1,6 @@
 ---
 description: UpdatedAt Search Criterion
-month_change: true
+month_change: false
 ---
 
 # UpdatedAt Criterion

--- a/docs/search/criteria_reference/updated_at_range_criterion.md
+++ b/docs/search/criteria_reference/updated_at_range_criterion.md
@@ -1,6 +1,6 @@
 ---
 description: UpdatedAtRange Search Criterion
-month_change: true
+month_change: false
 ---
 
 # UpdatedAtRange Criterion

--- a/docs/search/embeddings_reference/embeddings_reference.md
+++ b/docs/search/embeddings_reference/embeddings_reference.md
@@ -1,5 +1,5 @@
 ---
-month_change: true
+month_change: false
 description: Embedding queries, embedding configuration, providers, and embedding search fields
 ---
 

--- a/docs/templating/twig_function_reference/quable_twig_functions.md
+++ b/docs/templating/twig_function_reference/quable_twig_functions.md
@@ -1,7 +1,7 @@
 ---
 description: Twig functions exposed by the Quable connector.
 page_type: reference
-month_change: true
+month_change: false
 ---
 
 # Quable Twig functions


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | 5.0, 4.6
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Add May 2026 changes since #3138 based on dafaa48547e13b8b928dcd1a0527aa7443c8c63d...6e6946a4dfbefa579a2067c679a9f9a7f636391d

- Releases as main change
- Then changes that aren't coming from the releases

April 2026 PHP API summary was missing

Preview: https://ez-systems-developer-documentation--3242.com.readthedocs.build/en/3242/resources/new_in_doc/

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
