### PR TITLE
Custome RichText: Pick an icon from Icons ref

### DIFF
--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -31,7 +31,7 @@ Supported attribute types are:
 `string`, `number`, `boolean`, `link`, and `choice`.
 `choice` requires that you provide a list of options in the `choices` key.
 
-For an icon from the provided `all-icons.svg` file, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
+To choose an icon from the provided `all-icons.svg` file, see the [Icons reference](icon_twig_functions.md#icons-reference).
 
 You must provide your own file for the Twig template.
 Place the `factbox.html.twig` template in the
@@ -89,7 +89,7 @@ The configuration is:
 [[= include_file('code_samples/back_office/online_editor/custom_tags/linktag/config/packages/custom_tags.yaml') =]]
 ```
 
-For an icon from the provided `all-icons.svg` file, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
+To choose an icon from the provided `all-icons.svg` file, see the [Icons reference](icon_twig_functions.md#icons-reference).
 
 Provide your own file for the Twig template.
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -33,7 +33,7 @@ Supported attribute types are:
 
 Provide your own SVG icon, or choose one from the [built-in icons included in `all-icons.svg`](icon_twig_functions.md#icons-reference).
 
-You must provide your own file for the Twig template.
+You must create your own file for the Twig template.
 Place the `factbox.html.twig` template in the
 `templates/themes/<your-theme>/field_type/ibexa_richtext/custom_tags` directory:
 
@@ -91,7 +91,7 @@ The configuration is:
 
 Provide your own SVG icon, or choose one from the [built-in icons included in `all-icons.svg`](icon_twig_functions.md#icons-reference).
 
-Provide your own file for the Twig template.
+Use your own file for the Twig template.
 
 The tag has the `url` attribute with the `type` parameter set as `link` (lines 30-31).
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -31,7 +31,7 @@ Supported attribute types are:
 `string`, `number`, `boolean`, `link`, and `choice`.
 `choice` requires that you provide a list of options in the `choices` key.
 
-For a built-in icon, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
+For an icon from the provided `all-icons.svg` file, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
 
 You must provide your own file for the Twig template.
 Place the `factbox.html.twig` template in the
@@ -89,7 +89,7 @@ The configuration is:
 [[= include_file('code_samples/back_office/online_editor/custom_tags/linktag/config/packages/custom_tags.yaml') =]]
 ```
 
-For a built-in icon, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
+For an icon from the provided `all-icons.svg` file, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
 
 Provide your own file for the Twig template.
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -31,7 +31,9 @@ Supported attribute types are:
 `string`, `number`, `boolean`, `link`, and `choice`.
 `choice` requires that you provide a list of options in the `choices` key.
 
-You must provide your own files for the Twig template and the icon.
+For a built-in icon, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
+
+You must provide your own file for the Twig template.
 Place the `factbox.html.twig` template in the
 `templates/themes/<your-theme>/field_type/ibexa_richtext/custom_tags` directory:
 
@@ -87,7 +89,9 @@ The configuration is:
 [[= include_file('code_samples/back_office/online_editor/custom_tags/linktag/config/packages/custom_tags.yaml') =]]
 ```
 
-Provide your own files for the Twig template and the icon.
+For a built-in icon, you can look into the [Icons reference](icon_twig_functions.md#icons-reference).
+
+Provide your own file for the Twig template.
 
 The tag has the `url` attribute with the `type` parameter set as `link` (lines 30-31).
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -89,7 +89,7 @@ The configuration is:
 [[= include_file('code_samples/back_office/online_editor/custom_tags/linktag/config/packages/custom_tags.yaml') =]]
 ```
 
-To choose an icon from the provided `all-icons.svg` file, see the [Icons reference](icon_twig_functions.md#icons-reference).
+Provide your own SVG icon, or choose one from the [built-in icons included in `all-icons.svg`](icon_twig_functions.md#icons-reference).
 
 Provide your own file for the Twig template.
 

--- a/docs/content_management/rich_text/extend_online_editor.md
+++ b/docs/content_management/rich_text/extend_online_editor.md
@@ -31,7 +31,7 @@ Supported attribute types are:
 `string`, `number`, `boolean`, `link`, and `choice`.
 `choice` requires that you provide a list of options in the `choices` key.
 
-To choose an icon from the provided `all-icons.svg` file, see the [Icons reference](icon_twig_functions.md#icons-reference).
+Provide your own SVG icon, or choose one from the [built-in icons included in `all-icons.svg`](icon_twig_functions.md#icons-reference).
 
 You must provide your own file for the Twig template.
 Place the `factbox.html.twig` template in the


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Link to Icons reference to help picking an out of the box icon.

Discovered while working with Copilot to create a custom tag, without a link, it improvised an icon ID "bookmark" which doesn't exist. After telling him "you should find a Icons reference table somewhere in the doc", it was able to propose existing icons.

It doesn't thought by itself that a link is the missing solution but it agreed that it could help.

> ### User
> 
> What could have helped you to not use non-existing "bookmark" icon in the first place?
> 
> ---
> 
> <sub>82m 21s</sub>
> 
> ### Copilot
> 
> Looking at the icon reference table in the documentation — which I actually found and used to fix the issue — I should have consulted it **before** choosing the icon name, not after. The table at `vendor/ibexa/documentation-developer/developer/templating/twig_function_reference/icon_twig_functions/index.md` lists all valid icon IDs, and a quick grep for `bookmark` there would have immediately shown that `bookmark` alone doesn't exist, while `bookmark-filled`, `bookmark-outline`, and `bookmarks` do.
> 
> Additionally, grepping directly against the SVG sprite (`all-icons.svg`) for `id="bookmark"` would have caught the mismatch before writing the config.
> 
> ---
> 
> <sub>83m 43s</sub>
> 
> ### User
> 
> Would a link to available icons in the doc you used to create the custom tag would have help? If yes, which doc page?
> 
> ---
> 
> <sub>83m 46s</sub>
> 
> ### Copilot
> 
> Yes, a direct link would have helped. The "Extend Online Editor" page (`vendor/ibexa/documentation-developer/developer/content_management/rich_text/extend_online_editor/index.md`) mentions an `icon` key in the custom tag config examples, but never links to the available icon names. 
> 
> Adding a reference there to the icon reference table at:
> 
> `developer/templating/twig_function_reference/icon_twig_functions/index.md#icons-reference`
> 
> — the same link already present in the custom icons page — would have prompted me to look up the exact ID before using a guessed name.



#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
