### PR TITLE
Improved error messages for failed YAML tests

### DIFF
--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -41,7 +41,7 @@ final class YamlTest extends TestCase
             }
 
             self::fail(sprintf(
-                'YAML parse error in %s at line %d [hash:%s]: %s',
+                'YAML parse error in %s:%d [hash:%s]: %s',
                 $filePath,
                 $line,
                 $bodyHash,

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -41,7 +41,7 @@ final class YamlTest extends TestCase
             }
 
             self::fail(sprintf(
-                'YAML parse error in %s:%d [hash:%s]: %s',
+                'YAML parse error at %s:%d [hash:%s]: %s',
                 $filePath,
                 $line,
                 $bodyHash,


### PR DESCRIPTION
Target: 5.0, 6.0

Clicking the filename:linenumber takes you to the failing example
