### PR TITLE
Fixed cli.ibexa.cloud

### DIFF
--- a/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
+++ b/docs/ibexa_cloud/ddev_and_ibexa_cloud.md
@@ -12,7 +12,7 @@ Two ways are available to run an [[= product_name_cloud =]] project locally with
 
 !!! note
 
-    The following examples use [[[= product_name_cloud =]] CLI (`ibexa_cloud`)](https://cli.ibexa.co/).
+    The following examples use [[[= product_name_cloud =]] CLI (`ibexa_cloud`)](https://cli.ibexa.cloud/).
     For more information and examples, see [[[= product_name_cloud =]] CLI](ibexa_cloud_cli.md).
 
 ## With Ibexa Cloud add-ons
@@ -33,7 +33,7 @@ To use an `auth.json` file for this purpose, see [Using `auth.json`](install_wit
 The following sequence of commands:
 
 1. Downloads the [[= product_name_cloud =]] project from the default environment "production"
-   into a new directory (for example `my-ddev-project`), using the [`ibexa_cloud` command](https://cli.ibexa.co/).
+   into a new directory (for example `my-ddev-project`), using the [`ibexa_cloud` command](https://cli.ibexa.cloud/).
    (Replace `<project-ID>` with the hash of your own project.
 See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.html#3-use) for options like selecting another environment).
 1. Configures a new DDEV project.
@@ -78,7 +78,7 @@ The following example adapts the [manual method to run an already existing proje
 
 The following sequence of commands:
 
-1. Downloads the [[= product_name_cloud =]] Upsun project from the default environment "production" into a new directory, using the [[[= product_name_cloud =]] CLI](https://cli.ibexa.co/).
+1. Downloads the [[= product_name_cloud =]] Upsun project from the default environment "production" into a new directory, using the [[[= product_name_cloud =]] CLI](https://cli.ibexa.cloud/).
 (Replace `<project-ID>` with the hash of your own project. See [`ibexa_cloud help get`](https://fixed.docs.upsun.com/administration/cli.html#3-use) for options like selecting another environment).
 1. Configures a new DDEV project.
 1. Ignores `.ddev/` directory from Git.

--- a/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
+++ b/docs/infrastructure_and_maintenance/cache/http_cache/content_aware_cache.md
@@ -431,7 +431,7 @@ Typically, you can add a `gw` to the hostname and use nslookup to find it.
    Address:  1.2.3.4
 ```
 
-You can also use the [[[= product_name_cloud =]] CLI](https://cli.ibexa.co/) (which has the same command as the Upsun CLI) to find [the endpoint](https://fixed.docs.upsun.com/domains/steps/dns.html):
+You can also use the [[[= product_name_cloud =]] CLI](https://cli.ibexa.cloud/) (which has the same command as the Upsun CLI) to find [the endpoint](https://fixed.docs.upsun.com/domains/steps/dns.html):
 
 ```bash
     ibexa_cloud environment:info edge_hostname


### PR DESCRIPTION
- in theory it should have been cli.ibexa.cloud for a long time
- [cli.ibexa.co](http://cli.ibexa.co/) was only working because upsun had some "leftover"  DNS settings
- those DNS setting have been removed last week