### PR TITLE
Label/Description for custom tags

### DIFF
--- a/code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml
@@ -1,3 +1,23 @@
+ibexa_fieldtype_richtext:
+    custom_tags:
+        factbox:
+            template: '@ibexadesign/field_type/ezrichtext/custom_tags/factbox.html.twig'
+            icon: '/bundles/ibexaicons/img/all-icons.svg#information' # Optional
+            is_inline: false # Optional
+            label: 'Factbox custom tag' # Optional
+            description: 'Highlight a piece of information in a box' # Optional
+            attributes:
+                name:
+                    type: string
+                    required: true # Optional
+                    label: 'My name attribute' # Optional
+                style:
+                    type: choice
+                    required: true # Optional
+                    default_value: light
+                    choices: [light, dark]
+                    label: 'My style attribute' # Optional
+
 ibexa:
     system:
         admin_group:
@@ -9,17 +29,3 @@ ibexa:
                             buttons:
                                 factbox:
                                     priority: 5
-ibexa_fieldtype_richtext:
-    custom_tags:
-        factbox:
-            template: '@ibexadesign/field_type/ezrichtext/custom_tags/factbox.html.twig'
-            icon: '/bundles/ibexaicons/img/all-icons.svg#information'
-            attributes:
-                name:
-                    type: string
-                    required: true
-                style:
-                    type: choice
-                    required: true
-                    default_value: light
-                    choices: [light, dark]

--- a/code_samples/back_office/online_editor/custom_tags/factbox/config/packages/jms_translation.yaml
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/config/packages/jms_translation.yaml
@@ -3,6 +3,7 @@ jms_translation:
         app_translation_config:
             dirs: ['%kernel.project_dir%/src']
             output_dir: '%kernel.project_dir%/translations'
+            output_format: yaml
             extractors:
                 - 'app.translation_extractor.factbox'
                 - 'app.translation_extractor.factbox_choice'

--- a/code_samples/back_office/online_editor/custom_tags/factbox/config/packages/jms_translation.yaml
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/config/packages/jms_translation.yaml
@@ -1,0 +1,8 @@
+jms_translation:
+    configs:
+        app_translation_config:
+            dirs: ['%kernel.project_dir%/src']
+            output_dir: '%kernel.project_dir%/translations'
+            extractors:
+                - 'app.translation_extractor.factbox'
+                - 'app.translation_extractor.factbox_choice'

--- a/code_samples/back_office/online_editor/custom_tags/factbox/config/services.yaml
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/config/services.yaml
@@ -1,0 +1,20 @@
+services:
+    app.extractor.custom_tag:
+        class: Ibexa\FieldTypeRichText\Translation\Extractor\CustomTagExtractor
+        arguments:
+            $customTags: '%ibexa.field_type.richtext.custom_tags%'
+            $domain: '%ibexa.field_type.richtext.custom_tags.translation_domain%'
+            $allowlist: ['factbox']
+        tags:
+            -   name: jms_translation.extractor
+                alias: app.translation_extractor.factbox
+
+    app.extractor.custom_tag_choice:
+        class: Ibexa\FieldTypeRichText\Translation\Extractor\ChoiceAttributeExtractor
+        arguments:
+            $customTags: '%ibexa.field_type.richtext.custom_tags%'
+            $domain: '%ibexa.field_type.richtext.custom_tags.translation_domain%'
+            $allowlist: ['factbox']
+        tags:
+            -   name: jms_translation.extractor
+                alias: app.translation_extractor.factbox_choice

--- a/code_samples/back_office/online_editor/custom_tags/factbox/templates/themes/standard/field_type/ezrichtext/custom_tags/factbox.html.twig
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/templates/themes/standard/field_type/ezrichtext/custom_tags/factbox.html.twig
@@ -1,3 +1,5 @@
+{{ encore_entry_link_tags('factbox') }}
+
 <div class="ibexa-factbox ibexa-factbox--{{ params.style }}">
     <p>{{ params.name }}</p>
     <div>

--- a/code_samples/back_office/online_editor/custom_tags/factbox/translations/custom_tags.en.yaml
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/translations/custom_tags.en.yaml
@@ -1,3 +1,6 @@
 ezrichtext.custom_tags.factbox.label: 'Factbox'
+ezrichtext.custom_tags.factbox.description: 'Highlight a piece of information in a box'
 ezrichtext.custom_tags.factbox.attributes.name.label: 'Name'
 ezrichtext.custom_tags.factbox.attributes.style.label: 'Style'
+ezrichtext.custom_tags.factbox.attributes.style.choice.dark.label: 'Dark'
+ezrichtext.custom_tags.factbox.attributes.style.choice.light.label: 'Light'

