### PR TITLE
18: Add SiteAccess review labels

### DIFF
--- a/docs/administration/back_office/configure_product_tour.md
+++ b/docs/administration/back_office/configure_product_tour.md
@@ -1,6 +1,17 @@
 ---
 description: Configure custom product tour scenarios with steps, blocks, and interaction modes.
 month_change: false
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Product tour scenarios are configured under the SiteAccess-aware
+    ibexa.system.<siteaccess>.product_tour key. Confirm how a tenant picks the
+    SiteAccess scope for a scenario once SiteAccess configuration moves to a UI.
+
+    Links to the deleted browser.md, customize_dashboard.md and
+    customize_product_tour.md pages were removed; check that the surrounding text still
+    reads correctly.
 ---
 
 # Configure product tour scenarios

--- a/docs/administration/back_office/content_tree.md
+++ b/docs/administration/back_office/content_tree.md
@@ -1,5 +1,10 @@
 ---
 description: Configure SiteAccess, displayed content items, depth and root location for the content tree.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    Content tree settings are declared for a SiteAccess or a SiteAccess group. Confirm
+    how that scope is chosen once SiteAccess configuration moves to a UI.
 ---
 
 # Content tree

--- a/docs/administration/configuration/configuration.md
+++ b/docs/administration/configuration/configuration.md
@@ -1,5 +1,18 @@
 ---
 description: In Cohesivo you store and manage configuration in project files, typically in YAML format.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Describes the configuration system, including SiteAccess-aware settings that take a
+    different value per SiteAccess, per SiteAccess group, or globally. Confirm how much
+    of this remains accurate once configuration is delivered through a UI rather than
+    project files.
+
+    Links to the deleted php_api.md, repository_configuration.md,
+    template_configuration.md, devops.md, development_security.md, sessions.md and
+    persistence_cache.md pages were removed; check that the surrounding text still reads
+    correctly.
 ---
 
 # Configuration

--- a/docs/administration/configuration/dynamic_configuration.md
+++ b/docs/administration/configuration/dynamic_configuration.md
@@ -1,5 +1,15 @@
 ---
 description: Use the ConfigResolver to inject dynamic configuration into your services.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Defines the ConfigResolver scope and namespace semantics that every SiteAccess-aware
+    setting depends on. Confirm that the scope fallback order and the parameter naming
+    stay accurate once SiteAccess configuration moves to a UI.
+
+    Links to the deleted php_api.md page were removed; check that the surrounding text
+    still reads correctly.
 ---
 
 # Dynamic configuration

--- a/docs/administration/dashboard/configure_default_dashboard.md
+++ b/docs/administration/dashboard/configure_default_dashboard.md
@@ -1,5 +1,10 @@
 ---
 description: Configure default dashboard.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    The default dashboard can be configured per SiteAccess or per SiteAccess group.
+    Confirm how that scope is chosen once SiteAccess configuration moves to a UI.
 ---
 
 # Configure default dashboard

--- a/docs/administration/recent_activity/recent_activity.md
+++ b/docs/administration/recent_activity/recent_activity.md
@@ -1,6 +1,16 @@
 ---
 description: Log and monitor activity through UI, PHP API and REST API.
 month_change: false
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Activity log settings are shown scoped to a SiteAccess group. Confirm how that scope
+    is chosen once SiteAccess configuration moves to a UI.
+
+    Links to the deleted install_cohesivo.md, repository_configuration.md,
+    customize_dashboard.md and update_from_4.5.md pages and the generated PHP API
+    reference were removed; check that the surrounding text still reads correctly.
 ---
 
 # Recent activity

--- a/docs/ai/ai_actions/configure_ai_actions.md
+++ b/docs/ai/ai_actions/configure_ai_actions.md
@@ -3,10 +3,14 @@ description: Configure AI Actions.
 month_change: false
 saas_review:
     - siteaccess
+    - links_removed
 saas_review_note: >-
     Confirm where a tenant enters the OpenAI, Anthropic, Google Gemini, and
     Ibexa Connect credentials this page describes, and how SiteAccess-scoped
     API keys are set, once the credential-entry surface is specified.
+
+    Links to the deleted extend_ai_actions.md page were also removed from this page;
+    check that the surrounding text still reads correctly.
 ---
 
 # Configure AI Actions

