### PR TITLE
Fixed triple slashes in cards macro

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,10 @@ from mkdocs.structure.pages import Page
 from mkdocs.utils import meta
 from typing import List
 
+def _absolute_page_url(site, language, version, *parts):
+    return 'https://' + '/'.join((site, language, version) + parts)
+
+
 CARDS_TEMPLATE = """
 <div class="card-wrapper">
     <div>
@@ -109,25 +113,12 @@ def define_env(env):
             elif re.search(".html$", path):
                 html = True
                 content = open("docs/%s" % path, "r").read()
-                page = 'https:/' + '/'.join((
-                    '/',
-                    site,
-                    language,
-                    version,
-                    page
-                ))
+                page = _absolute_page_url(site, language, version, page)
             else:
                 html = False
                 path = path.rstrip('/')
                 content = open("docs/%s.md" % path, "r").read()
-                page = 'https:/' + '/'.join((
-                    '/',
-                    site,
-                    language,
-                    version,
-                    path,
-                    hash
-                ))
+                page = _absolute_page_url(site, language, version, path, hash)
 
             if html:
                 match = re.search("<meta property=\"og:title\" content=\"(.*)\"", content, re.MULTILINE)


### PR DESCRIPTION
Target: 5.0, 6.0

Regression after link checker changes.

Cards macro products links with triple slash: `https:///`

Both in HTML and in Markdown:

https://doc.ibexa.co/en/5.0/api/api/

``` html
<a href="https:///doc.ibexa.co/en/5.0/api/rest_api/rest_api_usage/rest_api_usage/" class="card">
            <div>
                <p class="title">REST API usage</p>
                <p class="description">The REST API covers objects in the Ibexa DXP Repository with regular and custom HTTP methods, such as GET or PUBLISH, and HTTP headers.</p>
            </div>
        </a>
```

<img width="1070" height="199" alt="Screenshot 2026-07-17 at 12 01 17" src="https://github.com/user-attachments/assets/4e414734-717e-4ee9-854b-ec33742662b8" />


Markdown: https://doc.ibexa.co/en/5.0/api/api/index.md

``` md
- [REST API usage](https:///doc.ibexa.co/en/5.0/api/rest_api/rest_api_usage/rest_api_usage/): The REST API covers objects in the Ibexa DXP Repository with regular and custom HTTP methods, such as GET or PUBLISH, and HTTP headers.
```

