### PR TITLE
Added version labels. Added SaaS to supported branches. Removed SaaS pill

### DIFF
--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
         branchName = branchNameRegexp[1];
     }
 
-    const versionLavels = {
+    const versionLabels = {
         "2.5": "eZ Platform 2.5",
         "3.3": "Ibexa DXP 3.3",
         "4.6": "Ibexa DXP 4.6",
@@ -38,7 +38,7 @@ $(document).ready(function() {
         );
     });
 
-    $('.rst-current-version.switcher__label').html(productNames[branchName] ?? branchName);
+    $('.rst-current-version.switcher__label').html(versionLabels[branchName] ?? branchName);
 
     // Change navigation icons on onclick
     $('.md-nav--primary .md-nav__item--nested .md-nav__link').click(function() {

--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -12,7 +12,19 @@ $(document).ready(function() {
     if (branchNameRegexp !== null && branchNameRegexp.hasOwnProperty(1) && branchNameRegexp[1].length) {
         branchName = branchNameRegexp[1];
     }
-    if (!/^\d+\.\d+$/.test(branchName) && branchName !== 'latest') {
+
+    const versionLavels = {
+        "2.5": "eZ Platform 2.5",
+        "3.3": "Ibexa DXP 3.3",
+        "4.6": "Ibexa DXP 4.6",
+        "5.0": "Ibexa DXP 5.0 (latest)",
+        "6.0": "Cohesivo 6.0",
+        "saas": "Cohesivo SaaS"
+    };
+
+    const specialVersions = ['latest', 'saas'];
+
+    if (!/^\d+\.\d+$/.test(branchName) && !specialVersions.includes(branchName)) {
         branchName = '6.0';
     }
 
@@ -26,10 +38,7 @@ $(document).ready(function() {
         );
     });
 
-    // Add version pill to top of navigation
-    $('#site-name').append('<span class="pill pill--inline">' + branchName + '</span>');
-
-    $('.rst-current-version.switcher__label').html(branchName);
+    $('.rst-current-version.switcher__label').html(productNames[branchName] ?? branchName);
 
     // Change navigation icons on onclick
     $('.md-nav--primary .md-nav__item--nested .md-nav__link').click(function() {
@@ -86,6 +95,11 @@ $(document).ready(function() {
                 .filter((versionNode) => eolVersions.includes(versionNode.textContent))
                 .forEach((versionNode) => {
                     versionNode.hidden = true;
+                });
+
+            allVersions
+                .forEach((versionNode) => {
+                    versionNode.textContent = versionLabels[versionNode.textContent] ?? versionNode.textContent;
                 });
 
             olderVersions.addEventListener('click', (event) => {

--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -3,9 +3,21 @@ let jquery = jQuery;
 
 $(document).ready(function() {
     const latestVersionNumber = '5.0';
+    const specialVersions = ['latest', 'saas'];
+
+    const versionLabels = {
+        "2.5": "eZ Platform 2.5",
+        "3.3": "Ibexa DXP 3.3",
+        "4.6": "Ibexa DXP 4.6",
+        "5.0": "Ibexa DXP 5.0",
+        "6.0": "Cohesivo 6.0",
+        "saas": "Cohesivo SaaS"
+    };
+
+    versionLabels[latestVersionNumber] = versionLabels[latestVersionNumber] + ' (latest)';
 
     // replace edit url
-    let branchName = '6.0';
+    let branchName = latestVersionNumber;
     const branchNameRegexp = /\/en\/([a-z0-9-_.]*)\//g.exec(document.location.href);
     const eolVersions = window.eol_versions ?? [];
 
@@ -13,19 +25,8 @@ $(document).ready(function() {
         branchName = branchNameRegexp[1];
     }
 
-    const versionLabels = {
-        "2.5": "eZ Platform 2.5",
-        "3.3": "Ibexa DXP 3.3",
-        "4.6": "Ibexa DXP 4.6",
-        "5.0": "Ibexa DXP 5.0 (latest)",
-        "6.0": "Cohesivo 6.0",
-        "saas": "Cohesivo SaaS"
-    };
-
-    const specialVersions = ['latest', 'saas'];
-
     if (!/^\d+\.\d+$/.test(branchName) && !specialVersions.includes(branchName)) {
-        branchName = '6.0';
+        branchName = latestVersionNumber;
     }
 
     // Insert version into header links

--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
         );
     });
 
-    $('.rst-current-version.switcher__label').html(versionLabels[branchName] ?? branchName);
+    $('.rst-current-version.switcher__label').html(branchName);
 
     // Change navigation icons on onclick
     $('.md-nav--primary .md-nav__item--nested .md-nav__link').click(function() {

--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -96,7 +96,7 @@ $(document).ready(function() {
 
             allVersions
                 .forEach((versionNode) => {
-                    versionNode.textContent = versionLabels[versionNode.textContent] ?? versionNode.textContent;
+                    versionNode.querySelector('a').textContent = versionLabels[versionNode.textContent] ?? versionNode.textContent;
                 });
 
             olderVersions.addEventListener('click', (event) => {

--- a/docs/js/custom.js
+++ b/docs/js/custom.js
@@ -2,7 +2,7 @@
 let jquery = jQuery;
 
 $(document).ready(function() {
-    const latestVersionNumber = '6.0';
+    const latestVersionNumber = '5.0';
 
     // replace edit url
     let branchName = '6.0';
@@ -79,12 +79,8 @@ $(document).ready(function() {
             const allVersions = [...document.querySelectorAll('.switcher__list .versions dd')];
             const olderVersions = document.querySelector('#older-versions');
 
-            // Merge "X.Y" and "latest" entries into "X.Y (latest)"
+            // Remove latest version entry from the list
             const latestVersion = allVersions.find(v => v.textContent.trim() === 'latest');
-            const versionXY = allVersions.find(v => v.textContent.trim() === latestVersionNumber);
-            
-            const versionXYLink = versionXY.querySelector('a');
-            versionXYLink.textContent = `${latestVersionNumber} (latest)`;
             latestVersion.remove();
 
             if (eolVersions.length > 0) {


### PR DESCRIPTION
Target: SaaS mostly, but the name prefixes must be cherry-picked be included in other supported versions, and to user doc.

As in the title.

Things done:

1) Added detecting `saas` as a correct version
2) Removed version pill from the topleft corner of the doc - I don't think we need to indicate version for SaaS.

<img width="358" height="157" alt="Screenshot 2026-09-08 at 14 38 20" src="https://github.com/user-attachments/assets/7b297ee7-9041-4367-9ef9-91e6f5aa042e" />


<img width="360" height="140" alt="Screenshot 2026-09-08 at 14 38 52" src="https://github.com/user-attachments/assets/b9d069f1-c998-477e-b3fa-d8ec6bd36780" />


3) Added product name prefixes to the versions.

For 6.0, the name will be "Cohesivo 6.0"
For SaaS, the name will be "Cohesivo SaaS".

<img width="516" height="253" alt="Screenshot 2026-09-08 at 14 39 52" src="https://github.com/user-attachments/assets/5099a6e7-db28-45f7-878b-49b8cc313b75" />

