### PR TITLE
Update Payum links

### DIFF
--- a/docs/commerce/payment/payum_integration.md
+++ b/docs/commerce/payment/payum_integration.md
@@ -7,7 +7,7 @@ edition: commerce
 
 [Payum](https://docs.payum.dev/v2#symfony-payum-bundle) is a payment processing solution that simplifies the integration of various payment services like Stripe and PayPal into your application.
 These services provide security of online transactions, and allow you to accept multiple payment methods while ensuring a seamless experience for the customers.
-By configuring service gateways, mapping workflow actions and translating payment service names, you streamline the online payment process, and can offer a diverse payment experience.
+By configuring service [gateways](https://docs.payum.dev/v2/supported-gateways), mapping workflow actions and translating payment service names, you streamline the online payment process, and can offer a diverse payment experience.
 
 ## General Payum configuration
 

--- a/docs/commerce/payment/payum_integration.md
+++ b/docs/commerce/payment/payum_integration.md
@@ -5,7 +5,7 @@ edition: commerce
 
 # Payum integration
 
-[Payum](https://payum.gitbook.io/payum) is a payment processing solution that simplifies the integration of various payment services like Stripe and PayPal into your application.
+[Payum](https://docs.payum.dev/) is a payment processing solution that simplifies the integration of various payment services like Stripe and PayPal into your application.
 These services provide security of online transactions, and allow you to accept multiple payment methods while ensuring a seamless experience for the customers.
 By configuring service gateways, mapping workflow actions and translating payment service names, you streamline the online payment process, and can offer a diverse payment experience.
 
@@ -69,9 +69,9 @@ ibexa:
 When you implement the online payment solution, take the following consideration into account:
 
 - To learn what credentials must be provided and what specific settings must be made, refer to the each payment service gateway's specific documentation.
-- To customize the online payment UI, see [Creating custom views](https://github.com/Payum/Payum/blob/master/docs/symfony/custom-payment-page.md) in Payum documentation.
+- To customize the online payment UI, see [Creating custom views](https://github.com/Payum/Payum/blob/2.x/docs/symfony/custom-payment-page.md) in Payum documentation.
 - When you modify the payment process, you may need to subscribe to events dispatched by Payum.
-For a list of events, see [Event dispatcher](https://github.com/Payum/Payum/blob/master/docs/event-dispatcher.md) in Payum documentation.
+For a list of events, see [Event dispatcher](https://github.com/Payum/Payum/blob/2.x/docs/event-dispatcher.md) in Payum documentation.
 
 !!! caution
 

--- a/docs/commerce/payment/payum_integration.md
+++ b/docs/commerce/payment/payum_integration.md
@@ -5,7 +5,7 @@ edition: commerce
 
 # Payum integration
 
-[Payum](https://docs.payum.dev/) is a payment processing solution that simplifies the integration of various payment services like Stripe and PayPal into your application.
+[Payum](https://docs.payum.dev/v2#symfony-payum-bundle) is a payment processing solution that simplifies the integration of various payment services like Stripe and PayPal into your application.
 These services provide security of online transactions, and allow you to accept multiple payment methods while ensuring a seamless experience for the customers.
 By configuring service gateways, mapping workflow actions and translating payment service names, you streamline the online payment process, and can offer a diverse payment experience.
 
@@ -69,9 +69,9 @@ ibexa:
 When you implement the online payment solution, take the following consideration into account:
 
 - To learn what credentials must be provided and what specific settings must be made, refer to the each payment service gateway's specific documentation.
-- To customize the online payment UI, see [Creating custom views](https://github.com/Payum/Payum/blob/2.x/docs/symfony/custom-payment-page.md) in Payum documentation.
+- To customize the online payment UI, see [Creating custom views](https://docs.payum.dev/v2/symfony/custom-payment-page) in Payum documentation.
 - When you modify the payment process, you may need to subscribe to events dispatched by Payum.
-For a list of events, see [Event dispatcher](https://github.com/Payum/Payum/blob/2.x/docs/event-dispatcher.md) in Payum documentation.
+For a list of events, see [Event dispatcher](https://docs.payum.dev/v2/event-dispatcher) in Payum documentation.
 
 !!! caution
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Update Payum links.
Use [docs.payum.dev/v2](https://docs.payum.dev/v2).
Add a link to available gateways.

- [`ibexa/connector-payum:5.0.x-dev` uses `payum/payum-bundle:^2.5`](https://github.com/ibexa/connector-payum/blob/5.0/composer.json#L19)
- [`payum/payum-bundle:2.7.1` uses `payum/core:^1.7.2`](https://github.com/Payum/PayumBundle/blob/2.7.1/composer.json#L41), but, I think the doc version correspond to the bundle version.
- `payum/payum` (containing all the gateways) is not installed!

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
