### PR TITLE
Prevent double "v' in the GIT_REF

### DIFF
--- a/tools/php_api_ref/phpdoc.sh
+++ b/tools/php_api_ref/phpdoc.sh
@@ -85,7 +85,7 @@ fi;
 if [[ "$DXP_VERSION" == *".x-dev" ]]; then
   GIT_REF=$BASE_DXP_BRANCH;
 else
-  GIT_REF="v$DXP_VERSION";
+  GIT_REF="v${DXP_VERSION#v}";
 fi
 
 if [ 0 -eq $DXP_ALREADY_EXISTS ]; then


### PR DESCRIPTION
In https://github.com/ibexa/documentation-developer/actions/runs/28514590198/job/84523037702, the DXP Version is set to:

"    DXP_VERSION: v4.6.31"

Then, the "v" prefix is added to it, resulting in GIT_REF becoming "vv4.6.31".

The solution is to add the prefix only if it doesn't exist - so both v4.6.31 and 4.6.31 become "v4.6.31".
