### PR TITLE
Update doctrine/DoctrineBundle doc branch

### DIFF
--- a/docs/administration/configuration/repository_configuration.md
+++ b/docs/administration/configuration/repository_configuration.md
@@ -30,7 +30,7 @@ ibexa:
 
     It uses [Doctrine DBAL](https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/) (Database Abstraction Layer).
     Database settings are supplied by [DoctrineBundle](https://github.com/doctrine/DoctrineBundle).
-    As such, you can refer to [DoctrineBundle's documentation](https://github.com/doctrine/DoctrineBundle/blob/2.18.x/docs/en/configuration.rst#doctrine-dbal-configuration).
+    As such, you can refer to [DoctrineBundle's documentation](https://github.com/doctrine/DoctrineBundle/blob/2.19.x/docs/en/configuration.rst#doctrine-dbal-configuration).
 
 If no repository is specified for a SiteAccess or SiteAccess group, the first repository defined under `ibexa.repositories` is used:
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Branch `2.18.x` has disappeared from https://github.com/doctrine/DoctrineBundle/branches
(reported in https://github.com/ibexa/documentation-developer/pull/3230#issuecomment-5046967340)

Seeing https://github.com/ibexa/core/blob/5.0/composer.json#L25 `"doctrine/doctrine-bundle": "^2.11.0",` constraint,
`2.19.x` branch seems to be the right one.

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
