### PR TITLE
Set edit links dynamically for RtD preview and PR builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /vendor/
 **/.DS_Store
 __pycache__/*
+hooks/__pycache__/*
 /site/
 **/.idea/
 .php-cs-fixer.cache

--- a/hooks/edit_uri.py
+++ b/hooks/edit_uri.py
@@ -1,0 +1,12 @@
+import os
+
+def on_config(config, **kwargs):
+    if os.environ.get("READTHEDOCS_VERSION_TYPE") == "external":
+        ref = os.environ.get("READTHEDOCS_GIT_COMMIT_HASH")
+    else:
+        ref = os.environ.get("GITHUB_HEAD_REF")
+
+    if ref:
+        config["edit_uri"] = f"edit/{ref}/docs/"
+
+    return config

--- a/hooks/edit_uri.py
+++ b/hooks/edit_uri.py
@@ -7,6 +7,6 @@ def on_config(config, **kwargs):
         ref = os.environ.get("GITHUB_HEAD_REF")
 
     if ref:
-        config["edit_uri"] = f"edit/{ref}/docs/"
+        config["edit_uri"] = f"blob/{ref}/docs/"
 
     return config

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ INHERIT: plugins.yml
 
 site_name: Developer Documentation
 repo_url: https://github.com/ibexa/documentation-developer
-edit_uri: edit/5.0/docs
+edit_uri: blob/5.0/docs
 site_url: https://doc.ibexa.co/en/latest/
 hooks:
     - hooks/edit_uri.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,8 @@ site_name: Developer Documentation
 repo_url: https://github.com/ibexa/documentation-developer
 edit_uri: edit/5.0/docs
 site_url: https://doc.ibexa.co/en/latest/
+hooks:
+    - hooks/edit_uri.py
 copyright: "Copyright 1999-2026 Ibexa AS and others"
 validation:
     omitted_files: warn

--- a/theme/partials/source.html
+++ b/theme/partials/source.html
@@ -1,5 +1,5 @@
 {% import "partials/language.html" as lang with context %}
-<a href="{{ page.edit_url|replace('/edit/', '/blob/') }}" title="{{ lang.t('source.link.title') }}" class="source-github">
+<a href="{{ page.edit_url }}" title="{{ lang.t('source.link.title') }}" class="source-github">
     <div class="md-source__icon md-icon">
         {% include ".icons/fontawesome/brands/github-alt.svg" %}
     </div>


### PR DESCRIPTION
Target: 5.0, 6.0

The current link checker has a bug: for new Markdown files, it reports 404 for "View on GitHub" button:

https://github.com/ibexa/documentation-developer/pull/3279#issuecomment-4901275241

```
Errors in site/release_notes/cohesivo_v6.0_deprecations/index.html

    [404] https://github.com/ibexa/documentation-developer/blob/5.0/docs/release_notes/cohesivo_v6.0_deprecations.md (at 194:10) | Rejected status code: 404 Not Found
```


This is because the 5.0 branch is hardcoded as "edit_uri", and it looks into the 5.0 branch for changes that were not merged yet.

This PR sets the value dynamically, so for it will work correctly for PRs and for ReadTheDocs preview builds.

Doc:

- GITHUB_HEAD_REF : https://docs.github.com/en/actions/reference/workflows-and-actions/variables
- ReadTheDocs does not have access to the branch name:

```
The [slug](https://docs.readthedocs.com/platform/stable/glossary.html#term-slug) of the version being built, such as latest, stable, or a branch name like feature-1234. For [pull request builds](https://docs.readthedocs.com/platform/stable/pull-requests.html), the value will be the pull request number.
```
(from https://docs.readthedocs.com/platform/stable/reference/environment-variables.html )

So for RTD previews, commit hash is used.

Tested locally by setting the variable before building and checking the output in the `site` dir:

``` bash
export READTHEDOCS_VERSION_TYPE=external
export READTHEDOCS_GIT_COMMIT_HASH=123456    
~/python/bin/python3.13 -m mkdocs build --strict
cat site/index.html | grep 123456

<a href="https://github.com/ibexa/documentation-developer/blob/123456/docs/index.md" title="source.link.title" class="source-github">
```