--- a/code_samples/back_office/online_editor/custom_tags/factbox/webpack.config.js
+++ b/code_samples/back_office/online_editor/custom_tags/factbox/webpack.config.js
@@ -1,0 +1,3 @@
+Encore.addStyleEntry('factbox', [
+    path.resolve(__dirname, './assets/scss/factbox.scss'),
+]);

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -41,22 +41,83 @@ Place the `factbox.html.twig` template in the
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/templates/themes/standard/field_type/ezrichtext/custom_tags/factbox.html.twig') =]]
 ```
 
-!!! tip
+If an attribute isn't required, check if it's defined by adding a check 
+in the template, for example:
 
-    If an attribute isn't required, check if it's defined by adding a check 
-    in the template, for example:
+```html+twig
+{% if params.your_attribute is defined %}
+    ...
+{% endif %}
+```
 
-    ```html+twig
-    {% if params.your_attribute is defined %}
-        ...
-    {% endif %}
-    ```
+In this example, the `style` attribute is a `choice` attribute with `light` and `dark` as possible values.
+The selected value is available as `params.style` in the template.
+Use it to build an `ibexa-factbox--light` or `ibexa-factbox--dark` modifier class on the wrapping `div` element for styling.
 
-Add labels for the new tag by providing translations in `translations/custom_tags.en.yaml`:
+You can then define the corresponding CSS for each choice, for example by using [Webpack Encore and assets](assets.md).
+
+Create a `assets/scss/factbox.scss` file for styling the custom tag:
+
+``` css
+.ibexa-factbox--light {
+    background-color: #f5f5f5;
+    color: #202020;
+}
+
+.ibexa-factbox--dark {
+    background-color: #202020;
+    color: #f5f5f5;
+}
+```
+
+### Provide translations for custom tags
+
+You can provide the label and description displayed for the custom tag and its attributes in the back office in one of two ways.
+
+#### Option 1: Manually add translations
+
+Add labels for the new tag by providing the translations manually in `translations/custom_tags.en.yaml`:
 
 ```yaml
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/translations/custom_tags.en.yaml') =]]
 ```
+
+This approach is quick, but doesn't work when your custom tag is defined in a bundle.
+The configuration and the labels are defined in separate files, making it easier to miss updating them when the custom tag changes.
+
+#### Option 2: Extract translation source texts from configuration
+
+To provide the translations with the custom tag configuration, specify the `label` and `description` keys for the custom tag itself and a `add label` key to each attribute.
+
+```yaml hl_lines="7-8 13 19"
+[[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml') =]]
+```
+
+To make use of them, create a new service with `Ibexa\FieldTypeRichText\Translation\Extractor\CustomTagExtractor` as the class.
+
+If it has `choice` attributes, add an additional service with `Ibexa\FieldTypeRichText\Translation\Extractor\ChoiceAttributeExtractor` as the class.
+
+In both cases, add your custom tag's identifier to the `allowlist` argument:
+
+```yaml hl_lines="7 17"
+[[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/services.yaml') =]]
+```
+
+Then, create your own translation extraction configuration, and specify the Symfony services created above as extractors:
+
+```yaml hl_lines="7-8"
+[[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/jms_translation.yaml') =]]
+```
+
+Run the translation extraction:
+
+```bash
+php bin/console translation:extract -c app_translation_config
+```
+
+This updates `translations/custom_tags.en.yaml` with the translations provided in the configuration itself, for any keys that don't already have a translation.
+
+### Use custom tag
 
 Now you can use the tag.
 In the back office, create or edit a content item that has a RichText field type.

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -26,6 +26,8 @@ Start preparing the tag by adding a configuration file:
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml') =]]
 ```
 
+The example enables the custom tag under the `admin_group` [SiteAccess group](siteaccess.md), which controls where editors can use it.
+The custom tag renders in all SiteAccesses, including the front end.
 Custom tags can have as many attributes as needed.
 Supported attribute types are:
 `string`, `number`, `boolean`, `link`, and `choice`.
@@ -34,8 +36,7 @@ Supported attribute types are:
 Provide your own SVG icon, or choose one from the [built-in icons included in `all-icons.svg`](icon_twig_functions.md#icons-reference).
 
 You must create your own file for the Twig template.
-Place the `factbox.html.twig` template in the 
-`templates/themes/<your-theme>/field_type/ezrichtext/custom_tags` directory:
+Place the `factbox.html.twig` template in the `templates/themes/<your-theme>/field_type/ezrichtext/custom_tags` directory:
 
 ```html+twig
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/templates/themes/standard/field_type/ezrichtext/custom_tags/factbox.html.twig') =]]
@@ -70,6 +71,14 @@ Create a `assets/scss/factbox.scss` file for styling the custom tag:
 }
 ```
 
+Then, register the file in `webpack.config.js` as an asset entry called `factbox`:
+
+``` js
+[[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/webpack.config.js') =]]
+```
+
+After you add the configuration, template, and asset files, clear the cache and run `yarn encore <dev|prod>`.
+
 ### Provide translations for custom tags
 
 You can provide the label and description displayed for the custom tag and its attributes in the back office in one of two ways.
@@ -87,11 +96,16 @@ The configuration and the labels are defined in separate files, making it easier
 
 #### Option 2: Extract translation source texts from configuration
 
-To provide the translations with the custom tag configuration, specify the `label` and `description` keys for the custom tag itself and a `add label` key to each attribute.
+To provide the translations with the custom tag configuration, specify the `label` and `description` keys for the custom tag itself, and a `label` key for each attribute.
 
 ```yaml hl_lines="7-8 13 19"
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml') =]]
 ```
+
+If you omit `label` or `description`, the extraction uses the identifier of the custom tag or attribute as the source text.
+
+To provide translations for values of a `choice` attribute, `ChoiceAttributeExtractor` capitalizes the first letter of the value.
+For example, `light` and `dark` options become `Light` and `Dark`.
 
 To make use of them, create a new service with `Ibexa\FieldTypeRichText\Translation\Extractor\CustomTagExtractor` as the class.
 
@@ -105,7 +119,7 @@ In both cases, add your custom tag's identifier to the `allowlist` argument:
 
 Then, create your own translation extraction configuration, and specify the Symfony services created above as extractors:
 
-```yaml hl_lines="7-8"
+```yaml hl_lines="6 8-9"
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/jms_translation.yaml') =]]
 ```
 
@@ -115,7 +129,9 @@ Run the translation extraction:
 php bin/console translation:extract -c app_translation_config
 ```
 
-This updates `translations/custom_tags.en.yaml` with the translations provided in the configuration itself, for any keys that don't already have a translation.
+This updates `translations/custom_tags.en.yaml` with the source texts taken from the configuration.
+
+Run the extraction again whenever you change the labels, descriptions, or attributes of the custom tag.
 
 ### Use custom tag
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -108,11 +108,6 @@ To provide the translations with the custom tag configuration, specify the `labe
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/config/packages/custom_tags.yaml') =]]
 ```
 
-If you omit `label` or `description`, the extraction uses the identifier of the custom tag or attribute as the source text.
-
-To provide translations for values of a `choice` attribute, `ChoiceAttributeExtractor` capitalizes the first letter of the value.
-For example, `light` and `dark` options become `Light` and `Dark`.
-
 To make use of them, create a new service with `Ibexa\FieldTypeRichText\Translation\Extractor\CustomTagExtractor` as the class.
 
 If it has `choice` attributes, add an additional service with `Ibexa\FieldTypeRichText\Translation\Extractor\ChoiceAttributeExtractor` as the class.
@@ -136,6 +131,11 @@ php bin/console translation:extract -c app_translation_config
 ```
 
 This updates `translations/custom_tags.en.yaml` with the source texts taken from the configuration.
+
+If you omit `label` or `description`, the extraction uses the identifier of the custom tag or attribute as the source text.
+
+To provide translations for values of a `choice` attribute, `ChoiceAttributeExtractor` capitalizes the first letter of the value.
+For example, `light` and `dark` options become `Light` and `Dark`.
 
 Run the extraction again whenever you change the labels, descriptions, or attributes of the custom tag.
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -28,9 +28,16 @@ Start preparing the tag by adding a configuration file:
 
 The example enables the custom tag under the `admin_group` [SiteAccess group](siteaccess.md), which controls where editors can use it.
 The custom tag renders in all SiteAccesses, including the front end.
+
 Custom tags can have as many attributes as needed.
 Supported attribute types are:
-`string`, `number`, `boolean`, `link`, and `choice`.
+
+- `string`
+- `number`
+- `boolean`
+- `link`
+- `choice`
+
 `choice` requires that you provide a list of options in the `choices` key.
 
 Provide your own SVG icon, or choose one from the [built-in icons included in `all-icons.svg`](icon_twig_functions.md#icons-reference).
@@ -42,8 +49,7 @@ Place the `factbox.html.twig` template in the `templates/themes/<your-theme>/fie
 [[= include_file('code_samples/back_office/online_editor/custom_tags/factbox/templates/themes/standard/field_type/ezrichtext/custom_tags/factbox.html.twig') =]]
 ```
 
-If an attribute isn't required, check if it's defined by adding a check 
-in the template, for example:
+If an attribute isn't required, check if it's defined by adding a check in the template, for example:
 
 ```html+twig
 {% if params.your_attribute is defined %}


### PR DESCRIPTION
Target: 4.6 5.0, 6.0

Doc for https://github.com/ibexa/fieldtype-richtext/pull/326/changes

This needs a couple of changes when merged to 5.0:

- ezrichtext becomes ibexa_richtext
- icon paths change


