### PR TITLE
Fix API Refs CI

### DIFF
--- a/.github/workflows/api_refs.yaml
+++ b/.github/workflows/api_refs.yaml
@@ -124,6 +124,9 @@ jobs:
                   fi
                   composer config --global http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
 
+                  git config --global user.name "${GITHUB_ACTOR}"
+                  git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
                   if [[ '4.6' != $BASE_BRANCH ]]; then
                     tools/api_refs/api_refs.sh
                     # Fix escape character:
@@ -140,8 +143,6 @@ jobs:
               env:
                   BASE_BRANCH: ${{ steps.version_and_branches.outputs.base_branch }}
               run: |
-                  git config --global user.name "${GITHUB_ACTOR}"
-                  git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
                   git add docs/api/php_api/php_api_reference/
                   if [[ '4.6' != $BASE_BRANCH ]]; then
                     git add tools/api_refs/.phpdoc/template/package-edition-map.twig


### PR DESCRIPTION
fatal: empty ident name (for <runner@runnerXXXXXXXX.xx.internal.cloudapp.net>) not allowed

| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

Set Git user earlier to avoid the following error:

```
Set up DXP recipes…
Initialized empty Git repository in /tmp/ibexa-dxp-phpdoc/.git/
 23/23 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@runnervmzvulz.bt05ewgluiaerd5fsj3vbem1cg.xx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.
```

Full failing job: https://github.com/ibexa/documentation-developer/actions/runs/32125687139/job/95675618341#step:9:1452

Reason:

It occurs in api_refs.sh during a hack when initializing a Git repository just to help recipes:
https://github.com/ibexa/documentation-developer/blob/5.0/tools/api_refs/api_refs.sh#L226-L227

Fix test:

Successful job: https://github.com/ibexa/documentation-developer/actions/runs/32141335553/job/95724436299#step:9:1436
Successful PR: https://github.com/ibexa/documentation-developer/pull/3356

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
