### PR TITLE
[Composer] Added one command to run them all (checks)

### DIFF
--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -45,33 +45,9 @@ jobs:
               with:
                   dependency-versions: highest
 
-            - name: Run PHPStan analysis
+            - name: Run code sample quality tests
               id: phpstan
-              continue-on-error: true
-              run: composer phpstan
-
-            - name: Run Deptrac analysis
-              id: deptrac
-              continue-on-error: true
-              run: composer deptrac
-
-            - name: Run Rector check
-              id: rector
-              continue-on-error: true
-              run: composer check-rector
-
-            - name: Run YAML snippet tests
-              id: check-yaml
-              continue-on-error: true
-              run: composer check-yaml
-
-            - name: Fail job if any check failed
-              if: always()
-              run: |
-                  if [[ "${{ steps.phpstan.outcome }}" == "failure" || "${{ steps.deptrac.outcome }}" == "failure" || "${{ steps.rector.outcome }}" == "failure" || "${{ steps.check-yaml.outcome }}" == "failure" ]]; then
-                      echo "One or more checks failed: PHPStan=${{ steps.phpstan.outcome }}, Deptrac=${{ steps.deptrac.outcome }}, Rector=${{ steps.rector.outcome }}, YAML=${{ steps.check-yaml.outcome }}"
-                      exit 1
-                  fi
+              run: composer test
 
 
     code-samples-inclusion-check:

--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -47,7 +47,7 @@ jobs:
 
             - name: Run code sample quality tests
               id: phpstan
-              run: composer test
+              run: composer test --ansi
               env:
                   PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.php == '8.4' && '1' || '' }}
 

--- a/.github/workflows/code_samples.yaml
+++ b/.github/workflows/code_samples.yaml
@@ -48,6 +48,8 @@ jobs:
             - name: Run code sample quality tests
               id: phpstan
               run: composer test
+              env:
+                  PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.php == '8.4' && '1' || '' }}
 
 
     code-samples-inclusion-check:

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ composer phpstan
 ```
 
 Regenerate the baseline by running:
+
 ```bash
-composer phpstan -- --generate-baseline
+composer phpstan-update-baseline
 ```
 
 #### Skipping validation of inline PHP snippets
@@ -120,8 +121,9 @@ composer deptrac
 ```
 
 Regenerate the baseline by running:
+
 ```bash
-vendor/bin/deptrac --formatter=baseline
+composer deptrac-update-baseline
 ```
 
 ## Checking links

