### PR TITLE
IBX-12127: New http(s) cheking options

### DIFF
--- a/docs/content_management/url_management/url_management.md
+++ b/docs/content_management/url_management/url_management.md
@@ -64,13 +64,17 @@ For details, see the tables below.
 
 #### http/https protocol
 
-| Option             | Description                                                                              |  Default value |
-|----------------------|----------------------------------------------------------------------------------------|-----------------------|
-| enabled            | Enables link validation.                                                      | true          |
-| timeout            | Defines the time that the request is allowed to take (in seconds).                       | 10            |
-| connection_timeout | Defines the time that the connect phase is allowed to take (in seconds).                 | 5             |
-| batch_size         | Defines a maximum number of asynchronous requests.                                     | 10            |
-| ignore_certificate | Decides if the peer's SSL certificate or the certificate name are verified against the host. | false         |
+| Option             | Description                                                                                  | Default value                                                                                                  |
+|--------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| enabled            | Enables link validation.                                                                     | true                                                                                                           |
+| timeout            | Defines the time that the request is allowed to take (in seconds).                           | 10                                                                                                             |
+| connection_timeout | Defines the time that the connect phase is allowed to take (in seconds).                     | 5                                                                                                              |
+| batch_size         | Defines a maximum number of asynchronous requests.                                           | 10                                                                                                             |
+| ignore_certificate | Decides if the peer's SSL certificate or the certificate name are verified against the host. | false                                                                                                          |
+| method             | Defines the HTTP method used to validate the URL (HEAD or GET).                              | HEAD                                                                                                           |
+| fallback_to_get    | Decides if the validation is retried with GET when HEAD failed.                              | true                                                                                                           |
+| user_agent         | Defines the user agent used to request the URL.                                              | Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0                                         |
+| headers            | Defines the headers used to request the URL.                                                 | {Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', Accept-Language: 'en-US,en;q=0.5'} |
 
 #### mailto protocol
 

--- a/docs/content_management/url_management/url_management.md
+++ b/docs/content_management/url_management/url_management.md
@@ -64,17 +64,17 @@ For details, see the tables below.
 
 #### http/https protocol
 
-| Option             | Description                                                                                  | Default value                                                                                                  |
-|--------------------|----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-| enabled            | Enables link validation.                                                                     | true                                                                                                           |
-| timeout            | Defines the time that the request is allowed to take (in seconds).                           | 10                                                                                                             |
-| connection_timeout | Defines the time that the connect phase is allowed to take (in seconds).                     | 5                                                                                                              |
-| batch_size         | Defines a maximum number of asynchronous requests.                                           | 10                                                                                                             |
-| ignore_certificate | Decides if the peer's SSL certificate or the certificate name are verified against the host. | false                                                                                                          |
-| method             | Defines the HTTP method used to validate the URL (HEAD or GET).                              | HEAD                                                                                                           |
-| fallback_to_get    | Decides if the validation is retried with GET when HEAD failed.                              | true                                                                                                           |
-| user_agent         | Defines the user agent used to request the URL.                                              | Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0                                         |
-| headers            | Defines the headers used to request the URL.                                                 | `{Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', Accept-Language: 'en-US,en;q=0.5'}` |
+| Option             | Description                                                                                  | Default value                                                                                                           |
+|--------------------|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| enabled            | Enables link validation.                                                                     | true                                                                                                                    |
+| timeout            | Defines the time that the request is allowed to take (in seconds).                           | 10                                                                                                                      |
+| connection_timeout | Defines the time that the connect phase is allowed to take (in seconds).                     | 5                                                                                                                       |
+| batch_size         | Defines a maximum number of asynchronous requests.                                           | 10                                                                                                                      |
+| ignore_certificate | Decides if the peer's SSL certificate or the certificate name are verified against the host. | false                                                                                                                   |
+| method             | Defines the HTTP method used to validate the URL (HEAD or GET).                              | HEAD                                                                                                                    |
+| fallback_to_get    | Decides if the validation is retried with GET when HEAD failed.                              | true                                                                                                                    |
+| user_agent         | Defines the user agent used to request the URL.                                              | Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0                                                  |
+| headers            | Defines the headers used to request the URL.                                                 | <nobr>Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8</nobr><br>Accept-Language: en-US,en;q=0.5 |
 
 #### mailto protocol
 

--- a/docs/content_management/url_management/url_management.md
+++ b/docs/content_management/url_management/url_management.md
@@ -74,7 +74,7 @@ For details, see the tables below.
 | method             | Defines the HTTP method used to validate the URL (HEAD or GET).                              | HEAD                                                                                                           |
 | fallback_to_get    | Decides if the validation is retried with GET when HEAD failed.                              | true                                                                                                           |
 | user_agent         | Defines the user agent used to request the URL.                                              | Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0                                         |
-| headers            | Defines the headers used to request the URL.                                                 | {Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', Accept-Language: 'en-US,en;q=0.5'} |
+| headers            | Defines the headers used to request the URL.                                                 | `{Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', Accept-Language: 'en-US,en;q=0.5'}` |
 
 #### mailto protocol
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | IBX-12127
| Versions      | 4.6, 5.0, 6.0
| Edition       | All

New options for the URL checker http(s) protocol
Preview: [URL management > Configuration > http/https protocol](https://ez-systems-developer-documentation--3377.com.readthedocs.build/en/3377/content_management/url_management/url_management/#httphttps-protocol)

Related PR: ibexa/core#809

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Code samples are working
- [ ] PHP code samples have been fixed with PHP CS fixer
- [ ] Added link to this PR in relevant JIRA ticket or code PR