--- a/docs/ai/mcp/mcp_config.md
+++ b/docs/ai/mcp/mcp_config.md
@@ -3,9 +3,14 @@ description: Configure an MCP server that exposes built-in and custom tools, pro
 month_change: true
 saas_review:
     - siteaccess
+    - links_removed
 saas_review_note: >-
     Confirm how MCP server-to-SiteAccess assignment and the other SiteAccess-aware
     settings on this page are exposed once SiteAccess configuration moves to a UI.
+
+    Links to the deleted development_security.md, graphql.md, clustering.md and
+    persistence_cache.md pages were also removed from this page; check that the
+    surrounding text still reads correctly.
 ---
 
 # Configure MCP Servers

--- a/docs/ai/mcp/mcp_usage.md
+++ b/docs/ai/mcp/mcp_usage.md
@@ -1,6 +1,16 @@
 ---
 description: Create custom capabilities for your MCP servers and test them.
 month_change: true
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    An MCP server is declared for a repository and assigned to SiteAccesses in
+    configuration. Confirm how the server-to-SiteAccess assignment is expressed once
+    SiteAccess configuration moves to a UI.
+
+    Links to the deleted editions.md and graphql.md pages and the generated PHP API
+    reference were removed; check that the surrounding text still reads correctly.
 ---
 
 # Work with MCP servers

--- a/docs/content_management/field_types/field_type_reference/measurementfield.md
+++ b/docs/content_management/field_types/field_type_reference/measurementfield.md
@@ -1,3 +1,16 @@
+---
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Each Measurement type and unit must be enabled for the back office SiteAccess before
+    it can be selected. Confirm where that per-SiteAccess enabling happens once
+    SiteAccess configuration moves to a UI.
+
+    Links to the deleted php_api.md and field_twig_functions.md pages were removed;
+    check that the surrounding text still reads correctly.
+---
+
 # Measurement field type
 
 The Measurement field type represents measurement information.

--- a/docs/content_management/file_management/file_management.md
+++ b/docs/content_management/file_management/file_management.md
@@ -1,5 +1,14 @@
 ---
 description: Configurations and management of binary files.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    IO handlers are configurable per SiteAccess. Confirm how per-SiteAccess file handler
+    settings are exposed once SiteAccess configuration moves to a UI.
+
+    Links to the deleted clustering.md page were removed; check that the surrounding
+    text still reads correctly.
 ---
 
 # File management

--- a/docs/content_management/file_management/file_url_handling.md
+++ b/docs/content_management/file_management/file_url_handling.md
@@ -1,5 +1,12 @@
 ---
 description: Manage files URL.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    The var and storage directory placeholders are SiteAccess-aware settings, and the
+    URL prefix is stored per scope under ibexa.site_access.config. Confirm how these
+    per-SiteAccess file URL settings are exposed once SiteAccess configuration moves to
+    a UI.
 ---
 
 # File URL handling

--- a/docs/content_management/images/configure_image_editor.md
+++ b/docs/content_management/images/configure_image_editor.md
@@ -1,5 +1,10 @@
 ---
 description: Configure image editor to crop, flip, and modify images.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    Image Editor settings are SiteAccess-aware. Confirm how the SiteAccess scope is
+    chosen for them once SiteAccess configuration moves to a UI.
 ---
 
 # Configure Image Editor

--- a/docs/content_management/images/fastly_io.md
+++ b/docs/content_management/images/fastly_io.md
@@ -1,5 +1,14 @@
 ---
 description: Configure Fastly Image Optimizer.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    The Fastly Image Optimizer variation handler is selected per SiteAccess. Confirm how
+    that per-SiteAccess choice is made once SiteAccess configuration moves to a UI.
+
+    Links to the deleted reverse_proxy.md and fastly.md pages were removed; check that
+    the surrounding text still reads correctly.
 ---
 
 # Fastly Image Optimizer (Fastly IO)