--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         ],
         "test": [
             "@composer-update",
-            "EXIT=0; composer check-cs || EXIT=1; composer phpstan || EXIT=1; composer deptrac || EXIT=1; composer check-rector || EXIT=1; composer markdownlint || EXIT=1; composer check-yaml || EXIT=1; exit $EXIT"
+            "EXIT=0; FAILED=''; { composer check-cs; } || { EXIT=1; FAILED="$FAILED check-cs"; }; { composer phpstan; } || { EXIT=1; FAILED="$FAILED phpstan"; }; { composer deptrac; } || { EXIT=1; FAILED="$FAILED deptrac"; }; { composer check-rector; } || { EXIT=1; FAILED="$FAILED check-rector"; }; { composer markdownlint; } || { EXIT=1; FAILED="$FAILED markdownlint"; }; { composer check-yaml; } || { EXIT=1;  FAILED="$FAILED markdownlint"; }; if [ 1 -eq $EXIT ]; then echo "Failed:$FAILED"; fi; exit $EXIT;"
         ],
         "fix": [
             "@composer-update",

--- a/composer.json
+++ b/composer.json
@@ -138,7 +138,7 @@
         ],
         "test": [
             "@composer-update",
-            "EXIT=0; FAILED=''; { composer check-cs; } || { EXIT=1; FAILED="$FAILED check-cs"; }; { composer phpstan; } || { EXIT=1; FAILED="$FAILED phpstan"; }; { composer deptrac; } || { EXIT=1; FAILED="$FAILED deptrac"; }; { composer check-rector; } || { EXIT=1; FAILED="$FAILED check-rector"; }; { composer markdownlint; } || { EXIT=1; FAILED="$FAILED markdownlint"; }; { composer check-yaml; } || { EXIT=1;  FAILED="$FAILED markdownlint"; }; if [ 1 -eq $EXIT ]; then echo "Failed:$FAILED"; fi; exit $EXIT;"
+            "EXIT=0; FAILED=''; { composer check-cs; } || { EXIT=1; FAILED=\"$FAILED check-cs\"; }; { composer phpstan; } || { EXIT=1; FAILED=\"$FAILED phpstan\"; }; { composer deptrac; } || { EXIT=1; FAILED=\"$FAILED deptrac\"; }; { composer check-rector; } || { EXIT=1; FAILED=\"$FAILED check-rector\"; }; { composer markdownlint; } || { EXIT=1; FAILED=\"$FAILED markdownlint\"; }; { composer check-yaml; } || { EXIT=1;  FAILED=\"$FAILED check-yaml\"; }; if [ 1 -eq $EXIT ]; then echo \"Failed:$FAILED\"; fi; exit $EXIT;"
         ],
         "fix": [
             "@composer-update",

--- a/composer.json
+++ b/composer.json
@@ -123,7 +123,17 @@
         "check-rector": "php tools/extract-inline-php.php && rector process --dry-run --ansi",
         "check-yaml": "phpunit --group yaml",
         "phpunit": "phpunit --exclude-group=yaml",
-        "yaml-update-baseline": "php tests/generate-yaml-baseline.php"
+        "yaml-update-baseline": "php tests/generate-yaml-baseline.php",
+        "composer-update": "[ -d vendor ] || composer update",
+        "yarn-install": "[ -d node_modules ] || yarn install",
+        "markdownlint": [
+            "@yarn-install",
+            "yarn markdownlint"
+        ],
+        "test": [
+            "@composer-update",
+            "EXIT=0; composer check-cs || EXIT=1; composer phpstan || EXIT=1; composer deptrac || EXIT=1; composer check-rector || EXIT=1; composer markdownlint || EXIT=1; exit $EXIT"
+        ]
     },
     "scripts-descriptions": {
         "fix-cs": "Automatically fixes code style in all files",
@@ -133,7 +143,11 @@
         "fix-rector": "Automatically applies Rector refactoring to code samples and syncs back to Markdown",
         "check-rector": "Check for code refactoring opportunities",
         "check-yaml": "Run PHPUnit tests (YAML validation)",
-        "yaml-update-baseline": "Regenerate tests/yaml-validation-baseline.yaml from current failures"
+        "yaml-update-baseline": "Regenerate tests/yaml-validation-baseline.yaml from current failures",
+        "composer-update": "Install composer dependencies if not already installed",
+        "yarn-install": "Install yarn dependencies if not already installed",
+        "markdownlint": "Run Markdownlint on all documentation files",
+        "test": "Run all checks (CS-Fixer, PHPStan, Deptrac, Rector, Markdownlint, YAML checks), continuing past failures and reporting failure overall if any check failed"
     },
     "config": {
         "allow-plugins": false

--- a/composer.json
+++ b/composer.json
@@ -124,6 +124,8 @@
         "check-yaml": "phpunit --group yaml",
         "phpunit": "phpunit --exclude-group=yaml",
         "yaml-update-baseline": "php tests/generate-yaml-baseline.php",
+        "phpstan-update-baseline": "@phpstan --generate-baseline",
+        "deptrac-update-baseline": "@deptrac --formatter=baseline",
         "composer-update": "[ -d vendor ] || composer update",
         "yarn-install": "[ -d node_modules ] || yarn install",
         "markdownlint": [
@@ -144,6 +146,8 @@
         "check-rector": "Check for code refactoring opportunities",
         "check-yaml": "Run PHPUnit tests (YAML validation)",
         "yaml-update-baseline": "Regenerate tests/yaml-validation-baseline.yaml from current failures",
+        "phpstan-update-baseline": "Regenerate PHPStan baseline from current failures",
+        "deptrac-update-baseline": "Regenerate Deptrac baseline from current failures",
         "composer-update": "Install composer dependencies if not already installed",
         "yarn-install": "Install yarn dependencies if not already installed",
         "markdownlint": "Run Markdownlint on all documentation files",

--- a/composer.json
+++ b/composer.json
@@ -132,9 +132,25 @@
             "@yarn-install",
             "yarn markdownlint"
         ],
+        "fix-markdownlint": [
+            "@yarn-install",
+            "yarn markdownlint --fix"
+        ],
         "test": [
             "@composer-update",
             "EXIT=0; composer check-cs || EXIT=1; composer phpstan || EXIT=1; composer deptrac || EXIT=1; composer check-rector || EXIT=1; composer markdownlint || EXIT=1; composer check-yaml || EXIT=1; exit $EXIT"
+        ],
+        "fix": [
+            "@composer-update",
+            "@composer fix-rector",
+            "@composer fix-cs",
+            "@composer fix-markdownlint"
+        ],
+        "baseline": [
+            "@composer-update",
+            "@composer phpstan-update-baseline",
+            "@composer deptrac-update-baseline",
+            "@composer yaml-update-baseline"
         ]
     },
     "scripts-descriptions": {
@@ -151,7 +167,10 @@
         "composer-update": "Install composer dependencies if not already installed",
         "yarn-install": "Install yarn dependencies if not already installed",
         "markdownlint": "Run Markdownlint on all documentation files",
-        "test": "Run all checks (CS-Fixer, PHPStan, Deptrac, Rector, Markdownlint, YAML checks), continuing past failures and reporting failure overall if any check failed"
+        "fix-markdownlint": "Automatically fixes Markdownlint issues in all documentation files",
+        "test": "Run all checks (CS-Fixer, PHPStan, Deptrac, Rector, Markdownlint, YAML checks), continuing past failures and reporting failure overall if any check failed",
+        "fix": "Run all automatic fixes (Rector, CS-Fixer, Markdownlint)",
+        "baseline": "Regenerate all baselines (PHPStan, Deptrac, YAML) from current failures"
     },
     "config": {
         "allow-plugins": false

--- a/composer.json
+++ b/composer.json
@@ -132,7 +132,7 @@
         ],
         "test": [
             "@composer-update",
-            "EXIT=0; composer check-cs || EXIT=1; composer phpstan || EXIT=1; composer deptrac || EXIT=1; composer check-rector || EXIT=1; composer markdownlint || EXIT=1; exit $EXIT"
+            "EXIT=0; composer check-cs || EXIT=1; composer phpstan || EXIT=1; composer deptrac || EXIT=1; composer check-rector || EXIT=1; composer markdownlint || EXIT=1; composer check-yaml || EXIT=1; exit $EXIT"
         ]
     },
     "scripts-descriptions": {

--- a/docs/templating/twig_function_reference/recommendations_twig_functions.md
+++ b/docs/templating/twig_function_reference/recommendations_twig_functions.md
@@ -108,17 +108,19 @@ To resolve `websiteId` on the project level, implement the interface as follows:
 
 ``` php
 namespace App\Tracking;
-use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
-use Ibexa\Contracts\Core\Repository\PermissionResolver;
+
 use Ibexa\Contracts\ConnectorRaptor\Tracking\ContextProvider\WebsiteIdContextProviderInterface;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Ibexa\Contracts\Core\SiteAccess\ConfigResolverInterface;
+
 final readonly class MyCrmWebsiteUserIdProvider implements WebsiteIdContextProviderInterface
 {
     public function __construct(
-        private ConfigResolverInterface $configResolver, 
+        private ConfigResolverInterface $configResolver,
         private PermissionResolver $permissionResolver,
-    )
-    {
+    ) {
     }
+
     public function getWebsiteId(): ?string
     {
         $currentUserId = $this->permissionResolver->getCurrentUserReference()->getUserId();
@@ -126,8 +128,10 @@ final readonly class MyCrmWebsiteUserIdProvider implements WebsiteIdContextProvi
         if ($this->isAnonymousUser($currentUserId)) {
             return null;
         }
+
         return $this->getWebsiteUserIdForCurrentUser($currentUserId);
     }
+
     /**
      * @phpstan-return non-empty-string
      */
@@ -136,6 +140,7 @@ final readonly class MyCrmWebsiteUserIdProvider implements WebsiteIdContextProvi
         // Implement custom logic resolving user identifier from the CRM
         return 'custom-identifier-for-the-user-retrieved-from-the-CRM';
     }
+
     private function isAnonymousUser(int $userId): bool
     {
         return (int) $this->configResolver->getParameter('anonymous_user_id') === $userId;


### PR DESCRIPTION
Target: 5.0, 6.0

This PR adds a single command to run all code and content quality checks - except Vale, which is not a dependency and cannot be run as easily.

Goal: I want to use that locally, to run all checks quickly with `composer test`.

In addition, some helper commands are added to regenerate baselines in a consistent way.

Usage:

- `composer test` before sending the PR to review
- `composer fix` in case something is detected
- `composer baseline` when a baseline needs to be generated

They run `composer update` already, so there's less friction.

