### PR TITLE
Expand the example showing how to inject PurgeClientInterface

### DIFF
--- a/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
@@ -326,19 +326,38 @@ In other words, HTTP Cache for `[Parent1]`, children of `[Parent1]` ( if any ), 
 ### Custom purging from code
 
 While the system purges tags whenever API is used to change data, you may need to purge directly from code.
-For that you can use the built-in purge client:
+For that you can inject the built-in [`PurgeClientInterface`](/api/php_api/php_api_reference/classes/Ibexa-Contracts-HttpCache-PurgeClient-PurgeClientInterface.html) by using the `ibexa.http_cache.purge_client` service name:
 
-``` php
+``` php hl_lines="12-13 19-21 23-25"
 use Ibexa\Contracts\HttpCache\Handler\ContentTagInterface;
+use Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
-/** @var \Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface $purgeClient */
-/** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location $location */
+#[AsCommand(name: 'app:purge-cache')]
+class MyCustomCacheCommand
+{
+    public function __construct(
+        #[Autowire(service: 'ibexa.http_cache.purge_client')]
+        private readonly PurgeClientInterface $purgeClient
+    ) {
+    }
 
-// Example for purging by Location ID:
-$purgeClient->purge([ContentTagInterface::LOCATION_PREFIX . $location->id]);
+    public function __invoke(SymfonyStyle $io): int
+    {
+        // Example for purging by Location ID:
+        $locationId = 2;
+        $this->purgeClient->purge([ContentTagInterface::LOCATION_PREFIX . $locationId]);
 
-// Example for purging all cache for instance for full re-deploy cases, usually this triggers an expiry (soft purge):
-$purgeClient->purgeAll();
+        // Example for purging all cache for instance for full re-deploy cases
+        // Usually this triggers an expiry (soft purge):
+        $this->purgeClient->purgeAll();
+
+        return Command::SUCCESS;
+    }
+}
 ```
 
 ### Purging from command line


### PR DESCRIPTION
Target: 5.0, 6.0

As reported on community Slack:

```
ok, i have a puzzler about the PurgeCache, I'm trying to create an App\Event\Subscriber\PublishVersion\MyContentOnPublishVersionSubscriber.php class that will clear the cache under specific conditions.

according https://doc.ibexa.co/en/latest/infrastructure_and_maintenance/cache/http_cache/content_aware_cache/#custom-purging-from-code I need the

/** @var \Ibexa\Contracts\HttpCache\PurgeClient\PurgeClientInterface $purgeClient */

I tried to autowire the PurgeClientInterface $purgeClient but that fails for both the __construct() and the onPublishVersionEvent(PublishVersionEvent $event)

The only way i've been able to get the $purgeClient is via service declaration.

services:
    App\Event\Subscriber\PublishVersion\NavItemOnPublishVersionSubscriber:
        arguments:
            $purgeClient: '@ibexa.http_cache.purge_client'
```

The current version of the doc doesn't tell how to inject the PurgeClient, and it cannot be autowired.

The example is expanded to show the name of the service that needs to be injected.
I've used invokable command with the `Autowire` attirubte to have a standalone, complete example

Tested locally that it works:
```
~/Desktop/Sites/v5 main +1 !174 ?16 ❯ php bin/console app:purge-cache                                                                                                                            6s  24.4.0 10:19:42


 [OK] Purging cache...
```