--- a/docs/content_management/taxonomy/taxonomy.md
+++ b/docs/content_management/taxonomy/taxonomy.md
@@ -1,6 +1,17 @@
 ---
 description: A taxonomy uses tags to categorize and organize content
 month_change: false
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    The taxonomy subtree deletion limit is SiteAccess-aware and can be set per
+    SiteAccess, per SiteAccess group, or globally. Confirm how that scope is chosen once
+    SiteAccess configuration moves to a UI.
+
+    Links to the deleted search_engines.md, field_type_search.md and
+    configure_elasticsearch.md pages and the generated PHP API reference were removed;
+    check that the surrounding text still reads correctly.
 ---
 
 # Taxonomy

--- a/docs/content_management/url_management/url_management.md
+++ b/docs/content_management/url_management/url_management.md
@@ -1,6 +1,16 @@
 ---
 description: Manage URL aliases and wildcards, and validate external URLs.
 month_change: false
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    External URL validation is configured under the SiteAccess-aware url_checker key,
+    while URL aliases are not SiteAccess-aware but depend on the SiteAccess root path.
+    Confirm both statements once SiteAccess configuration moves to a UI.
+
+    Links to the deleted install_cohesivo.md and field_type_storage.md pages were
+    removed; check that the surrounding text still reads correctly.
 ---
 
 # URL management

--- a/docs/customer_management/cp_applications.md
+++ b/docs/customer_management/cp_applications.md
@@ -1,5 +1,11 @@
 ---
 description: Customization of an approval process for new companies applications.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    Company application reasons are listed under a SiteAccess-scoped corporate_accounts
+    key. Confirm how that list is set per SiteAccess once SiteAccess configuration moves
+    to a UI.
 ---
 
 # Customer Portal applications

--- a/docs/customer_management/cp_configuration.md
+++ b/docs/customer_management/cp_configuration.md
@@ -1,5 +1,12 @@
 ---
 description: Configure Customer Portal to fit the needs of your business.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    The Customer Portal is served by a predefined SiteAccess in a SiteAccess group, and
+    roles and currencies are scoped per SiteAccess or SiteAccess group. Confirm how a
+    tenant adds Customer Portal SiteAccesses and scopes these settings once SiteAccess
+    configuration moves to a UI.
 ---
 
 # Customer Portal configuration

--- a/docs/customer_management/cp_page_builder.md
+++ b/docs/customer_management/cp_page_builder.md
@@ -1,5 +1,16 @@
 ---
 description: Create unique Customer Portals for your clients with Page Builder.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Making a Customer Portal site template available in Page Builder requires adding the
+    SiteAccess to the SiteAccess list, to a SiteAccess group, and to the Page Builder
+    SiteAccess list. Confirm how a tenant does all three once SiteAccess configuration
+    moves to a UI.
+
+    Links to the deleted add_navigation_menu.md page were removed; check that the
+    surrounding text still reads correctly.
 ---
 
 # Create Customer Portal

--- a/docs/getting_started/first_steps.md
+++ b/docs/getting_started/first_steps.md
@@ -1,5 +1,15 @@
 ---
 description: Start off working with Cohesivo by doing initial configuration and testing system capabilities.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    The Add SiteAccesses section walks a new user through adding a SiteAccess to the
+    SiteAccess list in YAML and relying on URI matching. Confirm the equivalent first
+    steps once SiteAccess configuration moves to a UI.
+
+    Links to the deleted beginner_tutorial.md, security_checklist.md and templates.md
+    pages were removed; check that the surrounding text still reads correctly.
 ---
 
 # First steps

--- a/docs/multisite/languages/back_office_translations.md
+++ b/docs/multisite/languages/back_office_translations.md
@@ -1,5 +1,15 @@
 ---
 description: The language of the back office is selected automatically based on browser language, or you can choose it manually in user settings.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Additional back office translations are added to a SiteAccess-scoped user
+    preferences key. Confirm how that per-SiteAccess list is set once SiteAccess
+    configuration moves to a UI.
+
+    Links to the deleted contribute_translations.md page were removed; check that the
+    surrounding text still reads correctly.
 ---
 
 # Back office translations

--- a/docs/multisite/languages/languages.md
+++ b/docs/multisite/languages/languages.md
@@ -1,5 +1,12 @@
 ---
 description: You can create multiple language versions (translations) of content and serve different language versions of your site with the help of SiteAccesses.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    Translation SiteAccesses, the default SiteAccess, and per-SiteAccess-group overrides
