### PR TITLE
Added mention about the new mount

### DIFF
--- a/docs/update_and_migration/from_5.0/update_from_5.0.md
+++ b/docs/update_and_migration/from_5.0/update_from_5.0.md
@@ -364,6 +364,23 @@ Update Symfony constraints in `composer.json` before updating the packages.
         Symfony 7.4 introduces a new [share directory](https://symfony.com/blog/new-in-symfony-7-4-share-directory), dedicated for storing application cache on the file system.
         If you decide to configure it (for example, by setting the `APP_SHARE_DIR` environment variable), review your existing scripts for explicit `var/cache` usage (for example, `rm -rf var/cache`) and decide whether to include `var/share` in the script.
 
+        If you use [[= product_name_cloud =]], add a mount for the `var/share` directory to your `.platform.app.yaml` file, next to the existing `var/cache` and `var/log` mounts:
+
+        ```yaml hl_lines="5-7"
+        mounts:
+            'var/cache':
+                source: local
+                source_path: cache
+            'var/share':
+                source: local
+                source_path: share
+            'var/log':
+                source: local
+                source_path: log
+        ```
+
+        Without this mount, the `var/share` directory is read-only and all writes to the `cache.app` cache pool fail.
+
         !!! caution "Always clear the persistence cache with `cache:pool:clear` command"
 
             Starting with Symfony 7.4, running `php bin/console cache:clear` doesn't clear the [[= product_name =]] persistence cache, even when using a filesystem-based cache pool.


### PR DESCRIPTION
Target: 4.6, 5.0, 6.0 (update instructions)

Companion PR for https://github.com/ibexa/cloud/pull/11

I'm specifying the mount direcly instead of saying "regenerate the Ibexa Cloud configuration files" because this change won't be released for another month.
