### PR TITLE
API Refs workflow must fail on error

### DIFF
--- a/tools/api_refs/api_refs.sh
+++ b/tools/api_refs/api_refs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set +x;
+set -e;
 
 AUTH_JSON=$(realpath ${1:-~/.composer/auth.json}); # Path to an auth.json file allowing to install the targeted edition and version
 PHP_API_OUTPUT_DIR=${2:-./docs/api/php_api/php_api_reference}; # Path to the directory where the built PHP API Reference is hosted


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | ~~saas~~, 6.0, 5.0, 4.6
| Edition       | <!-- Content/Headless, Experience, Commerce -->

The "Build API Refs" CI workflow could return a green light while failing.

api_refs.sh now stop on error and return an error.
https://github.com/ibexa/documentation-developer/actions/runs/32018064840/job/95351688101

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