+    of the translation SiteAccess list are all described as YAML. Confirm how the
+    language-to-SiteAccess mapping is expressed once SiteAccess configuration moves to a
+    UI.
 ---
 
 # Languages

--- a/docs/multisite/multisite_configuration.md
+++ b/docs/multisite/multisite_configuration.md
@@ -1,5 +1,15 @@
 ---
 description: Configure SiteAccesses to serve different content in different layouts.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    The whole page describes SiteAccess lists, SiteAccess groups, matching, and
+    per-SiteAccess settings as on-disk YAML. Confirm the equivalent UI, and whether
+    match rules stay author-editable, before this page is rewritten.
+
+    Links to the deleted repository_configuration.md and persistence_cache.md pages were
+    removed; check that the surrounding text still reads correctly.
 ---
 
 # Multisite configuration

--- a/docs/multisite/set_up_campaign_siteaccess.md
+++ b/docs/multisite/set_up_campaign_siteaccess.md
@@ -1,5 +1,15 @@
 ---
 description: Create a special SiteAccess to host a campaign site with different content subtree.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    A worked example that adds a campaign SiteAccess and its URI match rule to the
+    SiteAccess configuration in YAML. Confirm the equivalent steps once SiteAccess
+    configuration moves to a UI.
+
+    Links to the deleted design_engine.md page were removed; check that the surrounding
+    text still reads correctly.
 ---
 
 # Set up campaign SiteAccess

--- a/docs/multisite/set_up_translation_siteaccess.md
+++ b/docs/multisite/set_up_translation_siteaccess.md
@@ -1,5 +1,11 @@
 ---
 description: Set up SiteAccesses to hold different language versions of a site.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    A worked example that adds a translation SiteAccess to the SiteAccess list, puts it
+    in a SiteAccess group, and declares it as a translation SiteAccess. Confirm the
+    equivalent steps once SiteAccess configuration moves to a UI.
 ---
 
 # Set up translation SiteAccess

--- a/docs/multisite/site_factory/site_factory.md
+++ b/docs/multisite/site_factory/site_factory.md
@@ -1,6 +1,16 @@
 ---
 month_change: false
 description: Site Factory allows creating multiple sites (SiteAccesses) from the back office.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Site Factory is set up by adding empty SiteAccess groups and enabling the Site
+    Factory SiteAccess matcher in YAML. Confirm both steps, and how Site Factory sites
+    relate to configured SiteAccesses, once SiteAccess configuration moves to a UI.
+
+    Links to the deleted design_engine.md page were removed; check that the surrounding
+    text still reads correctly.
 ---
 
 # Site Factory

--- a/docs/multisite/site_factory/site_factory_configuration.md
+++ b/docs/multisite/site_factory/site_factory_configuration.md
@@ -1,5 +1,10 @@
 ---
 description: Configure Site Factory, including site skeletons.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    Each site skeleton binds a template to a SiteAccess group. Confirm how skeletons
+    reference SiteAccess groups once SiteAccess configuration moves to a UI.
 ---
 
 # Site Factory configuration

--- a/docs/multisite/siteaccess/siteaccess.md
+++ b/docs/multisite/siteaccess/siteaccess.md
@@ -1,6 +1,16 @@
 ---
 description: SiteAccesses enable you to provide separate configuration for each site in a multisite setup.
 page_type: landing_page
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    The landing page defines what a SiteAccess is and lists what can differ per
+    SiteAccess. Confirm that the definition and the list still match the product once
+    SiteAccess configuration moves to a UI.
+
+    Links to the deleted design_engine.md and persistence_cache.md pages were removed;
+    check that the surrounding text still reads correctly.
 ---
 
 # SiteAccess

--- a/docs/multisite/siteaccess/siteaccess_aware_configuration.md
+++ b/docs/multisite/siteaccess/siteaccess_aware_configuration.md
@@ -1,5 +1,16 @@
 ---
 description: Make sure your custom development's configuration can be used with SiteAccesses.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Defines SiteAccess-aware configuration: the namespace, scope, and parameter name
+    format and the scope fallback order. Several other pages link here for that
+    definition, so confirm it stays accurate once SiteAccess configuration moves to a
+    UI.
+
+    Links to the deleted php_api.md and repository_configuration.md pages were removed;
+    check that the surrounding text still reads correctly.
 ---
 
 # SiteAccess-aware configuration

