### PR TITLE
Removed memory session type

### DIFF
--- a/code_samples/mcp/mcp.matrix.yaml
+++ b/code_samples/mcp/mcp.matrix.yaml
@@ -11,7 +11,7 @@ ibexa:
                         - Ibexa\Mcp\Tool\SeoTools
                     discovery_cache: <cache_pool_service>
                     session:
-                        type: <psr16|file|memory>
+                        type: <psr16|file>
                         # Session options…
                 mcp_psr16:
                     discovery_cache: cache.redis.mcp


### PR DESCRIPTION
Memory type was removed in https://github.com/ibexa/mcp/pull/9 - and most mentions were removed in http://github.com/ibexa/documentation-developer/pull/3106/commits/4365ea317f15ac3be8827139fda409ff2d4dad81 , this seems like a leftover.