### PR TITLE
Fixed code samples after latest Rector release

### DIFF
--- a/code_samples/back_office/images/src/SvgExtension.php
+++ b/code_samples/back_office/images/src/SvgExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Twig;
 
 use Symfony\Component\Routing\RouterInterface;
+use Twig\Attribute\AsTwigFunction;
 
 class SvgExtension
 {
@@ -15,7 +16,7 @@ class SvgExtension
     {
     }
 
-    #[\Twig\Attribute\AsTwigFunction(name: 'ibexa_svg_link')]
+    #[AsTwigFunction(name: 'ibexa_svg_link')]
     public function generateLink(int $contentId, string $fieldIdentifier, string $filename): string
     {
         return $this->router->generate('app.svg_download', [

--- a/code_samples/back_office/images/src/SvgExtension.php
+++ b/code_samples/back_office/images/src/SvgExtension.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace App\Twig;
 
 use Symfony\Component\Routing\RouterInterface;
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
 
-class SvgExtension extends AbstractExtension
+class SvgExtension
 {
     /**
      * SvgExtension constructor.
@@ -17,17 +15,7 @@ class SvgExtension extends AbstractExtension
     {
     }
 
-    /**
-     * @return \Twig\TwigFunction[]
-     */
-    #[\Override]
-    public function getFunctions(): array
-    {
-        return [
-            new TwigFunction('ibexa_svg_link', $this->generateLink(...)),
-        ];
-    }
-
+    #[\Twig\Attribute\AsTwigFunction(name: 'ibexa_svg_link')]
     public function generateLink(int $contentId, string $fieldIdentifier, string $filename): string
     {
         return $this->router->generate('app.svg_download', [

--- a/docs/update_and_migration/from_4.6/update_to_5.0.md
+++ b/docs/update_and_migration/from_4.6/update_to_5.0.md
@@ -504,7 +504,6 @@ return RectorConfig::configure()
        naming: true, // https://getrector.com/find-rule?activeRectorSetGroup=core&rectorSet=core-naming
        instanceOf: true, // https://getrector.com/find-rule?activeRectorSetGroup=core&rectorSet=core-instanceof
        earlyReturn: true, // https://getrector.com/find-rule?activeRectorSetGroup=core&rectorSet=core-early-return
-       strictBooleans: true, // https://getrector.com/find-rule?activeRectorSetGroup=core&rectorSet=core-strict-booleans
        rectorPreset: true,
        symfonyCodeQuality: true, // https://getrector.com/find-rule?activeRectorSetGroup=symfony&rectorSet=symfony-code-quality
        symfonyConfigs: true, // https://getrector.com/find-rule?activeRectorSetGroup=symfony&rectorSet=symfony-configs

--- a/docs/update_and_migration/from_4.6/update_to_5.0.md
+++ b/docs/update_and_migration/from_4.6/update_to_5.0.md
@@ -470,7 +470,6 @@ As this update spans across a broad range of versions, multiple rules can be con
 //…
 use Ibexa\Contracts\Rector\Sets\IbexaSetList;
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Set\SensiolabsSetList;
 use Rector\Symfony\Set\SymfonySetList;
 
 return RectorConfig::configure()
@@ -489,7 +488,6 @@ return RectorConfig::configure()
            SymfonySetList::SYMFONY_72, // https://getrector.com/find-rule?activeRectorSetGroup=symfony&rectorSet=symfony-symfonysymfony-72
            SymfonySetList::SYMFONY_73, // https://getrector.com/find-rule?activeRectorSetGroup=symfony&rectorSet=symfony-symfonysymfony-73
            SymfonySetList::ANNOTATIONS_TO_ATTRIBUTES,
-           SensiolabsSetList::ANNOTATIONS_TO_ATTRIBUTES,
        ]
    )
    ->withPhpSets()

--- a/rector.php
+++ b/rector.php
@@ -25,4 +25,6 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_70,
         SymfonySetList::SYMFONY_71,
         SymfonySetList::SYMFONY_72,
+        SymfonySetList::SYMFONY_73,
+        SymfonySetList::SYMFONY_74,
     ]);


### PR DESCRIPTION
Target: 4.6, 5.0, 6.0

For 4.6, only the change in the update notes should be cherry-picked

Should be possible to review this by commits.

- `strictBooleans` has been removed: https://github.com/rectorphp/rector-src/pull/8243

I've used this opportunity to add the missing Symfony rules and run the refactoring.

CI failure in https://github.com/ibexa/documentation-developer/actions/runs/30838488540/job/91769459101?pr=3339 :

```
Error: Unknown parameter $strictBooleans in call to method Rector\Configuration\RectorConfigBuilder::withPreparedSets().
 ------ ----------------------------------------------------------------------- 
  Line   _inline_php/update_and_migration/from_4.6/update_to_5.0/20a5c589183c1  
         b8ee4f67c7a0c9352320eb7349e3f06f89c61e245ea4b7f585f.php                
 ------ ----------------------------------------------------------------------- 
  44     Unknown parameter $strictBooleans in call to method                    
         Rector\Configuration\RectorConfigBuilder::withPreparedSets().          
         🪪  argument.unknown                                                   
 ------ --------------------------------
```

Another error:

```
 Error: Access to constant ANNOTATIONS_TO_ATTRIBUTES on an unknown class Rector\Symfony\Set\SensiolabsSetList.
 ------ ----------------------------------------------------------------------- 
  Line   _inline_php/update_and_migration/from_4.6/update_to_5.0/317d4528e219c  
         00c0d1909bec8d7ba870d6a5ca9af0df1e54b7b0a6cbe9aa948.php                
 ------ ----------------------------------------------------------------------- 
  29     Access to constant ANNOTATIONS_TO_ATTRIBUTES on an unknown class       
         Rector\Symfony\Set\SensiolabsSetList.                                  
         🪪  class.notFound                                                     
         💡  Learn more at https://phpstan.org/user-guide/discovering-symbols   
```