--- a/docs/multisite/siteaccess/siteaccess_matching.md
+++ b/docs/multisite/siteaccess/siteaccess_matching.md
@@ -1,6 +1,16 @@
 ---
 description: Use SiteAccess matchers to control which site is served when and to which user.
 page_type: reference
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    A reference of the SiteAccess matchers, all configured in YAML. Confirm which
+    matchers survive and how match rules are expressed once SiteAccess configuration
+    moves to a UI.
+
+    Links to the deleted ez_platform_v2.4.md page were removed; check that the
+    surrounding text still reads correctly.
 ---
 
 # SiteAccess matching

--- a/docs/product_catalog/enable_purchasing_products.md
+++ b/docs/product_catalog/enable_purchasing_products.md
@@ -1,5 +1,11 @@
 ---
 description: Ensure your product catalog is ready for use with full configuration of products that enables purchasing them in the frontend shop.
+saas_review:
+    - siteaccess
+saas_review_note: >-
+    Currencies valid for a SiteAccess are set under a SiteAccess-scoped product catalog
+    key. Confirm how that per-SiteAccess list is set once SiteAccess configuration moves
+    to a UI.
 ---
 
 # Enable purchasing products

--- a/docs/product_catalog/prices.md
+++ b/docs/product_catalog/prices.md
@@ -1,5 +1,14 @@
 ---
 description: The price engine calculates product prices taking into account customer groups, currencies and taxes.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    States that a VAT rate can be set globally, meaning per SiteAccess. Confirm the
+    per-SiteAccess scope of VAT rates once SiteAccess configuration moves to a UI.
+
+    Links to the deleted discounts.md page and the generated PHP API reference were
+    removed; check that the surrounding text still reads correctly.
 ---
 
 # Prices

--- a/docs/product_catalog/product_catalog_guide.md
+++ b/docs/product_catalog/product_catalog_guide.md
@@ -1,6 +1,17 @@
 ---
 description: The product catalog guide provides a full description of the features and capabilities for managing products, their specifications, variants, pricing, and organization.
 month_change: false
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    States that a VAT rate can be set globally, meaning per SiteAccess. Confirm the
+    per-SiteAccess scope of VAT rates once SiteAccess configuration moves to a UI.
+
+    Links to the deleted create_custom_attribute_type.md, product_api.md,
+    shipping_management.md, discounts_guide.md, create_custom_catalog_filter.md,
+    commerce.md and content_aware_cache.md pages were removed; check that the
+    surrounding text still reads correctly.
 ---
 
 # Product catalog guide

--- a/docs/recommendations/raptor_integration/connector_installation_configuration.md
+++ b/docs/recommendations/raptor_integration/connector_installation_configuration.md
@@ -3,9 +3,14 @@ description: To configure the Raptor integration, follow the step-by-step proced
 month_change: false
 saas_review:
     - siteaccess
+    - links_removed
 saas_review_note: >-
     Confirm how customer_id, recommendations_api_key, and the other SiteAccess-aware
     connector settings on this page are exposed once SiteAccess configuration moves to a UI.
+
+    Links to the deleted background_tasks.md, recommendations_twig_functions.md and
+    hybrid_tracking.md pages were also removed from this page; check that the
+    surrounding text still reads correctly.
 ---
 
 # Configure [[= product_name_cdp_base =]]

--- a/docs/search/embeddings_reference/embeddings_reference.md
+++ b/docs/search/embeddings_reference/embeddings_reference.md
@@ -1,6 +1,17 @@
 ---
 month_change: false
 description: Embedding queries, embedding configuration, providers, and embedding search fields
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Embedding models must be configured per SiteAccess in system configuration. Confirm
+    how that per-SiteAccess model choice is made once SiteAccess configuration moves to
+    a UI.
+
+    Links to the deleted search_api.md, search_engines.md and
+    index_custom_elasticsearch_data.md pages and the generated PHP API reference were
+    removed; check that the surrounding text still reads correctly.
 ---
 
 # Embeddings search reference

--- a/docs/users/passwords.md
+++ b/docs/users/passwords.md
@@ -1,5 +1,16 @@
 ---
 description: Set up user password rules.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    The password recovery token validity is set with a SiteAccess-scoped security
