### PR TITLE
Bumped Composer version

### DIFF
--- a/docs/getting_started/requirements.md
+++ b/docs/getting_started/requirements.md
@@ -251,11 +251,17 @@ For production setups it's recommended that you use Varnish/Fastly, Redis/Valkey
 
 === "[[= product_name =]] v5.0"
 
-    - Composer: recent 2.8 version
+    - Composer: 2.8+
+
+    If you see a "+" next to the product version, it indicates a recommended version or higher within the same major release.
+    For example, "1.18+" means any 1.x version equal to or higher than 1.18, but not 2.x.
 
 === "[[= product_name =]] v4.6"
 
-    - Composer: recent 2.7 version
+    - Composer: 2.7+
+
+    If you see a "+" next to the product version, it indicates a recommended version or higher within the same major release.
+    For example, "1.18+" means any 1.x version equal to or higher than 1.18, but not 2.x.
 
 ## Asset manager
 


### PR DESCRIPTION
Target: 4.6, 5.0, 6.0

Feedback received on Slack - we should promote the latest Composer version (2.10 is available)
