### PR TITLE
Downgrade to PHPUnit 9.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^9.6",
         "symfony/yaml": "^7.0",
         "ibexa/connector-gemini": "5.0.x-dev",
         "ibexa/automated-translation": "5.0.x-dev",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
     bootstrap="tests/bootstrap.php"
     colors="true"
     failOnWarning="true"

--- a/tests/InlineSamples/InlinePhpPipelineTest.php
+++ b/tests/InlineSamples/InlinePhpPipelineTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Documentation\InlineSamples;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -209,8 +208,9 @@ final class InlinePhpPipelineTest extends TestCase
 
     /**
      * @param array<string, string> $fixerReplacements
+     *
+     * @dataProvider provideIdempotencyCases
      */
-    #[DataProvider('provideIdempotencyCases')]
     public function testPipelineIsIdempotent(string $md, array $fixerReplacements): void
     {
         // First pass (may or may not change the Markdown).

--- a/tests/InlineSamples/InlinePhpSyncerTest.php
+++ b/tests/InlineSamples/InlinePhpSyncerTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Documentation\InlineSamples;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -311,8 +310,9 @@ final class InlinePhpSyncerTest extends TestCase
 
     /**
      * @param array<string, string> $replacements Simulated cs-fixer changes: old => new.
+     *
+     * @dataProvider provideRoundtripCases
      */
-    #[DataProvider('provideRoundtripCases')]
     public function testRoundtripAppliesChangesAndIsIdempotent(
         string $md,
         array $replacements,

--- a/tests/InlineSamples/InlinePhpWriterTest.php
+++ b/tests/InlineSamples/InlinePhpWriterTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Documentation\InlineSamples;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -141,8 +140,9 @@ final class InlinePhpWriterTest extends TestCase
     /**
      * @param string $body         Input body (from MarkdownExtractor)
      * @param string $expectedBody Expected body section after the blank separator
+     *
+     * @dataProvider provideExactContent
      */
-    #[DataProvider('provideExactContent')]
     public function testExactFileContent(string $sourcePath, int $line, string $body, string $expectedBody): void
     {
         $expected = sprintf(InlinePhpWriter::FILE_TEMPLATE, $sourcePath, $line, $expectedBody);

--- a/tests/InlineSamples/MarkdownExtractorTest.php
+++ b/tests/InlineSamples/MarkdownExtractorTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Documentation\InlineSamples;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MarkdownExtractorTest extends TestCase
@@ -185,8 +184,9 @@ final class MarkdownExtractorTest extends TestCase
 
     /**
      * @param array<array{body: string, line: int}> $expected
+     *
+     * @dataProvider provideMultilineBlocks
      */
-    #[DataProvider('provideMultilineBlocks')]
     public function testExtractsMultilineBody(string $content, array $expected): void
     {
         $blocks = iterator_to_array($this->extractor->extract($content));

--- a/tests/Markdown/MarkdownYamlExtractorTest.php
+++ b/tests/Markdown/MarkdownYamlExtractorTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace Ibexa\Tests\Documentation\Markdown;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MarkdownYamlExtractorTest extends TestCase
@@ -185,8 +184,9 @@ final class MarkdownYamlExtractorTest extends TestCase
 
     /**
      * @param array<array{body: string, line: int}> $expected
+     *
+     * @dataProvider provideMultilineBlocks
      */
-    #[DataProvider('provideMultilineBlocks')]
     public function testExtractsMultilineBody(string $content, array $expected): void
     {
         $blocks = iterator_to_array($this->extractor->extract($content));

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -10,20 +10,22 @@ namespace Ibexa\Tests\Documentation\Yaml;
 
 use Ibexa\Tests\Documentation\ConfigurationProvider;
 use Ibexa\Tests\Documentation\ValidationBaseline;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 
-#[Group('yaml')]
+/**
+ * @group yaml
+ */
 final class YamlTest extends TestCase
 {
     private const string REPO_ROOT = __DIR__ . '/../../';
     private const string BASELINE_FILE = __DIR__ . '/../yaml-validation-baseline.yaml';
 
-    #[DataProvider('provideYamlSources')]
+    /**
+     * @dataProvider provideYamlSources
+     */
     public function testYamlIsSyntacticallyValid(string $filePath, int $line, string $body, string $bodyHash): void
     {
         $filePath = self::relativePath($filePath);
@@ -54,8 +56,9 @@ final class YamlTest extends TestCase
 
     /**
      * @param int $line Starting line of the config block (0 for standalone YAML files).
+     *
+     * @dataProvider provideBundleConfigs
      */
-    #[DataProvider('provideBundleConfigs')]
     public function testBundleConfigurationIsValid(
         string $extensionName,
         mixed $config,


### PR DESCRIPTION
After the changes from https://github.com/ibexa/version-comparison/pull/132 , the composer install  commands fail in this repo.

Example failure:

https://github.com/ibexa/documentation-developer/actions/runs/31193936516/job/92917410245?pr=3345

```
    Problem 1
      - Root composer.json requires ibexa/version-comparison 5.0.x-dev -> satisfiable by ibexa/version-comparison[5.0.x-dev].
      - Root composer.json requires phpunit/phpunit ^11.0 -> satisfiable by phpunit/phpunit[11.5.50, ..., 11.5.56].
      - phpunit/phpunit[11.5.50, ..., 11.5.56] require sebastian/diff ^6.0.2 -> satisfiable by sebastian/diff[6.0.2].
      - Conclusion: don't install sebastian/diff 6.0.2 (conflict analysis result)
```

The solution is to downgrade the PHPUnit dependency - from 11 to 9.6 (PHPUnit 10 requires sebastian/diff:^5.0).

This forces us to convert from PHP Attributes to PHPDoc annotations.
With these changes, the tests are running correctly and are passing.