+    parameter. Confirm how that per-SiteAccess setting is exposed once SiteAccess
+    configuration moves to a UI.
+
+    Links to the deleted add_forgot_password_option.md, add_login_form.md and
+    repository_configuration.md pages were removed; check that the surrounding text
+    still reads correctly.
 ---
 
 # Passwords

--- a/docs/users/user_registration.md
+++ b/docs/users/user_registration.md
@@ -1,5 +1,15 @@
 ---
 description: Register new users.
+saas_review:
+    - siteaccess
+    - links_removed
+saas_review_note: >-
+    Registration, forgotten password, and user settings templates are all configured per
+    SiteAccess. Confirm which of these per-SiteAccess settings survive once SiteAccess
+    configuration moves to a UI.
+
+    Links to the deleted 8_enable_account_registration.md page were removed; check that
+    the surrounding text still reads correctly.
 ---
 
 # Register new users


### PR DESCRIPTION
Ticket 18 of the Cohesivo SaaS conversion. Base: `saas-batch-3`.

A maintainer can list, with one search, every page whose SiteAccess content still
needs a product decision, and read on each one what specifically must be
confirmed. Readers see nothing.

**37 files changed, 323 insertions, 0 deletions** — every hunk inside the leading
`---` block.

## Labels only, proven

The ticket requires that no page's body content change. That was verified
mechanically, not asserted: for all 37 files, the text after the frontmatter
block is **byte-identical to `HEAD`**.

## Schema

Matches what ticket 13 already landed ahead of this:

```yaml
saas_review:
    - siteaccess
saas_review_note: >-
    …what a later pass must confirm
```

List-valued, because pages accumulate more than one reason and a scalar key
would silently overwrite.

## Inclusion rule: 38 of 54 pages

Not every page containing "SiteAccess" needs a label. A page is labelled when it
documents a SiteAccess-**scoped** setting or set-up step (an
`ibexa.system.<scope>` / `ibexa.site_access.config.<scope>` / `ibexa.siteaccess`
key, `siteaccess_group`/`siteaccess_list`, "configurable per SiteAccess") **or**
defines the SiteAccess scoping and matching semantics themselves.

The 16 excluded are genuine passing mentions — for example `subitems_list.md`,
where `siteaccess` is a component parameter name; `rest_requests.md`, where
`X-Siteaccess` is a REST header rather than a delivered setting; and
`page_blocks.md` / `react_app_block.md`, whose state configuration is explicitly
*not* SiteAccess-aware. Labelling those would inflate the maintainer's worklist
with pages that need no decision.

## Reason values

- `siteaccess` — 38 pages
- `links_removed` — 27 pages, each note naming the deleted targets

## Ticket 13's four pages were extended, not overwritten

Three gained `- links_removed` appended to their existing list plus an extra
paragraph in the existing note. `configure_translations_management.md` lost no
links and is byte-unchanged.

One page (`measurementfield.md`) had no frontmatter block at all and needed one
created.

## Nothing renders

The theme extends Material's `base.html` with no generic frontmatter loop. Proven
after a build: `grep -rl "saas_review" site/` → **0 hits**, as are the note
phrases, and `site/llms.txt` / `site/llms-full.txt` → 0. No review banner
anywhere.

## Maintainer search

```
grep -rln '^saas_review:' docs --include='*.md'          # all 38
grep -rl  '^    - links_removed$' docs --include='*.md'  # by reason
```

## Verification

- `mkdocs build --strict` → exit 0.
- `pytest -q` → 90 passed, **no warnings**.
- `mkdocs.yml`, the invariant test and its baseline all untouched.

## Two things for the reviewer

**Scope call on `links_removed`.** Repo-wide, **212** pages lost links to deleted
content; only 39 are in the SiteAccess set. This PR scopes the label to that set,
following the spec's framing of it as a co-reason ("a SiteAccess page that also
lost links to deleted content is the common case"). Read literally, the box would
need ~175 more pages — a separate mechanical pass, and git history already
records every removal. Flag it if you want the literal reading.

**Worth knowing for any later link audit**: this repo uses the `autolinks`
plugin, so a bare `foo.md` link resolves by basename anywhere under `docs/`. A
naive relative-path existence check produces false "deleted link" hits; the
detector used here is autolinks-aware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
