### PR TITLE
[PHP API Reference] Fixed navigation on mobile view

### DIFF
--- a/tools/api_refs/.phpdoc/template/components/header.html.twig
+++ b/tools/api_refs/.phpdoc/template/components/header.html.twig
@@ -1,5 +1,8 @@
 <header class="md-header" data-md-component="header">
     <nav class="md-header__inner md-grid" aria-label="">
+        <label class="md-header__button md-icon" for="__drawer" aria-label="Open navigation">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="currentColor" d="M3 6h18v2H3V6m0 5h18v2H3v-2m0 5h18v2H3v-2Z"/></svg>
+        </label>
         {% include 'components/header-title.html.twig' %}
         {% include 'components/doc-switcher.html.twig' %}
         {% include 'components/version-switcher.html.twig' %}

--- a/tools/api_refs/.phpdoc/template/css/base.css.twig
+++ b/tools/api_refs/.phpdoc/template/css/base.css.twig
@@ -31,9 +31,11 @@ body.menu-resizing {
     background-color: #306CBE;
 }
 
-.main_nav_content,
-.md-sidebar--primary {
-    width: 100%;
+@media only screen and (min-width: 76.1875em) {
+    .main_nav_content,
+    .md-sidebar--primary {
+        width: 100%;
+    }
 }
 
 .md-sidebar--primary {

--- a/tools/api_refs/.phpdoc/template/css/docs.switcher.css.twig
+++ b/tools/api_refs/.phpdoc/template/css/docs.switcher.css.twig
@@ -122,3 +122,9 @@
 .md-header__switcher .rst-other-versions dt {
     display: none;
 }
+
+@media only screen and (max-width: 44.9375em) {
+    .md-header__switcher:not(.push) {
+        display: none;
+    }
+}

--- a/tools/api_refs/.phpdoc/template/css/navigation.css.twig
+++ b/tools/api_refs/.phpdoc/template/css/navigation.css.twig
@@ -1,8 +1,61 @@
 .main_nav {
     border-right: 1px solid var(--mid-grey);
-    margin-left: -15rem;
     display: flex;
     flex-shrink: 0;
+}
+
+@media only screen and (max-width: 76.1874em) {
+    .main_nav {
+        width: 0 !important;
+        border-right: none;
+    }
+
+    .main_nav .site-header,
+    .main_nav__resize-handler {
+        display: none;
+    }
+
+    .md-sidebar--primary .md-sidebar__scrollwrap {
+        overflow-y: auto;
+    }
+
+    /* Keep the desktop-style nav tree inside the drawer instead of
+       Material's layered sliding panels */
+    .md-nav--primary,
+    .md-nav--primary .md-nav {
+        position: static;
+        display: block;
+        height: auto;
+        z-index: auto;
+    }
+
+    .md-nav--primary .md-nav__item {
+        border-top: none;
+    }
+
+    .md-nav__toggle ~ .md-nav {
+        display: none;
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+
+    .md-nav__toggle:checked ~ .md-nav,
+    .md-nav__toggle:indeterminate ~ .md-nav {
+        display: block;
+    }
+
+    .md-typeset h1,
+    .md-typeset h2,
+    .md-typeset h3,
+    .md-typeset h4 {
+        overflow-wrap: anywhere;
+    }
+
+    .md-typeset .method-parameters {
+        display: block;
+        overflow-x: auto;
+    }
 }
 
 .md-sidebar__scrollwrap {
@@ -11,7 +64,6 @@
 
 @media only screen and (min-width: 76.1875em) {
     .main_nav {
-        margin-left: 0;
         position: sticky;
         top: 56px;
         height: calc(100vh - 56px);

--- a/tools/api_refs/.phpdoc/template/js/menu-resizer.js
+++ b/tools/api_refs/.phpdoc/template/js/menu-resizer.js
@@ -25,7 +25,7 @@
     const setWidthOfSecondLevelMenu = () => {
         let secondLevelMenuWidth = getCookie('php-api:menu-width');
 
-        if (!secondLevelMenuWidth) {
+        if (!secondLevelMenuWidth || window.matchMedia('(max-width: 76.1875em)').matches) {
             return;
         }
 

--- a/tools/api_refs/.phpdoc/template/layout.html.twig
+++ b/tools/api_refs/.phpdoc/template/layout.html.twig
@@ -25,8 +25,11 @@
     <div class="popover popover--copied">Copied!</div>
 
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
+    <input class="md-toggle" data-md-toggle="drawer" type="checkbox" id="__drawer" autocomplete="off">
 
     {% include 'components/header.html.twig' %}
+
+    <label class="md-overlay" data-md-component="overlay" for="__drawer"></label>
 
     <div class="md-container" data-md-component="container">
         <main class="md-main" data-md-component="main">


### PR DESCRIPTION
Target: 4.6, 5.0, 6.0

Fixed by Fable (conversation in https://gist.github.com/mnocon/11cbbef2027557b9b5f365331e533955)

Preview available in: https://github.com/ibexa/documentation-developer/pull/3303

Example pages:

- https://ez-systems-developer-documentation--3303.com.readthedocs.build/en/3303/api/php_api/php_api_reference/
- https://ez-systems-developer-documentation--3303.com.readthedocs.build/en/3303/api/php_api/php_api_reference/namespaces/ibexa-contracts-automatedtranslation-client.html
- https://ez-systems-developer-documentation--3303.com.readthedocs.build/en/3303/api/php_api/php_api_reference/classes/Ibexa-Contracts-AutomatedTranslation-Client-ClientInterface.html

### Full view

<img width="1707" height="864" alt="Screenshot 2026-07-21 at 11 37 41" src="https://github.com/user-attachments/assets/0e791070-b535-49e5-8ab1-5cc6f7b5e644" />

### Medium screens

The view for medium screens could be improved, but I think it's good enough already.

The hamburher menu expands on click and can be used for navigation.

<img width="996" height="901" alt="Screenshot 2026-07-21 at 11 35 34" src="https://github.com/user-attachments/assets/f7d4f683-aad1-44b4-9f95-c6d8fbfc2c3d" />

### Small screens
<img width="802" height="909" alt="Screenshot 2026-07-21 at 11 36 00" src="https://github.com/user-attachments/assets/9be88aac-5a45-4974-8e04-eef91130698c" />
