### PR TITLE
Bumped Pagerfanta link

### DIFF
--- a/docs/search/search_api.md
+++ b/docs/search/search_api.md
@@ -259,7 +259,7 @@ Pagination can then be rendered for example using the following template:
 [[= include_code('code_samples/api/public_php_api/templates/themes/standard/full/custom_pagination.html.twig') =]]
 ```
 
-For more information and examples, see [PagerFanta documentation](https://www.babdev.com/open-source/packages/pagerfanta/docs/2.x/usage).
+For more information and examples, see [PagerFanta documentation](https://www.babdev.com/open-source/packages/pagerfanta/docs/3.x/usage).
 
 #### Pagerfanta adapters
 


### PR DESCRIPTION
Target: 5.0, 6.0

V5 is using Pagerfanta 3.8:

```
~/Desktop/Sites/v5 main +1 !178 ?26 ❯ composer show | grep pagerfanta                                                                                                                                24.4.0 14:43:51
babdev/pagerfanta-bundle                  4.6.0                Bundle integrating Pagerfanta with Symfony
pagerfanta/pagerfanta                     3.8.0                Pagination for PHP
```