### PR TITLE
03: Strip edition markers from pages, theme, badges, and styles

### DIFF
--- a/docs/administration/admin_panel/corporate_admin_panel.md
+++ b/docs/administration/admin_panel/corporate_admin_panel.md
@@ -1,6 +1,5 @@
 ---
 description: You can manage companies profiles in the Admin Panel.
-edition: experience
 ---
 
 # Corporate

--- a/docs/administration/admin_panel/segments_admin_panel.md
+++ b/docs/administration/admin_panel/segments_admin_panel.md
@@ -1,6 +1,5 @@
 ---
 description: You can use segments to display specific content to specific users.
-edition: experience
 ---
 
 # Segments

--- a/docs/administration/back_office/back_office_elements/custom_components.md
+++ b/docs/administration/back_office/back_office_elements/custom_components.md
@@ -91,7 +91,7 @@ The available groups for the back office are:
 |---|---|
 |`admin-ui-location-view-tab-groups`| `vendor/ibexa/taxonomy/src/bundle/Resources/views/themes/admin/ibexa/taxonomy/taxonomy_entry/show.html.twig` |
 
-## Page Builder [[% include 'snippets/experience_badge.md' %]]
+## Page Builder
 
 | Group name | Template file |
 |---|---|

--- a/docs/administration/back_office/configure_product_tour.md
+++ b/docs/administration/back_office/configure_product_tour.md
@@ -1,6 +1,5 @@
 ---
 description: Configure custom product tour scenarios with steps, blocks, and interaction modes.
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/administration/back_office/customize_integrated_help.md
+++ b/docs/administration/back_office/customize_integrated_help.md
@@ -1,6 +1,5 @@
 ---
 description: Customize the integrated help menu.
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/administration/back_office/customize_product_tour.md
+++ b/docs/administration/back_office/customize_product_tour.md
@@ -1,6 +1,5 @@
 ---
 description: Customize product tour scenarios with custom event listeners
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/administration/back_office/integrated_help.md
+++ b/docs/administration/back_office/integrated_help.md
@@ -1,6 +1,5 @@
 ---
 description: Integrated help provides quick access to documentation, training, and support resources.
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/administration/back_office/product_tour.md
+++ b/docs/administration/back_office/product_tour.md
@@ -1,6 +1,5 @@
 ---
 description: Product tours provide interactive guided walkthroughs to help users learn Cohesivo features.
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/administration/dashboard/configure_default_dashboard.md
+++ b/docs/administration/dashboard/configure_default_dashboard.md
@@ -1,6 +1,5 @@
 ---
 description: Configure default dashboard.
-edition: experience
 ---
 
 # Configure default dashboard

--- a/docs/administration/dashboard/customize_dashboard.md
+++ b/docs/administration/dashboard/customize_dashboard.md
@@ -1,6 +1,5 @@
 ---
 description: Customize dashboard.
-edition: experience
 ---
 
 # Customize dashboard

--- a/docs/administration/recent_activity/recent_activity.md
+++ b/docs/administration/recent_activity/recent_activity.md
@@ -1,6 +1,5 @@
 ---
 description: Log and monitor activity through UI, PHP API and REST API.
-edition: experience
 month_change: false
 ---
 

--- a/docs/ai/ai_actions/configure_ai_actions.md
+++ b/docs/ai/ai_actions/configure_ai_actions.md
@@ -36,7 +36,7 @@ The AI actions come with sample AI action configurations to quickly get you star
 
 Based on these examples, which reflect the most common use cases, you can learn to configure your own AI actions with greater ease.
 
-## Install Anthropic connector [[% include 'snippets/lts-update_badge.md' %]]
+## Install Anthropic connector
 
 Run the following command to install the package:
 
