### PR TITLE
PHP API Reference: Move from `main` to `5.0` in source links

### DIFF
--- a/tools/api_refs/.phpdoc/template/components/source.html.twig
+++ b/tools/api_refs/.phpdoc/template/components/source.html.twig
@@ -7,7 +7,7 @@
         {% set path = node.file.path|split('/', 4) %}
         {% set package = path|slice(1, 2)|join('/') %}
         {% if package_edition_map[package] is defined and 'oss' == package_edition_map[package] %}
-            {% set href = 'https://github.com/' ~ package ~ '/blob/main/' ~ path[3] %}
+            {% set href = 'https://github.com/' ~ package ~ '/blob/5.0/' ~ path[3] %}
         {% endif %}
     {% endif %}
     <a href="{{ href }}" title="" class="source-github">


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

For example, on https://doc.ibexa.co/en/5.0/api/php_api/php_api_reference/classes/Ibexa-Contracts-Core-FieldType-FieldType.html the View on GitHub link is leading to 404

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