@@ -95,7 +95,7 @@ You can now use the Anthropic connector in your project.
     Anthropic regularly releases new models and deprecates older ones.
     Before you configure the connector, check the [Anthropic models overview](https://platform.claude.com/docs/en/about-claude/models/overview) for the current list of supported model identifiers.
 
-## Install Google Gemini connector [[% include 'snippets/lts-update_badge.md' %]]
+## Install Google Gemini connector
 
 Run the following command to install the package:
 

--- a/docs/ai/ai_actions/extend_ai_actions.md
+++ b/docs/ai/ai_actions/extend_ai_actions.md
@@ -370,7 +370,7 @@ Your custom Action Type is now fully integrated into the back office UI and can 
 
 ![Transcribe Audio Action Type integrated into the back office](img/transcribe_audio.png "Transcribe Audio Action Type integrated into the back office")
 
-## Extend Google Gemini connector [[% include 'snippets/lts-update_badge.md' %]]
+## Extend Google Gemini connector
 
 The Gemini connector provides several extension points that allow you to customize available models, behavior, validation, and response handling, while remaining compatible with the AI Actions framework.
 

--- a/docs/ai/mcp/mcp.md
+++ b/docs/ai/mcp/mcp.md
@@ -1,7 +1,6 @@
 ---
 description: Overview of MCP resources in Cohesivo
 page_type: landing_page
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/ai/mcp/mcp_config.md
+++ b/docs/ai/mcp/mcp_config.md
@@ -1,6 +1,5 @@
 ---
 description: Configure an MCP server that exposes built-in and custom tools, prompts, and resources.
-edition: lts-update
 month_change: true
 ---
 

--- a/docs/ai/mcp/mcp_guide.md
+++ b/docs/ai/mcp/mcp_guide.md
@@ -1,6 +1,5 @@
 ---
 description: MCP servers expose tools, specialized prompts, and resources to AI agents.
-edition: lts-update
 month_change: false
 ---
 

--- a/docs/ai/mcp/mcp_usage.md
+++ b/docs/ai/mcp/mcp_usage.md
@@ -1,6 +1,5 @@
 ---
 description: Create custom capabilities for your MCP servers and test them.
-edition: lts-update
 month_change: true
 ---
 

--- a/docs/content_management/field_types/field_type_reference/addressfield.md
+++ b/docs/content_management/field_types/field_type_reference/addressfield.md
@@ -1,8 +1,3 @@
----
-edition: experience
----
-
-
 # Address field type
 
 This field represents and handles address fields.

--- a/docs/content_management/field_types/field_type_reference/formfield.md
+++ b/docs/content_management/field_types/field_type_reference/formfield.md
@@ -1,7 +1,3 @@
----
-edition: experience
----
-
 # Form field type
 
 The Form field type stores a Form consisting of one or more form fields.

--- a/docs/content_management/field_types/field_type_reference/pagefield.md
+++ b/docs/content_management/field_types/field_type_reference/pagefield.md
@@ -1,7 +1,3 @@
----
-edition: experience
----
-
 # Page field type
 
 Page field type represents a page with a layout consisting of multiple zones.

--- a/docs/content_management/field_types/field_type_reference/productspecificationfield.md
+++ b/docs/content_management/field_types/field_type_reference/productspecificationfield.md
@@ -1,5 +1,4 @@
 ---
-edition: headless
 month_change: false
 ---
 

--- a/docs/content_management/forms/create_custom_form_field.md
+++ b/docs/content_management/forms/create_custom_form_field.md
@@ -1,6 +1,5 @@
 ---
 description: Extend a Form with a custom Form field to fit your particular needs.
-edition: experience
 month_change: false
 ---
 

--- a/docs/content_management/forms/create_form_attribute.md
+++ b/docs/content_management/forms/create_form_attribute.md
@@ -1,6 +1,5 @@
 ---
 description: Create Form Builder Form attribute.
-edition: experience
 ---
 
 # Create Form Builder Form attribute

--- a/docs/content_management/forms/customize_email_notifications.md
+++ b/docs/content_management/forms/customize_email_notifications.md
@@ -1,6 +1,5 @@
 ---
 description: Adapt the form and content of emails sent out from the Form Builder.
-edition: experience
 ---
 
 # Customize email notifications

--- a/docs/content_management/forms/form_api.md
+++ b/docs/content_management/forms/form_api.md
@@ -1,6 +1,5 @@
 ---
 description: You can use PHP API to get, create and delete form submissions.
-edition: experience
 ---
 
 # Form API

--- a/docs/content_management/forms/form_builder_guide.md
+++ b/docs/content_management/forms/form_builder_guide.md
@@ -1,6 +1,5 @@
 ---
 description: See the Form Builder product guide and learn how to create various forms to increase the functionality of your website.
-edition: experience
 month_change: false
 ---
 

--- a/docs/content_management/forms/forms.md
+++ b/docs/content_management/forms/forms.md
@@ -1,6 +1,5 @@
 ---
 description: Forms are a type of content item that you can use to improve the functionality of your website.
-edition: experience
 page_type: landing_page
 ---
 

--- a/docs/content_management/forms/work_with_forms.md
+++ b/docs/content_management/forms/work_with_forms.md
@@ -1,6 +1,5 @@
 ---
 description: Form Builder enables creating dynamic forms to use in surveys, questionnaires, sign-up forms and others.
-edition: experience
 ---
 
 # Forms

--- a/docs/content_management/images/add_image_asset_from_dam.md
+++ b/docs/content_management/images/add_image_asset_from_dam.md
@@ -25,7 +25,7 @@ You can use the provided example DAM connector for [Unsplash](https://unsplash.c
 
 To add the Unsplash connector to your system, add the `ibexa/connector-unsplash` bundle to your installation.
 
-## Add Image Asset in Page Builder [[% include 'snippets/experience_badge.md' %]]
+## Add Image Asset in Page Builder
 
 To add Image Assets directly in the Page Builder, you can do it by using the Embed block.
 The example below shows how to add images from [Unsplash](https://unsplash.com/).

--- a/docs/content_management/locations.md
+++ b/docs/content_management/locations.md
@@ -73,7 +73,7 @@ which can be viewed by selecting the **Users** tab in the **Admin** Panel.
 The default ID number of the **Users** location is 5.
 It contains user group content items.
 
-### Forms [[% include 'snippets/experience_badge.md' %]]
+### Forms
 
 **Forms** is the top level location that is intended for Forms created using the [Form Builder]([[= user_doc =]]/content_management/work_with_forms/#create-forms).
 

--- a/docs/content_management/pages/create_custom_page_block.md
+++ b/docs/content_management/pages/create_custom_page_block.md
@@ -1,7 +1,6 @@
 ---
 description: Create and configure custom Page blocks to add customized content to Pages.
 month_change: false
-edition: experience
 ---
 
 # Create custom Page block

--- a/docs/content_management/pages/ibexa_connect_scenario_block.md
+++ b/docs/content_management/pages/ibexa_connect_scenario_block.md
@@ -1,6 +1,5 @@
 ---
 description: Work with Ibexa Connect scenario block that retrieves and displays data from an Ibexa Connect webhook.
-edition: experience
 ---
 
 # [[= product_name_connect =]] scenario block

--- a/docs/content_management/pages/page_block_attributes.md
+++ b/docs/content_management/pages/page_block_attributes.md
@@ -1,7 +1,6 @@
 ---
 description: Page blocks can contain multiple attributes, of both built-in and custom types.
 month_change: false
-edition: experience
 ---
 
 # Page block attributes

--- a/docs/content_management/pages/page_block_validators.md
+++ b/docs/content_management/pages/page_block_validators.md
@@ -1,6 +1,5 @@
 ---
 description: Set up rules for validating Page block content.
-edition: experience
 ---
 
 # Page block validators

--- a/docs/content_management/pages/page_blocks.md
+++ b/docs/content_management/pages/page_blocks.md
@@ -1,6 +1,5 @@
 ---
 description: Use blocks to customize the content of a Page with dynamic content.
-edition: experience
 ---
 
 # Page blocks

--- a/docs/content_management/pages/page_builder_guide.md
+++ b/docs/content_management/pages/page_builder_guide.md
@@ -1,6 +1,5 @@
 ---
 description: Read about the Page Builder - a powerful tool for creating and modifying pages in Cohesivo.
-edition: experience
 month_change: false
 ---
 

--- a/docs/content_management/pages/pages.md
+++ b/docs/content_management/pages/pages.md
@@ -1,7 +1,6 @@
 ---
 description: Pages are block-based special types of content that editors can create and modify by using a visual drag-and-drop editor.
 page_type: landing_page
-edition: experience
 ---
 
 # Pages

--- a/docs/content_management/pages/react_app_block.md
+++ b/docs/content_management/pages/react_app_block.md
@@ -1,6 +1,5 @@
 ---
 description: Create a block that allows an editor to embed a preconfigured React component into a page.
-edition: experience
 ---
 
 # React App block

--- a/docs/content_management/rich_text/create_custom_richtext_block.md
+++ b/docs/content_management/rich_text/create_custom_richtext_block.md
@@ -1,6 +1,5 @@
 ---
 description: Create a custom Page block containing rich text.
-edition: experience
 ---
 
 # Create custom RichText block

--- a/docs/content_management/taxonomy/taxonomy.md
+++ b/docs/content_management/taxonomy/taxonomy.md
@@ -259,7 +259,7 @@ ibexa:
     When you change the default suggestions generation model, ensure that you update the `ibexa.system.default.taxonomy.search.default_embedding_model` setting that is used for taxonomy indexing purposes.
     Otherwise the taxonomy suggestions feature fails to find matching entries.
 
-#### Change embeddings provider to Google Gemini [[% include 'snippets/lts-update_badge.md' %]]
+#### Change embeddings provider to Google Gemini
 
 Once you have installed and configured the [Google Gemini connector](configure_ai_actions.md#install-google-gemini-connector), you can modify the default configuration to use the `ibexa_gemini` embedding provider and one of the [supported models](https://ai.google.dev/gemini-api/docs/embeddings):
 

--- a/docs/css/pills.css
+++ b/docs/css/pills.css
@@ -7,27 +7,6 @@
   margin-right: 8px;
   color: #A32768;
 }
-.pill--headless {
-  color: #C4234A;
-  border-color: #C4234A;
-}
-.pill--headless::after {
-  content: "Headless";
-}
-.pill--experience {
-  color: #D3822B;
-  border-color: #D3822B;
-}
-.pill--experience::after {
-  content: "Experience";
-}
-.pill--lts-update {
-  color: #5DA7C0;
-  border-color: #5DA7C0;
-}
-.pill--lts-update::after {
-  content: "LTS Update";
-}
 .pill--new-feature {
   color: #2C9445;
   border-color: #2C9445;
@@ -50,10 +29,6 @@
   align-self: center;
   color: #3562A0;
   text-transform: lowercase;
-}
-
-div.pills {
-  float: right;
 }
 
 /*# sourceMappingURL=pills.css.map */

--- a/docs/customer_management/cp_applications.md
+++ b/docs/customer_management/cp_applications.md
@@ -1,6 +1,5 @@
 ---
 description: Customization of an approval process for new companies applications.
-edition: experience
 ---
 
 # Customer Portal applications

--- a/docs/customer_management/cp_configuration.md
+++ b/docs/customer_management/cp_configuration.md
@@ -1,6 +1,5 @@
 ---
 description: Configure Customer Portal to fit the needs of your business.
-edition: experience
 ---
 
 # Customer Portal configuration

--- a/docs/customer_management/cp_page_builder.md
+++ b/docs/customer_management/cp_page_builder.md
@@ -1,6 +1,5 @@
 ---
 description: Create unique Customer Portals for your clients with Page Builder.
-edition: experience
 ---
 
 # Create Customer Portal

--- a/docs/customer_management/customer_portal.md
+++ b/docs/customer_management/customer_portal.md
@@ -1,6 +1,5 @@
 ---
 description: Customer Portal allows your business clients to create and manage their company accounts.
-edition: experience
 page_type: landing_page
 ---
 

--- a/docs/customer_management/customer_portal_guide.md
+++ b/docs/customer_management/customer_portal_guide.md
@@ -1,6 +1,5 @@
 ---
 description: Check all the capabilities and advantages that the Customer Portal offers to the clients by reading the Customer Portal product guide.
-edition: experience
 ---
 
 # Customer Portal product guide

--- a/docs/multisite/multisite_configuration.md
+++ b/docs/multisite/multisite_configuration.md
@@ -131,7 +131,7 @@ ibexa:
                             Identifier\ContentType: [article]
 ```
 
-### SiteAccesses and Page Builder [[% include 'snippets/experience_badge.md' %]]
+### SiteAccesses and Page Builder
 
 To define which SiteAccesses are available in the submenu in Page Builder, use the following configuration:
 

--- a/docs/multisite/site_factory/site_factory.md
+++ b/docs/multisite/site_factory/site_factory.md
@@ -1,7 +1,6 @@
 ---
 month_change: false
 description: Site Factory allows creating multiple sites (SiteAccesses) from the back office.
-edition: experience
 ---
 
 # Site Factory

--- a/docs/multisite/site_factory/site_factory_configuration.md
+++ b/docs/multisite/site_factory/site_factory_configuration.md
@@ -1,6 +1,5 @@
 ---
 description: Configure Site Factory, including site skeletons.
-edition: experience
 ---
 
 # Site Factory configuration

--- a/docs/multisite/siteaccess/siteaccess_matching.md
+++ b/docs/multisite/siteaccess/siteaccess_matching.md
@@ -185,7 +185,7 @@ ibexa:
 
 Example URL `http://my_site.com:8080/content` matches SiteAccess `site`.
 
-### `Ibexa\SiteFactory\SiteAccessMatcher` [[% include 'snippets/experience_badge.md' %]]
+### `Ibexa\SiteFactory\SiteAccessMatcher`
 
 Enables the use of [Site Factory](site_factory.md).
 Doesn't take any parameters in configuration:

--- a/docs/multisite/translations_management/configure_translations_management.md
+++ b/docs/multisite/translations_management/configure_translations_management.md
@@ -1,6 +1,5 @@
 ---
 description: Install translations management and configure translation providers, language pairs, and more.
-edition: lts-update
 month_change: true
 ---
 

--- a/docs/multisite/translations_management/extend_translations_management.md
+++ b/docs/multisite/translations_management/extend_translations_management.md
@@ -1,6 +1,5 @@
 ---
 description: Add custom classes, exclude custom content types and add support for custom fields.
-edition: lts-update
 month_change: true
 ---
 

--- a/docs/multisite/translations_management/translations_management.md
+++ b/docs/multisite/translations_management/translations_management.md
@@ -1,6 +1,5 @@
 ---
 description: Translations management brings multiple features that help managers, developers and localization teams automate multilingual content delivery.
-edition: lts-update
 page_type: landing_page
 month_change: true
 ---

--- a/docs/multisite/translations_management/translations_management_guide.md
+++ b/docs/multisite/translations_management/translations_management_guide.md
@@ -1,6 +1,5 @@
 ---
 description: Translations management helps managers, developers and localization teams with multilingual content delivery.
-edition: lts-update
 month_change: true
 ---
 

--- a/docs/permissions/limitation_reference.md
+++ b/docs/permissions/limitation_reference.md
@@ -95,7 +95,7 @@ If you also combine it with `Owner of Parent` limitation, you effectively limit 
 |------|------|------|
 |`<ContentType_id>`|`<ContentType_name>`|All valid content type IDs can be set as value(s)|
 
-## Field Group limitation [[% include 'snippets/experience_badge.md' %]]
+## Field Group limitation
 
 A Field Group (`FieldGroup`) limitation specifies whether the user can work with content fields belonging to a specific group.
 A user with this limitation is allowed to edit fields belonging to the indicated group.
@@ -226,7 +226,7 @@ This limitation can be used as a role limitation.
 |------|------|------|
 |`<Session_id>`|`<Session_name>`|All valid session IDs can be set as value(s)|
 
-## Segment group limitation [[% include 'snippets/experience_badge.md' %]]
+## Segment group limitation
 
 The segment group (`SegmentGroup`) limitation specifies whether the user has access segments within a specific segment group.
 

--- a/docs/permissions/permission_use_cases.md
+++ b/docs/permissions/permission_use_cases.md
@@ -18,7 +18,7 @@ To allow the user to enter the back office interface and view all content, set t
 
 These policies are necessary for all other cases below that require access to the content structure.
 
-## Create content without publishing [[% include 'snippets/experience_badge.md' %]]
+## Create content without publishing
 
 You can use this option together with [[= product_name_exp =]]'s content review options.
 Users assigned with these policies can create content, but cannot publish it.

--- a/docs/permissions/policies.md
+++ b/docs/permissions/policies.md
@@ -87,7 +87,7 @@ Each role you assign to user or user group consists of policies which define, wh
 |                      | <nobr>`setup`</nobr>        | unused                                       |                      |
 |                      | <nobr>`system_info`</nobr>  | view the **System Information** tab in Admin |                      |
 
-#### Sites [[% include 'snippets/experience_badge.md' %]]
+#### Sites
 
 | Module              | Function                     | Effect                                                                                                | Possible limitations |
 |---------------------|------------------------------|-------------------------------------------------------------------------------------------------------|----------------------|

--- a/docs/qualifio/create_campaign.md
+++ b/docs/qualifio/create_campaign.md
@@ -1,6 +1,5 @@
 ---
 description: Create a campaign with Qualifio.
-edition: experience
 ---
 
 # Create [[= product_name_engage =]] campaign

--- a/docs/qualifio/install_qualifio.md
+++ b/docs/qualifio/install_qualifio.md
@@ -1,6 +1,5 @@
 ---
 description: Install and configure Qualifio.
-edition: experience
 ---
 
 # Install [[= product_name_engage =]]

--- a/docs/qualifio/integrate_ibexa_connect.md
+++ b/docs/qualifio/integrate_ibexa_connect.md
@@ -1,6 +1,5 @@
 ---
 description: Integrate Qualifio with Ibexa Connect.
-edition: experience
 ---
 
 # Integrate with [[= product_name_connect =]]

--- a/docs/qualifio/qualifio.md
+++ b/docs/qualifio/qualifio.md
@@ -1,6 +1,5 @@
 ---
 description: Use Qualifio to collect customer data by creating interactive content.
-edition: experience
 month_change: false
 ---
 

--- a/docs/raptor_cdp/raptor_cdp.md
+++ b/docs/raptor_cdp/raptor_cdp.md
@@ -1,6 +1,5 @@
 ---
 description: Raptor CDP is a software system designed to collect and organize customer data from multiple sources to build comprehensive customer profiles.
-edition: experience
 ---
 
 # [[= product_name_cdp =]] integration

--- a/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_activation.md
+++ b/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_activation.md
@@ -1,7 +1,6 @@
 ---
 description: Step-by-step activation procedure of Raptor CDP.
 page_type: landing_page
-edition: experience
 ---
 
 # Activate [[= product_name_cdp =]]

--- a/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_add_tracking.md
+++ b/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_add_tracking.md
@@ -1,6 +1,5 @@
 ---
 description: Adding tracking in Raptor CDP.
-edition: experience
 ---
 
 # Track with [[= product_name_cdp =]]

--- a/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_configuration.md
+++ b/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_configuration.md
@@ -1,6 +1,5 @@
 ---
 description: Step-by-step configuration procedure of Raptor CDP.
-edition: experience
 ---
 
 # Configure [[= product_name_cdp =]]

--- a/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_data_export.md
+++ b/docs/raptor_cdp/raptor_cdp_activation/raptor_cdp_data_export.md
@@ -1,6 +1,5 @@
 ---
 description: Step-by-step data export procedure in Raptor CDP.
-edition: experience
 ---
 
 # Export [[= product_name_cdp =]] data

--- a/docs/raptor_cdp/raptor_cdp_data_customization.md
+++ b/docs/raptor_cdp/raptor_cdp_data_customization.md
@@ -1,6 +1,5 @@
 ---
 description: Data customization in Raptor CDP.
-edition: experience
 ---
 
 # Customize [[= product_name_cdp =]] data

--- a/docs/raptor_cdp/raptor_cdp_guide.md
+++ b/docs/raptor_cdp/raptor_cdp_guide.md
@@ -1,6 +1,5 @@
 ---
 description: The Raptor CDP product guide describes all the possibilities that the Customer Data Platform offers to help you build great customer experiences.
-edition: experience
 ---
 
 # [[= product_name_cdp =]] product guide

--- a/docs/raptor_cdp/raptor_cdp_installation.md
+++ b/docs/raptor_cdp/raptor_cdp_installation.md
@@ -1,6 +1,5 @@
 ---
 description: Installation of standalone Raptor CDP package.
-edition: experience
 ---
 
 # Install [[= product_name_cdp =]]

--- a/docs/recommendations/raptor_integration/recommendation_blocks.md
+++ b/docs/recommendations/raptor_integration/recommendation_blocks.md
@@ -1,6 +1,5 @@
 ---
 description: Recommendation blocks in Page Builder
-edition: experience
 month_change: false
 ---
 

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,12 +1,12 @@
 ---
-description: Ibexa DXP v5.0 incorporates features brought by LTS Updates from previous versions, brings upgrades to the tech stack and improvements to developer experience.
-title: Ibexa DXP v5.0 LTS
+description: Cohesivo release notes list the new features and improvements delivered to the platform.
+title: Cohesivo release notes
 month_change: true
 ---
 
 <!-- vale Ibexa.VariablesVersion = NO -->
 
-[[= release_notes_filters('Ibexa DXP v5.0 LTS', ['Headless', 'Experience', 'LTS Update', 'New feature', 'First release']) =]]
+[[= release_notes_filters('Cohesivo release notes', ['New feature', 'First release']) =]]
 
 <div class="release-notes" markdown="1">
 
@@ -16,7 +16,7 @@ month_change: true
 [[= release_note_entry_begin(
     'TODO: Release notes for SaaS',
     date,
-    ['Headless', 'Experience', 'LTS Update', 'New feature']
+    ['New feature']
 ) =]]
 
 <!-- markdownlint-disable-next-line heading-increment -->

--- a/docs/snippets/experience_badge.md
+++ b/docs/snippets/experience_badge.md
@@ -1,1 +1,0 @@
-<span class="pill pill--inline pill--experience"></span>

--- a/docs/snippets/lts-update_badge.md
+++ b/docs/snippets/lts-update_badge.md
@@ -1,1 +1,0 @@
-<span class="pill pill--inline pill--lts-update"></span>

--- a/docs/users/segment_api.md
+++ b/docs/users/segment_api.md
@@ -1,6 +1,5 @@
 ---
 description: You can use PHP API to get segment information, create and manage segments, and assign users to them.
-edition: experience
 ---
 
 # Segment API

--- a/main.py
+++ b/main.py
@@ -229,7 +229,7 @@ def define_env(env):
         return text.lower().replace(' ', '-')
 
     def validate_categories(categories: List[str]) -> None:
-        available_categories = ['Headless', 'Experience', 'LTS Update', 'New feature', 'First release']
+        available_categories = ['New feature', 'First release']
 
         for category in categories:
             if category not in available_categories:

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -22,9 +22,6 @@ $color-light-400: #ECECF1;
 $color-dark: #131C26;
 $color-dark-400: #71767C;
 
-$color-headless: #C4234A;
-$color-experience: #D3822B;
-$color-lts-update: #5DA7C0;
 $color-new-feature: #2C9445;
 $color-first-release: #2C9445;
 

--- a/scss/pills.scss
+++ b/scss/pills.scss
@@ -11,9 +11,6 @@
     color: variables.$color-primary-main;
 
     $types: (
-        "headless": (variables.$color-headless, "Headless"),
-        "experience": (variables.$color-experience, "Experience"),
-        "lts-update": (variables.$color-lts-update, "LTS Update"),
         "new-feature": (variables.$color-new-feature, "New feature"),
         "first-release": (variables.$color-first-release, "First release")
       );
@@ -44,8 +41,4 @@
       color: variables.$color-new-doc;
       text-transform: lowercase;
     }
-}
-
-div.pills {
-  float: right;
 }

--- a/tests/python/invariants-baseline.yaml
+++ b/tests/python/invariants-baseline.yaml
@@ -19,82 +19,8 @@
 # list below to be empty.
 
 
-# 74 page(s) carry edition frontmatter (`edition:` or `editions:`).
-edition_frontmatter:
-  - administration/admin_panel/corporate_admin_panel.md
-  - administration/admin_panel/segments_admin_panel.md
-  - administration/back_office/configure_product_tour.md
-  - administration/back_office/customize_integrated_help.md
-  - administration/back_office/customize_product_tour.md
-  - administration/back_office/integrated_help.md
-  - administration/back_office/product_tour.md
-  - administration/dashboard/configure_default_dashboard.md
-  - administration/dashboard/customize_dashboard.md
-  - administration/dashboard/php_api_dashboard_service.md
-  - administration/recent_activity/recent_activity.md
-  - ai/mcp/mcp.md
-  - ai/mcp/mcp_config.md
-  - ai/mcp/mcp_guide.md
-  - ai/mcp/mcp_usage.md
-  - api/event_reference/integrated_help_events.md
-  - api/event_reference/page_events.md
-  - api/event_reference/segmentation_events.md
-  - api/event_reference/site_events.md
-  - api/event_reference/translations_management_events.md
-  - content_management/field_types/field_type_reference/addressfield.md
-  - content_management/field_types/field_type_reference/formfield.md
-  - content_management/field_types/field_type_reference/pagefield.md
-  - content_management/field_types/field_type_reference/productspecificationfield.md
-  - content_management/forms/create_custom_form_field.md
-  - content_management/forms/create_form_attribute.md
-  - content_management/forms/customize_email_notifications.md
-  - content_management/forms/form_api.md
-  - content_management/forms/form_builder_guide.md
-  - content_management/forms/forms.md
-  - content_management/forms/work_with_forms.md
-  - content_management/pages/create_custom_page_block.md
-  - content_management/pages/ibexa_connect_scenario_block.md
-  - content_management/pages/page_block_attributes.md
-  - content_management/pages/page_block_validators.md
-  - content_management/pages/page_blocks.md
-  - content_management/pages/page_builder_guide.md
-  - content_management/pages/pages.md
-  - content_management/pages/react_app_block.md
-  - content_management/rich_text/create_custom_richtext_block.md
-  - customer_management/cp_applications.md
-  - customer_management/cp_configuration.md
-  - customer_management/cp_page_builder.md
-  - customer_management/customer_portal.md
-  - customer_management/customer_portal_guide.md
-  - multisite/site_factory/site_factory.md
-  - multisite/site_factory/site_factory_configuration.md
-  - multisite/translations_management/configure_translations_management.md
-  - multisite/translations_management/extend_translations_management.md
-  - multisite/translations_management/translate_with_cli.md
-  - multisite/translations_management/translations_management.md
-  - multisite/translations_management/translations_management_guide.md
-  - qualifio/create_campaign.md
-  - qualifio/install_qualifio.md
-  - qualifio/integrate_ibexa_connect.md
-  - qualifio/qualifio.md
-  - raptor_cdp/raptor_cdp.md
-  - raptor_cdp/raptor_cdp_activation/raptor_cdp_activation.md
-  - raptor_cdp/raptor_cdp_activation/raptor_cdp_add_tracking.md
-  - raptor_cdp/raptor_cdp_activation/raptor_cdp_configuration.md
-  - raptor_cdp/raptor_cdp_activation/raptor_cdp_data_export.md
-  - raptor_cdp/raptor_cdp_data_customization.md
-  - raptor_cdp/raptor_cdp_data_export_schedule.md
-  - raptor_cdp/raptor_cdp_guide.md
-  - raptor_cdp/raptor_cdp_installation.md
-  - recommendations/raptor_integration/recommendation_blocks.md
-  - templating/render_content/render_page.md
-  - tutorials/page_and_form_tutorial/1_get_a_starter_website.md
-  - tutorials/page_and_form_tutorial/2_prepare_the_landing_page.md
-  - tutorials/page_and_form_tutorial/3_use_existing_blocks.md
-  - tutorials/page_and_form_tutorial/4_create_a_custom_block.md
-  - tutorials/page_and_form_tutorial/5_create_newsletter_form.md
-  - tutorials/page_and_form_tutorial/page_and_form_tutorial.md
-  - users/segment_api.md
+# 0 page(s) carry edition frontmatter (`edition:` or `editions:`).
+edition_frontmatter: []
 
 # 29 page(s) reference a product-name variable slated for deletion (product_name_headless, product_name_exp, product_name_com, product_name_cloud, product_name_content, product_name_oss).
 deleted_product_variables:

--- a/theme/main.html
+++ b/theme/main.html
@@ -87,16 +87,6 @@
               {% endfor %}
                   <li class="breadcrumb-item breadcrumb-item-current">{{ page.title }}</li>
           </ul>
-          {% if page.meta.edition or page.meta.editions %}
-            <div class="pills">
-            {% if page.meta.edition == 'lts-update' or 'lts-update' in page.meta.editions  %}
-            <span class="pill pill--lts-update"></span>
-            {% endif %}
-            {% if page.meta.edition == 'experience' or 'experience' in page.meta.editions %}
-              <span class="pill pill--experience"></span>
-            {% endif %}
-            </div>
-          {% endif %}
           {% if config.extra.current_version_is_eol %}
             {% include "partials/eol_warning.html" %}
           {% endif %}


### PR DESCRIPTION
Ticket 03 of the Cohesivo SaaS conversion. Base: `saas-batch-3`.

A reader sees no indication that any feature belongs to a particular edition.
Nothing is badged, nothing is gated, and no feature appears to require a
different licence.

Edition marking is spread across four independent mechanisms and all of them go
together — leaving any one behind renders stale or empty badges.

## The four mechanisms

1. **Frontmatter**: `edition:` stripped from **59** pages (45 `experience`, 13
   `lts-update`, 1 `headless`). No page used a plural `editions:` key. Three
   field-type reference pages had `edition:` as their only frontmatter key, so
   their now-empty `---` block was removed entirely — normal here, since 46 doc
   pages already carry no frontmatter.
2. **Badge snippets**: both snippet files deleted, **13** call sites cleaned. The
   leading space and the whole `[[% include %]]` were removed, so no heading slug
   changed and no trailing whitespace was introduced.
3. **Theme**: the 10-line `{% if page.meta.edition or page.meta.editions %}`
   block removed from `theme/main.html`. `grep -rn edition theme/` → 0.
4. **Styles**: the three edition entries dropped from `$types` in
   `scss/pills.scss` along with the trailing `div.pills`; `$color-headless`,
   `$color-experience` and `$color-lts-update` deleted from
   `scss/_variables.scss`; `docs/css/pills.css` updated to match.

Plus the release-notes filter whitelist in `main.py` reduced to
`['New feature', 'First release']`, and release-notes metadata restated to
"Cohesivo release notes" with no reference to the on-premise product or its
editions.

## The three traps, all respected

- `pill--new-feature` and `pill--first-release` are **release-note categories**,
  not edition badges. They survive in the SCSS, the CSS and the whitelist. The
  built site still carries one `pill pill--new-feature`.
- `.pill`, `.pill--inline` and `.pill--new` survive — the nav version pill and
  the "New in doc" marker depend on them. The built site still carries 75
  `pill pill--new`. Only `div.pills` was deleted.
- Ordering: `docs/release_notes.md` was edited **before** the `main.py`
  whitelist. Doing it the other way round fails the strict build.

`PILL_CLASS_TO_EDITION` was left alone — that is ticket 04's. `.notification--lts-update`
and `docs/index.md` were left alone — those are ticket 19's.

## LTS Update

Removed as part of the edition sweep, per the standing decision: the
`lts-update` frontmatter value, its badge snippet and call sites, the
`pill--lts-update` rules, `$color-lts-update`, and the `LTS Update` release-note
category all go. It is a self-hosted release-delivery concept that leaves
features reading as gated.

## Counts differ from the notes, correctly

The notes said 74 frontmatter pages and 17 badge call sites. Measured on this
branch: **59** and **13**. The difference is exactly the pages that tickets 07,
08, 09, 10 and 12 had already deleted. Every other line number and exact string
in the notes was accurate.

## Verification

- `mkdocs build --strict` → exit 0.
- `pytest -q` → 100 passed. No test asserted on an editions line, so nothing had
  to be deferred to ticket 04.
- Unresolved-variable check clean.
- Built site: zero `class="pills"`, zero `pill pill--inline`, zero
  `pill--experience|lts-update|headless`, and
  `grep -c "^Editions: " site/llms-full.txt` → **0**.
- Baseline: `edition_frontmatter: []`. The other three lists untouched.

## One thing to verify by hand

`docs/css/pills.css` is a committed compiled artifact and was edited by hand,
because `sass` is not installed in this environment. It was written to match what
the SCSS now compiles to, but nothing in the gates proves that. Worth one real
`sass` run before release. Tracked as **R14**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
